### PR TITLE
Enable CI Build and fix tests on Java 9 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+  - openjdk8
+  - openjdk11

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mc1arke_sonarqube-community-branch-plugin&metric=alert_status)](https://sonarcloud.io/dashboard?id=mc1arke_sonarqube-community-branch-plugin)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mc1arke_sonarqube-community-branch-plugin&metric=alert_status)](https://sonarcloud.io/dashboard?id=mc1arke_sonarqube-community-branch-plugin) [![Build Status](https://travis-ci.org/mc1arke/sonarqube-community-branch-plugin.svg?branch=master)](https://travis-ci.org/mc1arke/sonarqube-community-branch-plugin)
 
 # Sonarqube Community Branch Plugin
 A plugin for SonarQube to allow branch analysis in the Community version.

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     compileOnly fileTree(dir: sonarLibraries, include: '**/*.jar')
     testCompile fileTree(dir: sonarLibraries, include: '**/*.jar')
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.24.0'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.1.0'
     zip "sonarqube:sonarqube:${sonarqubeVersion}@zip"
 }
 


### PR DESCRIPTION
Adds integration with Travis for a CI build for Java 8 and Java 11, and fixes the tests that this integration highlighted were failing on Java 11.