### PR TITLE
#19: Add support for SonarQube 7.8 APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,16 @@
 # Sonarqube Community Branch Plugin
 A plugin for SonarQube to allow branch analysis in the Community version.
 
-# Installation
-Either build the project or [download the release version of the plugin JAR](https://github.com/mc1arke/sonarqube-community-branch-plugin/releases). Copy the plugin JAR file to the `extensions/plugins/`directory of your SonarQube instance and restart SonarQube.
-
 # Compatibility
-The latest release of the plugin supports SonarQube Community edition 7.4 and above.
+Use the following table to find the correct plugin version for each SonarQube version
+
+SonarQube Version | Plugin Version
+------------------|---------------
+7.8+              | 1.1.0
+7.4 - 7.7         | 1.0.2
+
+# Installation
+Either build the project or [download a compatible release version of the plugin JAR](https://github.com/mc1arke/sonarqube-community-branch-plugin/releases). Copy the plugin JAR file to the `extensions/plugins/` directory of your SonarQube instance and restart SonarQube.
 
 # Features
 The plugin is intended to support the features and parameters specified in the SonarQube documentation, with the following caveats

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '7.4'
+def sonarqubeVersion = '7.8'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 
@@ -57,7 +57,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.24.0'
     zip "sonarqube:sonarqube:${sonarqubeVersion}@zip"
-    compileOnly group: 'org.sonarsource.sonarqube', name: 'sonar-plugin-api', version: "${sonarqubeVersion}"
+    compileOnly group: 'org.sonarsource.sonarqube', name: 'sonar-plugin-api', version: "7.7"
 }
 
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranch.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranch.java
@@ -23,9 +23,6 @@ import org.sonar.ce.task.projectanalysis.analysis.Branch;
 import org.sonar.core.component.ComponentKeys;
 import org.sonar.db.component.BranchType;
 import org.sonar.db.component.ComponentDto;
-import org.sonar.scanner.protocol.output.ScannerReport;
-
-import java.util.Optional;
 
 /**
  * @author Michael Clarke
@@ -37,15 +34,17 @@ public class CommunityBranch implements Branch {
     private final boolean main;
     private final String mergeBranchUuid;
     private final String pullRequestKey;
+    private final String targetBranchName;
 
     public CommunityBranch(String name, BranchType branchType, boolean main, String mergeBranchUuid,
-                           String pullRequestKey) {
+                           String pullRequestKey, String targetBranchName) {
         super();
         this.name = name;
         this.branchType = branchType;
         this.main = main;
         this.mergeBranchUuid = mergeBranchUuid;
         this.pullRequestKey = pullRequestKey;
+        this.targetBranchName = targetBranchName;
     }
 
     @Override
@@ -69,8 +68,8 @@ public class CommunityBranch implements Branch {
     }
 
     @Override
-    public Optional<String> getMergeBranchUuid() {
-        return Optional.ofNullable(mergeBranchUuid);
+    public String getMergeBranchUuid() {
+        return mergeBranchUuid;
     }
 
     @Override
@@ -86,13 +85,7 @@ public class CommunityBranch implements Branch {
         return pullRequestKey;
     }
 
-    // This method can be removed when removing support for all SonarQube versions before 7.6
     @Override
-    public String generateKey(ScannerReport.Component projectKey, ScannerReport.Component fileOrDirPath) {
-        return generateKey(projectKey.getKey(), null == fileOrDirPath ? null : fileOrDirPath.getPath());
-    }
-
-    //@Override for SonarQube 7.6
     public String generateKey(String projectKey, String fileOrDirPath) {
         String effectiveKey;
         if (null == fileOrDirPath) {
@@ -108,6 +101,11 @@ public class CommunityBranch implements Branch {
         } else {
             return ComponentDto.generateBranchKey(effectiveKey, name);
         }
+    }
+
+    @Override
+    public String getTargetBranchName() {
+        return targetBranchName;
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfiguration.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfiguration.java
@@ -58,7 +58,7 @@ public class CommunityBranchConfiguration implements BranchConfiguration {
     }
 
     @Override
-    public String targetScmBranch() {
+    public String targetBranchName() {
         return targetScmBranch;
     }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegateTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegateTest.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -92,11 +92,12 @@ public class CommunityBranchLoaderDelegateTest {
         new CommunityBranchLoaderDelegate(dbClient, metadataHolder).load(metadata);
 
         assertEquals(BranchType.SHORT, metadataHolder.getBranch().getType());
-        assertFalse(metadataHolder.getBranch().getMergeBranchUuid().isPresent());
+        assertNull(metadataHolder.getBranch().getMergeBranchUuid());
         assertEquals("branchKey", metadataHolder.getBranch().getName());
         assertFalse(metadataHolder.getBranch().isLegacyFeature());
         assertFalse(metadataHolder.getBranch().isMain());
         assertFalse(metadataHolder.getBranch().supportsCrossProjectCpd());
+        assertNull(metadataHolder.getBranch().getTargetBranchName());
     }
 
     @Test
@@ -144,12 +145,12 @@ public class CommunityBranchLoaderDelegateTest {
         new CommunityBranchLoaderDelegate(dbClient, metadataHolder).load(metadata);
 
         assertEquals(BranchType.SHORT, metadataHolder.getBranch().getType());
-        assertTrue(metadataHolder.getBranch().getMergeBranchUuid().isPresent());
-        assertEquals("projectUuid", metadataHolder.getBranch().getMergeBranchUuid().get());
+        assertEquals("projectUuid", metadataHolder.getBranch().getMergeBranchUuid());
         assertEquals("branch", metadataHolder.getBranch().getName());
         assertFalse(metadataHolder.getBranch().isLegacyFeature());
         assertFalse(metadataHolder.getBranch().isMain());
         assertFalse(metadataHolder.getBranch().supportsCrossProjectCpd());
+        assertNull(metadataHolder.getBranch().getTargetBranchName());
     }
 
     @Test
@@ -166,6 +167,7 @@ public class CommunityBranchLoaderDelegateTest {
 
         ScannerReport.Metadata metadata =
                 ScannerReport.Metadata.getDefaultInstance().toBuilder().setBranchName("branch")
+                        .setTargetBranchName("targetBranchName")
                         .setBranchType(ScannerReport.Metadata.BranchType.LONG).build();
 
         DbClient dbClient = mock(DbClient.class);
@@ -176,12 +178,12 @@ public class CommunityBranchLoaderDelegateTest {
         new CommunityBranchLoaderDelegate(dbClient, metadataHolder).load(metadata);
 
         assertEquals(BranchType.LONG, metadataHolder.getBranch().getType());
-        assertTrue(metadataHolder.getBranch().getMergeBranchUuid().isPresent());
-        assertEquals("projectUuid", metadataHolder.getBranch().getMergeBranchUuid().get());
+        assertEquals("projectUuid", metadataHolder.getBranch().getMergeBranchUuid());
         assertEquals("branch", metadataHolder.getBranch().getName());
         assertFalse(metadataHolder.getBranch().isLegacyFeature());
         assertFalse(metadataHolder.getBranch().isMain());
         assertFalse(metadataHolder.getBranch().supportsCrossProjectCpd());
+        assertEquals("targetBranchName", metadataHolder.getBranch().getTargetBranchName());
     }
 
     @Test
@@ -198,6 +200,7 @@ public class CommunityBranchLoaderDelegateTest {
         ScannerReport.Metadata metadata =
                 ScannerReport.Metadata.getDefaultInstance().toBuilder().setBranchName("sourceBranch")
                         .setMergeBranchName("branch").setBranchType(ScannerReport.Metadata.BranchType.PULL_REQUEST)
+                        .setTargetBranchName("")
                         .build();
 
         DbClient dbClient = mock(DbClient.class);
@@ -208,12 +211,12 @@ public class CommunityBranchLoaderDelegateTest {
         new CommunityBranchLoaderDelegate(dbClient, metadataHolder).load(metadata);
 
         assertEquals(BranchType.PULL_REQUEST, metadataHolder.getBranch().getType());
-        assertTrue(metadataHolder.getBranch().getMergeBranchUuid().isPresent());
-        assertEquals("mergeBranchUuid", metadataHolder.getBranch().getMergeBranchUuid().get());
+        assertEquals("mergeBranchUuid", metadataHolder.getBranch().getMergeBranchUuid());
         assertEquals("sourceBranch", metadataHolder.getBranch().getName());
         assertFalse(metadataHolder.getBranch().isLegacyFeature());
         assertFalse(metadataHolder.getBranch().isMain());
         assertFalse(metadataHolder.getBranch().supportsCrossProjectCpd());
+        assertEquals("branch", metadataHolder.getBranch().getTargetBranchName());
     }
 
     @Test
@@ -236,14 +239,6 @@ public class CommunityBranchLoaderDelegateTest {
 
 
         new CommunityBranchLoaderDelegate(dbClient, metadataHolder).load(metadata);
-
-        assertEquals(BranchType.PULL_REQUEST, metadataHolder.getBranch().getType());
-        assertTrue(metadataHolder.getBranch().getMergeBranchUuid().isPresent());
-        assertEquals("mergeBranchUuid", metadataHolder.getBranch().getMergeBranchUuid().get());
-        assertEquals("sourceBranch", metadataHolder.getBranch().getName());
-        assertFalse(metadataHolder.getBranch().isLegacyFeature());
-        assertFalse(metadataHolder.getBranch().isMain());
-        assertFalse(metadataHolder.getBranch().supportsCrossProjectCpd());
     }
 
 
@@ -272,6 +267,7 @@ public class CommunityBranchLoaderDelegateTest {
         ScannerReport.Metadata metadata =
                 ScannerReport.Metadata.getDefaultInstance().toBuilder().setBranchName("branch")
                         .setBranchType(ScannerReport.Metadata.BranchType.SHORT).setMergeBranchName("mergeBranchName")
+                        .setTargetBranchName("targetBranchThatDoesNotMatchMergeBranch")
                         .build();
 
         DbClient dbClient = mock(DbClient.class);
@@ -282,12 +278,12 @@ public class CommunityBranchLoaderDelegateTest {
         new CommunityBranchLoaderDelegate(dbClient, metadataHolder).load(metadata);
 
         assertEquals(BranchType.SHORT, metadataHolder.getBranch().getType());
-        assertTrue(metadataHolder.getBranch().getMergeBranchUuid().isPresent());
-        assertEquals("targetBranchUuid", metadataHolder.getBranch().getMergeBranchUuid().get());
+        assertEquals("targetBranchUuid", metadataHolder.getBranch().getMergeBranchUuid());
         assertEquals("branch", metadataHolder.getBranch().getName());
         assertFalse(metadataHolder.getBranch().isLegacyFeature());
         assertFalse(metadataHolder.getBranch().isMain());
         assertFalse(metadataHolder.getBranch().supportsCrossProjectCpd());
+        assertEquals("targetBranchThatDoesNotMatchMergeBranch", metadataHolder.getBranch().getTargetBranchName());
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchTest.java
@@ -23,7 +23,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sonar.db.component.BranchType;
-import org.sonar.scanner.protocol.output.ScannerReport;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,66 +40,45 @@ public class CommunityBranchTest {
 
     @Test
     public void testGenerateKeyMainBranchNullFileOfPath() {
-        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, true, null, null);
+        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, true, null, null, null);
 
-        ScannerReport.Component projectKey =
-                ScannerReport.Component.getDefaultInstance().toBuilder().setKey("projectKey").build();
-
-        assertEquals("projectKey", testCase.generateKey(projectKey, null));
+        assertEquals("projectKey", testCase.generateKey("projectKey", null));
     }
 
     @Test
     public void testGenerateKeyMainBranchNonNullFileOfPathHolder() {
-        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, true, null, null);
+        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, true, null, null, null);
 
-        ScannerReport.Component projectKey =
-                ScannerReport.Component.getDefaultInstance().toBuilder().setKey("projectKey").build();
-        ScannerReport.Component fileOrPath = ScannerReport.Component.getDefaultInstance();
-
-        assertEquals("projectKey", testCase.generateKey(projectKey, fileOrPath));
+        assertEquals("projectKey", testCase.generateKey("projectKey", ""));
     }
 
     @Test
     public void testGenerateKeyMainBranchNonNullFileOfPathContent() {
-        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, true, null, null);
+        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, true, null, null, null);
 
-        ScannerReport.Component projectKey =
-                ScannerReport.Component.getDefaultInstance().toBuilder().setKey("projectKey").build();
-        ScannerReport.Component fileOrPath =
-                ScannerReport.Component.getDefaultInstance().toBuilder().setPath("path").build();
-
-        assertEquals("projectKey:path", testCase.generateKey(projectKey, fileOrPath));
+        assertEquals("projectKey:path", testCase.generateKey("projectKey", "path"));
     }
 
     @Test
     public void testGenerateKeyNonMainBranchNonNullFileOfPathContentPullRequest() {
-        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, false, null, "pullRequestKey");
+        CommunityBranch testCase =
+                new CommunityBranch("name", BranchType.PULL_REQUEST, false, null, "pullRequestKey", null);
 
-        ScannerReport.Component projectKey =
-                ScannerReport.Component.getDefaultInstance().toBuilder().setKey("projectKey").build();
-        ScannerReport.Component fileOrPath =
-                ScannerReport.Component.getDefaultInstance().toBuilder().setPath("path").build();
-
-        assertEquals("projectKey:path:PULL_REQUEST:pullRequestKey", testCase.generateKey(projectKey, fileOrPath));
+        assertEquals("projectKey:path:PULL_REQUEST:pullRequestKey", testCase.generateKey("projectKey", "path"));
     }
 
     @Test
     public void testGenerateKeyNonMainBranchNonNullFileOfPathContentShortBranch() {
-        CommunityBranch testCase = new CommunityBranch("name", BranchType.SHORT, false, null, null);
+        CommunityBranch testCase = new CommunityBranch("name", BranchType.SHORT, false, null, null, null);
 
-        ScannerReport.Component projectKey =
-                ScannerReport.Component.getDefaultInstance().toBuilder().setKey("projectKey").build();
-        ScannerReport.Component fileOrPath =
-                ScannerReport.Component.getDefaultInstance().toBuilder().setPath("path").build();
-
-        assertEquals("projectKey:path:BRANCH:name", testCase.generateKey(projectKey, fileOrPath));
+        assertEquals("projectKey:path:BRANCH:name", testCase.generateKey("projectKey", "path"));
     }
 
 
     @Test
     public void testGetPulRequestKey() {
-        assertEquals("prKey",
-                     new CommunityBranch("name", BranchType.PULL_REQUEST, false, null, "prKey").getPullRequestKey());
+        assertEquals("prKey", new CommunityBranch("name", BranchType.PULL_REQUEST, false, null, "prKey", null)
+                .getPullRequestKey());
     }
 
     @Test
@@ -109,7 +87,7 @@ public class CommunityBranchTest {
                 .expectMessage(IsEqual.equalTo("Only a branch of type PULL_REQUEST can have a pull request ID"));
         expectedException.expect(IllegalStateException.class);
 
-        new CommunityBranch("name", BranchType.SHORT, false, null, "prKey").getPullRequestKey();
+        new CommunityBranch("name", BranchType.SHORT, false, null, "prKey", null).getPullRequestKey();
     }
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoaderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoaderTest.java
@@ -180,7 +180,7 @@ public class CommunityBranchConfigurationLoaderTest {
         BranchConfiguration result =
                 testCase.load(parameters, supplier, projectBranches, mock(ProjectPullRequests.class));
 
-        assertEquals("master", result.targetScmBranch());
+        assertEquals("master", result.targetBranchName());
         assertEquals("feature/shortLivedFeatureBranch", result.branchName());
         assertEquals("masterBranchInfo", result.longLivingSonarReferenceBranch());
         assertTrue(result.isShortOrPullRequest());
@@ -211,7 +211,7 @@ public class CommunityBranchConfigurationLoaderTest {
         BranchConfiguration result =
                 testCase.load(parameters, supplier, projectBranches, mock(ProjectPullRequests.class));
 
-        assertEquals("masterxxx", result.targetScmBranch());
+        assertEquals("masterxxx", result.targetBranchName());
         assertEquals("feature/shortLivedBranch", result.branchName());
         assertEquals("defaultBranchInfo", result.longLivingSonarReferenceBranch());
         assertTrue(result.isShortOrPullRequest());
@@ -237,7 +237,7 @@ public class CommunityBranchConfigurationLoaderTest {
         BranchConfiguration result =
                 testCase.load(parameters, supplier, projectBranches, mock(ProjectPullRequests.class));
 
-        assertEquals("masterxxx", result.targetScmBranch());
+        assertEquals("masterxxx", result.targetBranchName());
         assertEquals("feature/shortLivedBranch", result.branchName());
         assertEquals("defaultBranchInfo", result.longLivingSonarReferenceBranch());
         assertTrue(result.isShortOrPullRequest());
@@ -344,7 +344,7 @@ public class CommunityBranchConfigurationLoaderTest {
         BranchConfiguration result =
                 testCase.load(parameters, supplier, projectBranches, mock(ProjectPullRequests.class));
 
-        assertEquals("longLivedBranch", result.targetScmBranch());
+        assertEquals("longLivedBranch", result.targetBranchName());
         assertEquals("feature/shortLivedBranch", result.branchName());
         assertEquals("longLivedBranch", result.longLivingSonarReferenceBranch());
         assertTrue(result.isShortOrPullRequest());
@@ -376,7 +376,7 @@ public class CommunityBranchConfigurationLoaderTest {
         BranchConfiguration result =
                 testCase.load(parameters, supplier, projectBranches, mock(ProjectPullRequests.class));
 
-        assertEquals("master", result.targetScmBranch());
+        assertEquals("master", result.targetBranchName());
         assertEquals("feature/shortLivedBranch", result.branchName());
         assertEquals("master", result.longLivingSonarReferenceBranch());
         assertTrue(result.isShortOrPullRequest());
@@ -401,7 +401,7 @@ public class CommunityBranchConfigurationLoaderTest {
         BranchConfiguration result =
                 testCase.load(parameters, supplier, projectBranches, mock(ProjectPullRequests.class));
 
-        assertNull(result.targetScmBranch());
+        assertNull(result.targetBranchName());
         assertEquals("longLivedBranch", result.branchName());
         assertEquals("longLivedBranch", result.longLivingSonarReferenceBranch());
         assertFalse(result.isShortOrPullRequest());
@@ -428,7 +428,7 @@ public class CommunityBranchConfigurationLoaderTest {
         BranchConfiguration result =
                 testCase.load(parameters, supplier, projectBranches, mock(ProjectPullRequests.class));
 
-        assertEquals("target", result.targetScmBranch());
+        assertEquals("target", result.targetBranchName());
         assertEquals("feature/sourceBranch", result.branchName());
         assertEquals("target", result.longLivingSonarReferenceBranch());
         assertTrue(result.isShortOrPullRequest());
@@ -457,7 +457,7 @@ public class CommunityBranchConfigurationLoaderTest {
         BranchConfiguration result =
                 testCase.load(parameters, supplier, projectBranches, mock(ProjectPullRequests.class));
 
-        assertEquals("master", result.targetScmBranch());
+        assertEquals("master", result.targetBranchName());
         assertEquals("feature/sourceBranch", result.branchName());
         assertEquals("master", result.longLivingSonarReferenceBranch());
         assertTrue(result.isShortOrPullRequest());
@@ -485,7 +485,7 @@ public class CommunityBranchConfigurationLoaderTest {
         BranchConfiguration result =
                 testCase.load(parameters, supplier, projectBranches, mock(ProjectPullRequests.class));
 
-        assertEquals("master", result.targetScmBranch());
+        assertEquals("master", result.targetBranchName());
         assertEquals("feature/sourceBranch", result.branchName());
         assertEquals("master", result.longLivingSonarReferenceBranch());
         assertTrue(result.isShortOrPullRequest());


### PR DESCRIPTION
SonarQube 7.8 contains changes to the APIs required for managing branches, with new methods having been introduced, and the existing `getMergeBranchUUid` method signature in `org.sonar.ce.tasj.projectanalysis.Branch` modified in a non-backwards-compatible way. Due to the incompatible changes, the supported SonarQube API version has been bumped from 7.4 to 7.8 and any methods that only existed to support older SonarQube versions have been removed.

The 7.8 release of SonarQube does not currently have a sonar-plugin-api dependency released with it, so the SonarQube 7.7 dependency for the plugin-api component is being used in its place.