### PR TITLE
#72: Allow override configuration from CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 #Gradle
 /.gradle/
 /build/
+.gradletasknamecache
 
 #Intellij
 /out/

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -22,11 +22,13 @@ import com.github.mc1arke.sonarqube.plugin.ce.CommunityBranchEditionProvider;
 import com.github.mc1arke.sonarqube.plugin.ce.CommunityReportAnalysisComponentProvider;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.server.BitbucketServerPullRequestDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4.GraphqlCheckRunProvider;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabServerPullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchConfigurationLoader;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchParamsValidator;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityProjectBranchesLoader;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityProjectPullRequestsLoader;
+import com.github.mc1arke.sonarqube.plugin.scanner.ScannerConfigurationLoaderSensor;
 import com.github.mc1arke.sonarqube.plugin.server.CommunityBranchFeatureExtension;
 import com.github.mc1arke.sonarqube.plugin.server.CommunityBranchSupportDelegate;
 import org.sonar.api.CoreProperties;
@@ -43,6 +45,7 @@ import org.sonar.core.extension.CoreExtension;
  */
 public class CommunityBranchPlugin implements Plugin, CoreExtension {
 
+    public static final String PULL_REQUEST_PROVIDER = "sonar.pullrequest.provider";
     private static final String PULL_REQUEST_CATEGORY_LABEL = "Pull Request";
     private static final String GITHUB_INTEGRATION_SUBCATEGORY_LABEL = "Integration With Github";
     private static final String GENERAL = "General";
@@ -86,29 +89,29 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
         if (SonarQubeSide.COMPUTE_ENGINE == context.getRuntime().getSonarQubeSide() ||
             SonarQubeSide.SERVER == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(
-                    PropertyDefinition.builder("sonar.pullrequest.provider").category(PULL_REQUEST_CATEGORY_LABEL)
+                    PropertyDefinition.builder(PULL_REQUEST_PROVIDER).category(PULL_REQUEST_CATEGORY_LABEL)
                             .subCategory("General").onQualifiers(Qualifiers.PROJECT).name("Provider")
                             .type(PropertyType.SINGLE_SELECT_LIST).options("Github", "BitbucketServer", "GitlabServer").build(),
 
-                    PropertyDefinition.builder("sonar.alm.github.app.privateKey.secured")
+                    PropertyDefinition.builder(GraphqlCheckRunProvider.PULL_REQUEST_GITHUB_TOKEN)
                             .category(PULL_REQUEST_CATEGORY_LABEL).subCategory(GITHUB_INTEGRATION_SUBCATEGORY_LABEL)
                             .onQualifiers(Qualifiers.APP).name("App Private Key").type(PropertyType.TEXT).build(),
 
-                    PropertyDefinition.builder("sonar.alm.github.app.name").category(PULL_REQUEST_CATEGORY_LABEL)
+                    PropertyDefinition.builder(GraphqlCheckRunProvider.PULL_REQUEST_GITHUB_APP_NAME).category(PULL_REQUEST_CATEGORY_LABEL)
                             .subCategory(GITHUB_INTEGRATION_SUBCATEGORY_LABEL).onQualifiers(Qualifiers.APP)
                             .name("App Name").defaultValue("SonarQube Community Pull Request Analysis")
                             .type(PropertyType.STRING).build(),
 
-                    PropertyDefinition.builder("sonar.alm.github.app.id").category(PULL_REQUEST_CATEGORY_LABEL)
+                    PropertyDefinition.builder(GraphqlCheckRunProvider.PULL_REQUEST_GITHUB_APP_ID).category(PULL_REQUEST_CATEGORY_LABEL)
                             .subCategory(GITHUB_INTEGRATION_SUBCATEGORY_LABEL).onQualifiers(Qualifiers.APP)
                             .name("App ID").type(PropertyType.STRING).build(),
 
-                    PropertyDefinition.builder("sonar.pullrequest.github.repository")
+                    PropertyDefinition.builder(GraphqlCheckRunProvider.PULL_REQUEST_GITHUB_REPOSITORY)
                             .category(PULL_REQUEST_CATEGORY_LABEL).subCategory(GITHUB_INTEGRATION_SUBCATEGORY_LABEL)
                             .onlyOnQualifiers(Qualifiers.PROJECT).name("Repository identifier")
                             .description("Example: SonarSource/sonarqube").type(PropertyType.STRING).build(),
 
-                    PropertyDefinition.builder("sonar.pullrequest.github.endpoint")
+                    PropertyDefinition.builder(GraphqlCheckRunProvider.PULL_REQUEST_GITHUB_URL)
                             .category(PULL_REQUEST_CATEGORY_LABEL).subCategory(GITHUB_INTEGRATION_SUBCATEGORY_LABEL)
                             .onQualifiers(Qualifiers.APP).name("The API URL for a GitHub instance").description(
                             "The API url for a GitHub instance. https://api.github.com/ for github.com, https://github.company.com/api/ when using GitHub Enterprise")
@@ -185,7 +188,8 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
     public void define(Plugin.Context context) {
         if (SonarQubeSide.SCANNER == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(CommunityProjectBranchesLoader.class, CommunityProjectPullRequestsLoader.class,
-                                  CommunityBranchConfigurationLoader.class, CommunityBranchParamsValidator.class);
+                                  CommunityBranchConfigurationLoader.class, CommunityBranchParamsValidator.class,
+                                  ScannerConfigurationLoaderSensor.class);
         }
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestBuildStatusDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestBuildStatusDecorator.java
@@ -28,5 +28,5 @@ public interface PullRequestBuildStatusDecorator {
 
     String name();
 
-    void decorateQualityGateStatus(AnalysisDetails analysisDetails);
+    void decorateQualityGateStatus(AnalysisDetails analysisDetails, UnifyConfiguration configuration);
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTask.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTask.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
 
+import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
 import org.sonar.api.ce.posttask.Analysis;
 import org.sonar.api.ce.posttask.Branch;
 import org.sonar.api.ce.posttask.PostProjectAnalysisTask;
@@ -86,9 +87,10 @@ public class PullRequestPostAnalysisTask implements PostProjectAnalysisTask,
         }
 
         Configuration configuration = configurationRepository.getConfiguration();
+        UnifyConfiguration unifyConfiguration = new UnifyConfiguration(configuration, projectAnalysis.getScannerContext());
 
         Optional<PullRequestBuildStatusDecorator> optionalPullRequestDecorator =
-                findCurrentPullRequestStatusDecorator(configuration, pullRequestDecorators);
+                findCurrentPullRequestStatusDecorator(unifyConfiguration, pullRequestDecorators);
 
         if (!optionalPullRequestDecorator.isPresent()) {
             LOGGER.info("No decorator found for this Pull Request");
@@ -127,16 +129,16 @@ public class PullRequestPostAnalysisTask implements PostProjectAnalysisTask,
 
         PullRequestBuildStatusDecorator pullRequestDecorator = optionalPullRequestDecorator.get();
         LOGGER.info("using pull request decorator" + pullRequestDecorator.name());
-        pullRequestDecorator.decorateQualityGateStatus(analysisDetails);
+        pullRequestDecorator.decorateQualityGateStatus(analysisDetails, unifyConfiguration);
     }
 
     private static Optional<PullRequestBuildStatusDecorator> findCurrentPullRequestStatusDecorator(
-            Configuration configuration, List<PullRequestBuildStatusDecorator> pullRequestDecorators) {
+            UnifyConfiguration unifyConfiguration, List<PullRequestBuildStatusDecorator> pullRequestDecorators) {
 
-        Optional<String> optionalImplementationName = configuration.get("sonar.pullrequest.provider");
+        Optional<String> optionalImplementationName = unifyConfiguration.getProperty(CommunityBranchPlugin.PULL_REQUEST_PROVIDER);
 
         if (!optionalImplementationName.isPresent()) {
-            LOGGER.debug("'sonar.pullrequest.provider' property not set");
+            LOGGER.debug(CommunityBranchPlugin.PULL_REQUEST_PROVIDER + " property not set");
             return Optional.empty();
         }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/UnifyConfiguration.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/UnifyConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Artemy Osipov
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
+
+import org.sonar.api.ce.posttask.ScannerContext;
+import org.sonar.api.config.Configuration;
+
+import java.util.Optional;
+
+public class UnifyConfiguration {
+
+    private final Configuration serverConfiguration;
+    private final ScannerContext scannerContext;
+
+    public UnifyConfiguration(Configuration serverConfiguration, ScannerContext scannerContext) {
+        this.serverConfiguration = serverConfiguration;
+        this.scannerContext = scannerContext;
+    }
+
+    public Optional<String> getProperty(String propertyName) {
+        if (scannerContext.getProperties().containsKey(propertyName)) {
+            return Optional.of(scannerContext.getProperties().get(propertyName));
+        }
+
+        return getServerProperty(propertyName);
+    }
+
+    public String getRequiredProperty(String propertyName) {
+        return getProperty(propertyName).orElseThrow(() ->
+                new IllegalStateException(propertyName + " must be specified in the project configuration or as scanner parameter")
+        );
+    }
+
+    public Optional<String> getServerProperty(String propertyName) {
+        return serverConfiguration.get(propertyName);
+    }
+
+    public String getRequiredServerProperty(String propertyName) {
+        return getServerProperty(propertyName).orElseThrow(() ->
+                new IllegalStateException(propertyName + " must be specified in the project configuration")
+        );
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/CheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/CheckRunProvider.java
@@ -19,10 +19,11 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public interface CheckRunProvider {
-    void createCheckRun(AnalysisDetails analysisDetails) throws IOException, GeneralSecurityException;
+    void createCheckRun(AnalysisDetails analysisDetails, UnifyConfiguration unifyConfiguration) throws IOException, GeneralSecurityException;
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
@@ -20,6 +20,7 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
 
 public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorator {
 
@@ -30,9 +31,9 @@ public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorat
     }
 
     @Override
-    public void decorateQualityGateStatus(AnalysisDetails analysisDetails) {
+    public void decorateQualityGateStatus(AnalysisDetails analysisDetails, UnifyConfiguration unifyConfiguration) {
         try {
-            checkRunProvider.createCheckRun(analysisDetails);
+            checkRunProvider.createCheckRun(analysisDetails, unifyConfiguration);
         } catch (Exception ex) {
             throw new IllegalStateException("Could not decorate Pull Request on Github", ex);
         }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerConfigurationLoaderSensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerConfigurationLoaderSensor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 Artemy Osipov
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner;
+
+import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.server.BitbucketServerPullRequestDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4.GraphqlCheckRunProvider;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabServerPullRequestDecorator;
+import com.google.common.collect.Sets;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+
+import java.util.Optional;
+import java.util.Set;
+
+public class ScannerConfigurationLoaderSensor implements Sensor {
+
+    private final Set<String> overridableParameters;
+
+    public ScannerConfigurationLoaderSensor() {
+        this(Sets.newHashSet(
+                CommunityBranchPlugin.PULL_REQUEST_PROVIDER,
+                BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_PROJECT_KEY,
+                BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_USER_SLUG,
+                BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_REPOSITORY_SLUG,
+                GraphqlCheckRunProvider.PULL_REQUEST_GITHUB_REPOSITORY,
+                GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG
+        ));
+    }
+
+    ScannerConfigurationLoaderSensor(Set<String> overridableParameters) {
+        this.overridableParameters = overridableParameters;
+    }
+
+    @Override
+    public void describe(SensorDescriptor descriptor) {
+        descriptor.name(getClass().getName());
+    }
+
+    @Override
+    public void execute(SensorContext context) {
+        overridableParameters.forEach(param -> saveProperty(param, context));
+    }
+
+    private void saveProperty(String propertyName, SensorContext context) {
+        Optional<String> param = context.config().get(propertyName);
+
+        param.ifPresent(value -> context.addContextProperty(propertyName, value));
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/UnifyConfigurationTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/UnifyConfigurationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 Artemy Osipov
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
+
+import org.assertj.core.util.Maps;
+import org.junit.Test;
+import org.sonar.api.ce.posttask.ScannerContext;
+import org.sonar.api.config.Configuration;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class UnifyConfigurationTest {
+
+    private static final String PROPERTY_NAME = "some.sonar.property";
+    private static final String PROPERTY_VALUE = "some.sonar.value";
+
+    private Configuration configuration = mock(Configuration.class);
+    private ScannerContext scannerContext = mock(ScannerContext.class);
+
+    private UnifyConfiguration unifyConfiguration = new UnifyConfiguration(configuration, scannerContext);
+
+    @Test
+    public void shouldReturnPropertyFromScannerContextWhenPropertySetAtScanner() {
+        doReturn(Maps.newHashMap(PROPERTY_NAME, PROPERTY_VALUE))
+                .when(scannerContext)
+                .getProperties();
+
+        Optional<String> property = unifyConfiguration.getProperty(PROPERTY_NAME);
+
+        assertThat(property).hasValue(PROPERTY_VALUE);
+    }
+
+    @Test
+    public void shouldReturnPropertyFromScannerContextWhenPropertySetAtScannerAndAtConfiguration() {
+        doReturn(Optional.of("from configuration"))
+                .when(configuration)
+                .get(PROPERTY_NAME);
+        doReturn(Maps.newHashMap(PROPERTY_NAME, PROPERTY_VALUE))
+                .when(scannerContext)
+                .getProperties();
+
+        Optional<String> property = unifyConfiguration.getProperty(PROPERTY_NAME);
+
+        assertThat(property).hasValue(PROPERTY_VALUE);
+    }
+
+    @Test
+    public void shouldReturnPropertyFromConfigurationWhenPropertyNotSetAtScannerButSetAtConfiguration() {
+        doReturn(Optional.of(PROPERTY_VALUE))
+                .when(configuration)
+                .get(PROPERTY_NAME);
+
+        Optional<String> property = unifyConfiguration.getProperty(PROPERTY_NAME);
+
+        assertThat(property).hasValue(PROPERTY_VALUE);
+    }
+
+    @Test
+    public void shouldReturnPropertyFromScannerContextWhenPropertySetAsBlankStringAtConfigurationButSetAtScanner() {
+        doReturn(Optional.of("  "))
+                .when(configuration)
+                .get(PROPERTY_NAME);
+        doReturn(Maps.newHashMap(PROPERTY_NAME, PROPERTY_VALUE))
+                .when(scannerContext)
+                .getProperties();
+
+        Optional<String> property = unifyConfiguration.getProperty(PROPERTY_NAME);
+
+        assertThat(property).hasValue(PROPERTY_VALUE);
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenPropertyNotSet() {
+        doReturn(new HashMap<>())
+                .when(scannerContext)
+                .getProperties();
+
+        Optional<String> property = unifyConfiguration.getProperty(PROPERTY_NAME);
+
+        assertThat(property).isEmpty();
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenRequiredPropertyNotSet() {
+        doReturn(new HashMap<>())
+                .when(scannerContext)
+                .getProperties();
+
+        assertThatThrownBy(
+                () -> unifyConfiguration.getRequiredProperty(PROPERTY_NAME)
+        ).isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/server/BitbucketServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/server/BitbucketServerPullRequestDecoratorTest.java
@@ -49,7 +49,7 @@ public class BitbucketServerPullRequestDecoratorTest {
 
     @Before
     public void setUp() {
-        bitbucketServerPullRequestDecorator = new BitbucketServerPullRequestDecorator(null);
+        bitbucketServerPullRequestDecorator = new BitbucketServerPullRequestDecorator();
 
         headers = new HashMap<>();
         headers.put("Authorization", String.format("Bearer %s", APITOKEN));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerConfigurationLoaderSensorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerConfigurationLoaderSensorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Artemy Osipov
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner;
+
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.config.Configuration;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+
+public class ScannerConfigurationLoaderSensorTest {
+
+    private static final String PROPERTY_1 = "property1";
+    private static final String PROPERTY_2 = "property2";
+
+    private ScannerConfigurationLoaderSensor sensor = new ScannerConfigurationLoaderSensor(Sets.newHashSet(PROPERTY_1, PROPERTY_2));
+
+    private SensorContext context = mock(SensorContext.class);
+    private Configuration configuration = mock(Configuration.class);
+
+    @Before
+    public void init() {
+        doReturn(configuration)
+                .when(context)
+                .config();
+    }
+
+    @Test
+    public void shouldSaveToContextOnlySpecifiedParameters() {
+        String propValue = "someValue";
+        doReturn(Optional.of(propValue))
+                .when(configuration)
+                .get(PROPERTY_1);
+
+        sensor.execute(context);
+
+        verify(context).addContextProperty(PROPERTY_1, propValue);
+        verify(context, never()).addContextProperty(eq(PROPERTY_2), any());
+    }
+}


### PR DESCRIPTION
During the merging of the configurations for PullRequestBuildStatusDecorator, I removed the explicit reading of the default parameter values from PropertyDefinitions for github decorator. According to the implementation of org.sonar.api.config.Configuration sonar reads them itself. Unfortunately, I have an opportunity to check only with BitbucketServer and it really works with this command

```
docker run -ti -v $(pwd):/usr/src newtmitch/sonar-scanner:4.0.0-alpine \
  -Dsonar.host.url=$SONAR_URL \
  -Dsonar.projectKey="project:repo" \
  -Dsonar.projectName="repo" \
  -Dsonar.projectBaseDir=/usr/src \
  -Dsonar.sources=. \
  -Dsonar.pullrequest.key="13" \
  -Dsonar.pullrequest.branch="test-sonar" \
  -Dsonar.pullrequest.base="master" \
  -Dsonar.pullrequest.provider="BitbucketServer" \
  -Dsonar.pullrequest.bitbucket.projectKey="project" \
  -Dsonar.pullrequest.bitbucket.repositorySlug="repo"
```