### PR TITLE
Gitlab PR Decorator Fixes for Sonar 8.1

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -153,10 +153,10 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
                 }
             }
 
-            QualityGate.Condition newCoverageCondition = analysis.findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)
-                    .orElseThrow(() -> new IllegalStateException("Could not find New Coverage Condition in analysis"));
-            String coverageValue = newCoverageCondition.getStatus().equals(QualityGate.EvaluationStatus.NO_VALUE) ? "0" : newCoverageCondition.getValue();
-
+            String coverageValue = analysis.findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)
+                    .filter(condition -> condition.getStatus() != QualityGate.EvaluationStatus.NO_VALUE)
+                    .map(QualityGate.Condition::getValue)
+                    .orElse("0");
 
             List<PostAnalysisIssueVisitor.ComponentIssue> openIssues = analysis.getPostAnalysisIssueVisitor().getIssues().stream().filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().getStatus())).collect(Collectors.toList());
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -185,6 +185,7 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
                                 new BasicNameValuePair("position[base_sha]", mergeRequest.getDiffRefs().getBaseSha()),
                                 new BasicNameValuePair("position[start_sha]", mergeRequest.getDiffRefs().getStartSha()),
                                 new BasicNameValuePair("position[head_sha]", mergeRequest.getDiffRefs().getHeadSha()),
+                                new BasicNameValuePair("position[old_path]", path),
                                 new BasicNameValuePair("position[new_path]", path),
                                 new BasicNameValuePair("position[new_line]", String.valueOf(issue.getIssue().getLine())),
                                 new BasicNameValuePair("position[position_type]", "text"));

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -67,8 +67,8 @@ import java.util.stream.Collectors;
 
 public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusDecorator {
 
-    public static final String PULLREQUEST_GITLAB_URL =
-            "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.gitlab.url";
+    public static final String PULLREQUEST_GITLAB_API_URL =
+            "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.gitlab.api.url";
     public static final String PULLREQUEST_GITLAB_REPOSITORY_SLUG =
             "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.gitlab.repositorySlug";
 
@@ -93,10 +93,10 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
         String revision = analysis.getCommitSha();
 
         try {
-            final String hostURL = analysis.getScannerProperty(PULLREQUEST_GITLAB_URL).orElseThrow(
+            final String apiURL = analysis.getScannerProperty(PULLREQUEST_GITLAB_API_URL).orElseThrow(
                     () -> new IllegalStateException(String.format(
                             "Could not decorate Gitlab merge request. '%s' has not been set in scanner properties",
-                            PULLREQUEST_GITLAB_URL)));
+                            PULLREQUEST_GITLAB_API_URL)));
             final String apiToken = almSettingDto.getPersonalAccessToken();
             final String repositorySlug = analysis.getScannerProperty(PULLREQUEST_GITLAB_REPOSITORY_SLUG).orElseThrow(
                     () -> new IllegalStateException(String.format(
@@ -104,8 +104,7 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
                             PULLREQUEST_GITLAB_REPOSITORY_SLUG)));
             final String pullRequestId = analysis.getBranchName();
 
-            final String restURL = String.format("%s/api/v4", hostURL);
-            final String projectURL = restURL + String.format("/projects/%s", URLEncoder.encode(repositorySlug, StandardCharsets.UTF_8.name()));
+            final String projectURL = apiURL + String.format("/projects/%s", URLEncoder.encode(repositorySlug, StandardCharsets.UTF_8.name()));
             final String statusUrl = projectURL + String.format("/statuses/%s", revision);
             final String mergeRequestURl = projectURL + String.format("/merge_requests/%s", pullRequestId);
             final String prCommitsURL = mergeRequestURl + "/commits";

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -25,7 +25,10 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response.Commit;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response.Discussion;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response.MergeRequest;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response.Note;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response.User;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
@@ -33,6 +36,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -105,6 +109,7 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
             final String pullRequestId = analysis.getBranchName();
 
             final String projectURL = apiURL + String.format("/projects/%s", URLEncoder.encode(repositorySlug, StandardCharsets.UTF_8.name()));
