### PR TITLE
#4: Use correct target branch when generating a pull request's details

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegate.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegate.java
@@ -86,8 +86,7 @@ public class CommunityBranchLoaderDelegate implements BranchLoaderDelegate {
             String pullRequestKey = metadata.getPullRequestKey();
 
             BranchDto dto = branchDto.get();
-            return new CommunityBranch(branchName, BranchType.PULL_REQUEST, dto.isMain(), dto.getMergeBranchUuid(),
-                                       pullRequestKey);
+            return new CommunityBranch(branchName, BranchType.PULL_REQUEST, false, dto.getUuid(), pullRequestKey);
         } else {
             throw new IllegalStateException(
                     String.format("Could not find target branch '%s' in project", targetBranch));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegateTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegateTest.java
@@ -189,9 +189,8 @@ public class CommunityBranchLoaderDelegateTest {
         BranchDto branchDto = mock(BranchDto.class);
         when(branchDto.getBranchType()).thenReturn(BranchType.PULL_REQUEST);
         when(branchDto.getKey()).thenReturn("branchKey");
-        when(branchDto.getMergeBranchUuid()).thenReturn("mergeBranchUuid");
+        when(branchDto.getUuid()).thenReturn("mergeBranchUuid");
         when(branchDto.getProjectUuid()).thenReturn("projectUuid");
-        when(branchDto.getUuid()).thenReturn("branchUuid");
 
         BranchDao branchDao = mock(BranchDao.class);
         when(branchDao.selectByBranchKey(any(), eq("projectUuid"), eq("branch"))).thenReturn(Optional.of(branchDto));


### PR DESCRIPTION
A lookup is performed on the target branch of a pull request to ensure the branch exists, since SonarQube uses the target branch as the base for comparing metrics on the Pull Request. However, the retrieved branch is then used incorrectly, with the UUID of the retrieved branch's target branch being returned as the target for the Pull Request, rather than the UUID of the retrieved branch. As long-lived branches that are generally targeted by Pull Requests will not have a target branch, this may result in a `NoSuchElementException` from SonarQube's Compute Engine when trying to use the non-existent UUID, or could result in SonarQube showing the wrong branch as being targeted for a pull request thereby picking up new issues on the source branch incorrectly where a short-lived branch is targeted.

This change updates the generation of the pull request details to use the UUID of the retrieved target branch when creating Pull Request details, rather than the UUID of the target of the retrieved branch.