### PR TITLE
Add support for SonarQube 7.9

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin;
 
+import com.github.mc1arke.sonarqube.plugin.ce.CommunityBranchEditionProvider;
 import com.github.mc1arke.sonarqube.plugin.ce.CommunityReportAnalysisComponentProvider;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchConfigurationLoader;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchParamsValidator;
@@ -44,7 +45,7 @@ public class CommunityBranchPlugin implements Plugin {
             context.addExtensions(CommunityProjectBranchesLoader.class, CommunityProjectPullRequestsLoader.class,
                                   CommunityBranchConfigurationLoader.class, CommunityBranchParamsValidator.class);
         } else if (SonarQubeSide.COMPUTE_ENGINE == context.getRuntime().getSonarQubeSide()) {
-            context.addExtension(CommunityReportAnalysisComponentProvider.class);
+            context.addExtensions(CommunityReportAnalysisComponentProvider.class, CommunityBranchEditionProvider.class);
         } else if (SonarQubeSide.SERVER == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class);
         }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchEditionProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchEditionProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce;
+
+import org.sonar.core.platform.EditionProvider;
+
+import java.util.Optional;
+
+public class CommunityBranchEditionProvider implements EditionProvider {
+
+    @Override
+    public Optional<Edition> get() {
+        return Optional.of(Edition.DEVELOPER);
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin;
 
+import com.github.mc1arke.sonarqube.plugin.ce.CommunityBranchEditionProvider;
 import com.github.mc1arke.sonarqube.plugin.ce.CommunityReportAnalysisComponentProvider;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchConfigurationLoader;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchParamsValidator;
@@ -83,10 +84,12 @@ public class CommunityBranchPluginTest {
         testCase.define(context);
 
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
-        verify(context).addExtension(argumentCaptor.capture());
+        verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
 
-        assertEquals(CommunityReportAnalysisComponentProvider.class, argumentCaptor.getValue());
+        assertEquals(
+                Arrays.asList(CommunityReportAnalysisComponentProvider.class, CommunityBranchEditionProvider.class),
+                argumentCaptor.getAllValues().subList(0, 2));
     }
 
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchEditionProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchEditionProviderTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.sonar.core.platform.EditionProvider;
+
+import java.util.Optional;
+
+public class CommunityBranchEditionProviderTest {
+
+    @Test
+    public void testGetEdition() {
+        Assert.assertEquals(Optional.of(EditionProvider.Edition.DEVELOPER), new CommunityBranchEditionProvider().get());
+    }
+
+}


### PR DESCRIPTION
SonarQube 7.9 contains an signature change on the method in `BranchConfigurationLoader` interface, and additional checks on the current edition of SonarQube to restrict what plugins/versions can support Branch Analysis.

An additional method implementation has therefore been added to deal with the interface change, whilst retaining the old method for backwards compatibility, and a new `CommunityBranchEditionProvider` has been added to make SonarQube Compute Engine believe that Developer Edition is currently being executed thereby allowing the branch restriction checks to be satisfied.