+            final String userURL = apiURL + "/user";
             final String statusUrl = projectURL + String.format("/statuses/%s", revision);
             final String mergeRequestURl = projectURL + String.format("/merge_requests/%s", pullRequestId);
             final String prCommitsURL = mergeRequestURl + "/commits";
@@ -113,14 +118,38 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
             LOGGER.info(String.format("Status url is: %s ", statusUrl));
             LOGGER.info(String.format("PR commits url is: %s ", prCommitsURL));
             LOGGER.info(String.format("MR discussion url is: %s ", mergeRequestDiscussionURL));
+            LOGGER.info(String.format("User url is: %s ", userURL));
 
             Map<String, String> headers = new HashMap<>();
             headers.put("PRIVATE-TOKEN", apiToken);
             headers.put("Accept", "application/json");
 
+            User user = getSingle(userURL, headers, User.class);
+            LOGGER.info(String.format("Using user: %s ", user.getUsername()));
+
             List<String> commits = getPagedList(prCommitsURL, headers, new TypeReference<List<Commit>>() {
             }).stream().map(Commit::getId).collect(Collectors.toList());
             MergeRequest mergeRequest = getSingle(mergeRequestURl, headers, MergeRequest.class);
+
+            List<Discussion> discussions = getPagedList(mergeRequestDiscussionURL, headers, new TypeReference<List<Discussion>>() {
+            });
+
+            LOGGER.info(String.format("Discussions in MR: %s ", discussions
+                    .stream()
+                    .map(Discussion::getId)
+                    .collect(Collectors.joining(", "))));
+
+            for (Discussion discussion : discussions) {
+                for (Note note : discussion.getNotes()) {
+                    if (!note.isSystem() && note.getAuthor() != null && note.getAuthor().getUsername().equals(user.getUsername())) {
+                        //delete only our own comments
+                        deleteCommitDiscussionNote(mergeRequestDiscussionURL + String.format("/%s/notes/%s",
+                                discussion.getId(),
+                                note.getId()),
+                                headers);
+                    }
+                }
+            }
 
             QualityGate.Condition newCoverageCondition = analysis.findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)
                     .orElseThrow(() -> new IllegalStateException("Could not find New Coverage Condition in analysis"));
@@ -239,8 +268,22 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
         return discussions;
     }
 
-    private void postCommitComment(String commitCommentUrl, Map<String, String> headers, List<NameValuePair> params)
-            throws IOException {
+    private void deleteCommitDiscussionNote(String commitDiscussionNoteURL, Map<String, String> headers) throws IOException {
+        //https://docs.gitlab.com/ee/api/discussions.html#delete-a-commit-thread-note
+        HttpDelete httpDelete = new HttpDelete(commitDiscussionNoteURL);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            httpDelete.addHeader(entry.getKey(), entry.getValue());
+        }
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            LOGGER.info("Deleting {} with headers {}", commitDiscussionNoteURL, headers);
+
+            HttpResponse httpResponse = httpClient.execute(httpDelete);
+            validateGitlabResponse(httpResponse, 204, "Commit discussions note deleted");
+        }
+    }
+
+    private void postCommitComment(String commitCommentUrl, Map<String, String> headers, List<NameValuePair> params) throws IOException {
         //https://docs.gitlab.com/ee/api/commits.html#post-comment-to-commit
         HttpPost httpPost = new HttpPost(commitCommentUrl);
         for (Map.Entry<String, String> entry : headers.entrySet()) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -71,10 +71,12 @@ import java.util.stream.Collectors;
 
 public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusDecorator {
 
-    public static final String PULLREQUEST_GITLAB_API_URL =
-            "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.gitlab.api.url";
-    public static final String PULLREQUEST_GITLAB_REPOSITORY_SLUG =
-            "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.gitlab.repositorySlug";
+    public static final String PULLREQUEST_GITLAB_INSTANCE_URL =
+            "sonar.pullrequest.gitlab.instanceUrl";
+    public static final String PULLREQUEST_GITLAB_PROJECT_ID =
+            "sonar.pullrequest.gitlab.projectId";
+    public static final String PULLREQUEST_GITLAB_PROJECT_URL =
+            "sonar.pullrequest.gitlab.projectUrl";
 
     private static final Logger LOGGER = Loggers.get(GitlabServerPullRequestDecorator.class);
     private static final List<String> OPEN_ISSUE_STATUSES =
@@ -97,18 +99,18 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
         String revision = analysis.getCommitSha();
 
         try {
-            final String apiURL = analysis.getScannerProperty(PULLREQUEST_GITLAB_API_URL).orElseThrow(
+            final String apiURL = analysis.getScannerProperty(PULLREQUEST_GITLAB_INSTANCE_URL).orElseThrow(
                     () -> new IllegalStateException(String.format(
                             "Could not decorate Gitlab merge request. '%s' has not been set in scanner properties",
-                            PULLREQUEST_GITLAB_API_URL)));
+                            PULLREQUEST_GITLAB_INSTANCE_URL)));
             final String apiToken = almSettingDto.getPersonalAccessToken();
-            final String repositorySlug = analysis.getScannerProperty(PULLREQUEST_GITLAB_REPOSITORY_SLUG).orElseThrow(
+            final String projectId = analysis.getScannerProperty(PULLREQUEST_GITLAB_PROJECT_ID).orElseThrow(
                     () -> new IllegalStateException(String.format(
                             "Could not decorate Gitlab merge request. '%s' has not been set in scanner properties",
-                            PULLREQUEST_GITLAB_REPOSITORY_SLUG)));
+                            PULLREQUEST_GITLAB_PROJECT_ID)));
             final String pullRequestId = analysis.getBranchName();
 
-            final String projectURL = apiURL + String.format("/projects/%s", URLEncoder.encode(repositorySlug, StandardCharsets.UTF_8.name()));
+            final String projectURL = apiURL + String.format("/projects/%s", URLEncoder.encode(projectId, StandardCharsets.UTF_8.name()));
             final String userURL = apiURL + "/user";
             final String statusUrl = projectURL + String.format("/statuses/%s", revision);
             final String mergeRequestURl = projectURL + String.format("/merge_requests/%s", pullRequestId);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/response/Discussion.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/response/Discussion.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Markus Heberling
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Discussion {
+    private final String id;
+
+    private final List<Note> notes;
+
+    @JsonCreator
+    public Discussion(@JsonProperty("id") String id, @JsonProperty("notes") List<Note> notes) {
+        this.id = id;
+        this.notes = notes;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public List<Note> getNotes() {
+        return notes;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/response/Note.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/response/Note.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 Markus Heberling
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Note {
+    private final long id;
+
+    private final boolean system;
+
+    private final User author;
+
+    @JsonCreator
+    public Note(@JsonProperty("id") long id, @JsonProperty("system") boolean system, @JsonProperty("author") User author) {
+        this.id = id;
+        this.system = system;
+        this.author = author;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public boolean isSystem() {
+        return system;
+    }
+
+    public User getAuthor() {
+        return author;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/response/User.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/response/User.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 Markus Heberling
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class User {
+    private final String username;
+
+    @JsonCreator
+    public User(@JsonProperty("username") String username) {
+        this.username = username;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoader.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoader.java
@@ -20,6 +20,7 @@ package com.github.mc1arke.sonarqube.plugin.scanner;
 
 import org.apache.commons.lang.StringUtils;
 import org.sonar.api.utils.MessageException;
+import org.sonar.api.utils.System2;
 import org.sonar.core.config.ScannerProperties;
 import org.sonar.scanner.scan.branch.BranchConfiguration;
 import org.sonar.scanner.scan.branch.BranchConfigurationLoader;
@@ -30,8 +31,11 @@ import org.sonar.scanner.scan.branch.ProjectBranches;
 import org.sonar.scanner.scan.branch.ProjectPullRequests;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -45,10 +49,18 @@ public class CommunityBranchConfigurationLoader implements BranchConfigurationLo
     private static final Set<String> PULL_REQUEST_ANALYSIS_PARAMETERS = new HashSet<>(
             Arrays.asList(ScannerProperties.PULL_REQUEST_BRANCH, ScannerProperties.PULL_REQUEST_KEY,
                           ScannerProperties.PULL_REQUEST_BASE));
+    private final System2 system2;
+
+    public CommunityBranchConfigurationLoader(System2 system2) {
+        this.system2 = system2;
+    }
+
 
     @Override
     public BranchConfiguration load(Map<String, String> localSettings, ProjectBranches projectBranches,
                                     ProjectPullRequests pullRequests) {
+        localSettings = autoConfigure(localSettings);
+
         if (projectBranches.isEmpty()) {
             if (isTargetingDefaultBranch(localSettings)) {
                 return new DefaultBranchConfiguration();
@@ -71,6 +83,27 @@ public class CommunityBranchConfigurationLoader implements BranchConfigurationLo
         }
 
         return new DefaultBranchConfiguration();
+    }
+
+    private Map<String, String> autoConfigure(Map<String, String> localSettings) {
+        Map<String, String> mutableLocalSettings=new HashMap<>(localSettings);
+        if (Boolean.parseBoolean(system2.envVariable("GITLAB_CI"))) {
+            //GitLab CI auto configuration
+            if (system2.envVariable("CI_MERGE_REQUEST_IID") != null) {
+                // we are inside a merge request
+                Optional.ofNullable(system2.envVariable("CI_MERGE_REQUEST_IID")).ifPresent(
+                        v -> mutableLocalSettings.putIfAbsent(ScannerProperties.PULL_REQUEST_KEY, v));
+                Optional.ofNullable(system2.envVariable("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME")).ifPresent(
+                        v -> mutableLocalSettings.putIfAbsent(ScannerProperties.PULL_REQUEST_BRANCH, v));
+                Optional.ofNullable(system2.envVariable("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")).ifPresent(
+                        v -> mutableLocalSettings.putIfAbsent(ScannerProperties.PULL_REQUEST_BASE, v));
+            } else {
+                // branch or tag
+                Optional.ofNullable(system2.envVariable("CI_COMMIT_REF_NAME")).ifPresent(
+                        v -> mutableLocalSettings.putIfAbsent(ScannerProperties.BRANCH_NAME, v));
+            }
+        }
+        return Collections.unmodifiableMap(mutableLocalSettings);
     }
 
     private static boolean isTargetingDefaultBranch(Map<String, String> localSettings) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
@@ -47,14 +47,14 @@ public class ScannerPullRequestPropertySensor implements Sensor {
                     v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL, v));
             Optional.ofNullable(system2.envVariable("CI_PROJECT_PATH")).ifPresent(v -> sensorContext
                     .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG, v));
-        } else {
-            Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL)).ifPresent(
-                    v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL, v));
-            Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG))
-                    .ifPresent(v -> sensorContext
-                            .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG,
-                                                v));
         }
+
+        Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL)).ifPresent(
+                v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL, v));
+        Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG))
+                .ifPresent(v -> sensorContext
+                        .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG,
+                                            v));
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
@@ -43,18 +43,20 @@ public class ScannerPullRequestPropertySensor implements Sensor {
     @Override
     public void execute(SensorContext sensorContext) {
         if (Boolean.parseBoolean(system2.envVariable("GITLAB_CI"))) {
-            Optional.ofNullable(system2.envVariable("CI_API_V4_URL")).ifPresent(
-                    v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL, v));
+            Optional.ofNullable(system2.envVariable("CI_API_V4_URL")).ifPresent(v -> sensorContext
+                    .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL, v));
             Optional.ofNullable(system2.envVariable("CI_PROJECT_PATH")).ifPresent(v -> sensorContext
-                    .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG, v));
+                    .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID, v));
+            Optional.ofNullable(system2.envVariable("CI_MERGE_REQUEST_PROJECT_URL")).ifPresent(v -> sensorContext
+                    .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, v));
         }
 
-        Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL)).ifPresent(
-                v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL, v));
-        Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG))
-                .ifPresent(v -> sensorContext
-                        .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG,
-                                            v));
+        Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL)).ifPresent(
+                v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL, v));
+        Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID)).ifPresent(
+                v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID, v));
+        Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL)).ifPresent(
+                v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, v));
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
@@ -44,12 +44,12 @@ public class ScannerPullRequestPropertySensor implements Sensor {
     public void execute(SensorContext sensorContext) {
         if (Boolean.parseBoolean(system2.envVariable("GITLAB_CI"))) {
             Optional.ofNullable(system2.envVariable("CI_API_V4_URL")).ifPresent(
-                    v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_URL, v));
+                    v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL, v));
             Optional.ofNullable(system2.envVariable("CI_PROJECT_PATH")).ifPresent(v -> sensorContext
                     .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG, v));
         } else {
-            Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_URL)).ifPresent(
-                    v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_URL, v));
+            Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL)).ifPresent(
+                    v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL, v));
             Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG))
                     .ifPresent(v -> sensorContext
                             .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG,

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
@@ -49,6 +49,8 @@ public class ScannerPullRequestPropertySensor implements Sensor {
                     .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID, v));
             Optional.ofNullable(system2.envVariable("CI_MERGE_REQUEST_PROJECT_URL")).ifPresent(v -> sensorContext
                     .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, v));
+            Optional.ofNullable(system2.envVariable("CI_PIPELINE_ID")).ifPresent(v -> sensorContext
+                    .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, v));
         }
 
         Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL)).ifPresent(
@@ -57,6 +59,8 @@ public class ScannerPullRequestPropertySensor implements Sensor {
                 v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID, v));
         Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL)).ifPresent(
                 v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, v));
+        Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID)).ifPresent(
+                v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, v));
     }
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -83,10 +83,10 @@ public class GitlabServerPullRequestDecoratorTest {
         when(almSettingDto.getPersonalAccessToken()).thenReturn("token");
 
         AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
-        when(analysisDetails.getScannerProperty(eq(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL)))
+        when(analysisDetails.getScannerProperty(eq(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL)))
                 .thenReturn(Optional.of(wireMockRule.baseUrl()+"/api/v4"));
         when(analysisDetails
-                     .getScannerProperty(eq(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG)))
+                     .getScannerProperty(eq(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID)))
                 .thenReturn(Optional.of(repositorySlug));
         when(analysisDetails.getAnalysisProjectKey()).thenReturn(projectKey);
         when(analysisDetails.getBranchName()).thenReturn(branchName);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -162,6 +162,7 @@ public class GitlabServerPullRequestDecoratorTest {
                         urlEncode("position[base_sha]") + "=d6a420d043dfe85e7c240fd136fc6e197998b10a&" +
                         urlEncode("position[start_sha]") + "=d6a420d043dfe85e7c240fd136fc6e197998b10a&" +
                         urlEncode("position[head_sha]") + "=" + commitSHA + "&" +
+                        urlEncode("position[old_path]") + "=" + urlEncode(filePath) + "&" +
                         urlEncode("position[new_path]") + "=" + urlEncode(filePath) + "&" +
                         urlEncode("position[new_line]") + "=" + lineNumber + "&" +
                         urlEncode("position[position_type]") + "=text"))

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -83,8 +83,8 @@ public class GitlabServerPullRequestDecoratorTest {
         when(almSettingDto.getPersonalAccessToken()).thenReturn("token");
 
         AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
-        when(analysisDetails.getScannerProperty(eq(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_URL)))
-                .thenReturn(Optional.of(wireMockRule.baseUrl()));
+        when(analysisDetails.getScannerProperty(eq(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_API_URL)))
+                .thenReturn(Optional.of(wireMockRule.baseUrl()+"/api/v4"));
         when(analysisDetails
                      .getScannerProperty(eq(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG)))
                 .thenReturn(Optional.of(repositorySlug));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -112,78 +112,60 @@ public class GitlabServerPullRequestDecoratorTest {
         when(scmInfo.getChangesetForLine(anyInt())).thenReturn(Changeset.newChangesetBuilder().setDate(0L).setRevision(commitSHA).build());
         when(scmInfoRepository.getScmInfo(component)).thenReturn(Optional.of(scmInfo));
         wireMockRule.stubFor(get(urlPathEqualTo("/api/v4/user")).withHeader("PRIVATE-TOKEN", equalTo("token")).willReturn(okJson("{\n" +
-                                                                                                                                 "  \"id\": 1,\n" +
-                                                                                                                                 "  \"username\": \"" +
-                                                                                                                                 user +
-                                                                                                                                 "\"}")));
+                "  \"id\": 1,\n" +
+                "  \"username\": \"" + user + "\"}")));
 
         wireMockRule.stubFor(get(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName)).willReturn(okJson("{\n" +
-                                                                                                                                                      "  \"id\": 15235,\n" +
-                                                                                                                                                      "  \"iid\": " +
-                                                                                                                                                      branchName +
-                                                                                                                                                      ",\n" +
-                                                                                                                                                      "  \"diff_refs\": {\n" +
-                                                                                                                                                      "    \"base_sha\":\"d6a420d043dfe85e7c240fd136fc6e197998b10a\",\n" +
-                                                                                                                                                      "    \"head_sha\":\"" +
-                                                                                                                                                      commitSHA +
-                                                                                                                                                      "\",\n" +
-                                                                                                                                                      "    \"start_sha\":\"d6a420d043dfe85e7c240fd136fc6e197998b10a\"}\n" +
-                                                                                                                                                      "}")));
+                "  \"id\": 15235,\n" +
+                "  \"iid\": " + branchName + ",\n" +
+                "  \"diff_refs\": {\n" +
+                "    \"base_sha\":\"d6a420d043dfe85e7c240fd136fc6e197998b10a\",\n" +
+                "    \"head_sha\":\"" + commitSHA + "\",\n" +
+                "    \"start_sha\":\"d6a420d043dfe85e7c240fd136fc6e197998b10a\"}\n" +
+                "}")));
 
         wireMockRule.stubFor(get(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/commits")).willReturn(okJson("[\n" +
-                                                                                                                                                                   "  {\n" +
-                                                                                                                                                                   "    \"id\": \"" +
-                                                                                                                                                                   commitSHA +
-                                                                                                                                                                   "\"\n" +
-                                                                                                                                                                   "  }]")));
+                "  {\n" +
+                "    \"id\": \"" + commitSHA + "\"\n" +
+                "  }]")));
 
         wireMockRule.stubFor(get(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/discussions")).willReturn(okJson("[\n" +
-                                                                                                                                                                       "  {\n" +
-                                                                                                                                                                       "    \"id\": \"" +
-                                                                                                                                                                       discussionId +
-                                                                                                                                                                       "\",\n" +
-                                                                                                                                                                       "    \"individual_note\": false,\n" +
-                                                                                                                                                                       "    \"notes\": [\n" +
-                                                                                                                                                                       "      {\n" +
-                                                                                                                                                                       "        \"id\": " +
-                                                                                                                                                                       noteId +
-                                                                                                                                                                       ",\n" +
-                                                                                                                                                                       "        \"type\": \"DiscussionNote\",\n" +
-                                                                                                                                                                       "        \"body\": \"discussion text\",\n" +
-                                                                                                                                                                       "        \"attachment\": null,\n" +
-                                                                                                                                                                       "        \"author\": {\n" +
-                                                                                                                                                                       "          \"id\": 1,\n" +
-                                                                                                                                                                       "          \"username\": \"" +
-                                                                                                                                                                       user +
-                                                                                                                                                                       "\"\n" +
-                                                                                                                                                                       "        }}]}]")));
+                "  {\n" +
+                "    \"id\": \"" + discussionId + "\",\n" +
+                "    \"individual_note\": false,\n" +
+                "    \"notes\": [\n" +
+                "      {\n" +
+                "        \"id\": " + noteId + ",\n" +
+                "        \"type\": \"DiscussionNote\",\n" +
+                "        \"body\": \"discussion text\",\n" +
+                "        \"attachment\": null,\n" +
+                "        \"author\": {\n" +
+                "          \"id\": 1,\n" +
+                "          \"username\": \"" + user + "\"\n" +
+                "        }}]}]")));
 
         wireMockRule.stubFor(delete(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/discussions/" + discussionId + "/notes/" + noteId)).willReturn(noContent()));
 
         wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/statuses/" + commitSHA))
-                                     .withQueryParam("name", equalTo("SonarQube"))
-                                     .withQueryParam("state", equalTo("failed")).withQueryParam("target_url",
-                                                                                                equalTo(sonarRootUrl +
-                                                                                                        "/dashboard?id=" +
-                                                                                                        projectKey +
-                                                                                                        "&pullRequest=" +
-                                                                                                        branchName))
-                                     .withQueryParam("coverage", equalTo(coverage.getValue())).willReturn(created()));
+                .withQueryParam("name", equalTo("SonarQube"))
+                .withQueryParam("state", equalTo("failed"))
+                .withQueryParam("target_url", equalTo(sonarRootUrl + "/dashboard?id=" + projectKey + "&pullRequest=" + branchName))
+                .withQueryParam("coverage", equalTo(coverage.getValue()))
+                .willReturn(created()));
 
         wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/discussions"))
-                                     .withRequestBody(equalTo("body=summary")).willReturn(created()));
+                .withRequestBody(equalTo("body=summary"))
+                .willReturn(created()));
 
         wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/discussions"))
-                                     .withRequestBody(equalTo("body=issue&" + urlEncode("position[base_sha]") +
-                                                              "=d6a420d043dfe85e7c240fd136fc6e197998b10a&" +
-                                                              urlEncode("position[start_sha]") +
-                                                              "=d6a420d043dfe85e7c240fd136fc6e197998b10a&" +
-                                                              urlEncode("position[head_sha]") + "=" + commitSHA + "&" +
-                                                              urlEncode("position[new_path]") + "=" +
-                                                              urlEncode(filePath) + "&" +
-                                                              urlEncode("position[new_line]") + "=" + lineNumber + "&" +
-                                                              urlEncode("position[position_type]") + "=text"))
-                                     .willReturn(created()));
+                .withRequestBody(equalTo("body=issue&" +
+                        urlEncode("position[base_sha]") + "=d6a420d043dfe85e7c240fd136fc6e197998b10a&" +
+                        urlEncode("position[start_sha]") + "=d6a420d043dfe85e7c240fd136fc6e197998b10a&" +
+                        urlEncode("position[head_sha]") + "=" + commitSHA + "&" +
+                        urlEncode("position[new_path]") + "=" + urlEncode(filePath) + "&" +
+                        urlEncode("position[new_line]") + "=" + lineNumber + "&" +
+                        urlEncode("position[position_type]") + "=text"))
+                .willReturn(created()));
 
         Server server = mock(Server.class);
         when(server.getPublicRootUrl()).thenReturn(sonarRootUrl);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoaderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoaderTest.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sonar.api.utils.MessageException;
+import org.sonar.api.utils.System2;
 import org.sonar.scanner.scan.branch.BranchConfiguration;
 import org.sonar.scanner.scan.branch.BranchInfo;
 import org.sonar.scanner.scan.branch.BranchType;
@@ -55,7 +56,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testExceptionWhenNoExistingBranchAndBranchParamsPresent() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         ProjectBranches branchInfo = mock(ProjectBranches.class);
         when(branchInfo.isEmpty()).thenReturn(true);
 
@@ -71,7 +72,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testDefaultConfigWhenNoExistingBranchAndBranchNameParamMaster() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         ProjectBranches branchInfo = mock(ProjectBranches.class);
         when(branchInfo.isEmpty()).thenReturn(true);
 
@@ -84,7 +85,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testErrorWhenNoExistingBranchAndBranchTargetMasterButNoSourceBranch() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         ProjectBranches branchInfo = mock(ProjectBranches.class);
         when(branchInfo.isEmpty()).thenReturn(true);
 
@@ -103,7 +104,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testDefaultConfigWhenNoExistingBranchAndBranchParamsAllMaster() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         ProjectBranches branchInfo = mock(ProjectBranches.class);
         when(branchInfo.isEmpty()).thenReturn(true);
 
@@ -117,7 +118,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testExceptionWhenNoExistingBranchAndPullRequestAndBranchParametersPresent() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         ProjectBranches branchInfo = mock(ProjectBranches.class);
         when(branchInfo.isEmpty()).thenReturn(true);
 
@@ -136,7 +137,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testDefaultBranchInfoWhenNoBranchParametersSpecifiedAndNoBranchesExist() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
 
         ProjectBranches branchInfo = mock(ProjectBranches.class);
         when(branchInfo.isEmpty()).thenReturn(true);
@@ -151,14 +152,14 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testDefaultBranchInfoWhenNoParametersSpecified() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         assertEquals(DefaultBranchConfiguration.class, testCase.load(new HashMap<>(), mock(ProjectBranches.class),
                                                                      mock(ProjectPullRequests.class)).getClass());
     }
 
     @Test
     public void testValidBranchInfoWhenAllBranchParametersSpecified() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.branch.name", "feature/shortLivedFeatureBranch");
         parameters.put("sonar.branch.target", "master");
@@ -186,7 +187,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testValidBranchInfoWhenOnlySourceBranchSpecifiedAndMasterExists() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.branch.name", "feature/shortLivedBranch");
 
@@ -208,7 +209,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testValidBranchInfoWhenOnlySourceBranchSpecifiedAndMasterExists2() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.branch.name", "feature/shortLivedBranch");
         parameters.put("sonar.branch.target", "");
@@ -231,7 +232,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testExceptionWhenOnlySourceBranchSpecifiedAndNoMasterExists() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.branch.name", "feature/shortLivedBranch");
 
@@ -250,7 +251,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testUnknownTargetBranch() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.branch.name", "feature/shortLivedBranch");
         parameters.put("sonar.branch.target", "feature/otherShortLivedBranch");
@@ -272,7 +273,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testExistingBranchOnlySourceParameters() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.branch.name", "longLivedBranch");
 
@@ -294,7 +295,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testPullRequestAllParameters() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.pullrequest.branch", "feature/sourceBranch");
         parameters.put("sonar.pullrequest.base", "target");
@@ -320,7 +321,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testPullRequestMandatoryParameters() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.pullrequest.branch", "feature/sourceBranch");
         parameters.put("sonar.pullrequest.key", "pr-key");
@@ -344,7 +345,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testPullRequestMandatoryParameters2() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.pullrequest.branch", "feature/sourceBranch");
         parameters.put("sonar.pullrequest.key", "pr-key");
@@ -370,7 +371,7 @@ public class CommunityBranchConfigurationLoaderTest {
 
     @Test
     public void testPullRequestNoSuchTarget() {
-        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader();
+        CommunityBranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(System2.INSTANCE);
         Map<String, String> parameters = new HashMap<>();
         parameters.put("sonar.pullrequest.branch", "feature/sourceBranch");
         parameters.put("sonar.pullrequest.base", "missingTarget");


### PR DESCRIPTION
* Support automatic configuration in GitLab CI
* Align property names with sonar developer edition
* Autodelete comments
* Don't fail if no new coverage condition is provided
* Support multiple pipelines on one commit

Fixes #84
Fixes #85
Fixes #86
Closes #74