### PR TITLE
Removed exception "IllegalStateException" if could not find New Coverage Condition in analysis and replaced to "0"

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -107,9 +107,9 @@ public class AnalysisDetails {
 
     public String createAnalysisSummary(FormatterFactory formatterFactory) {
 
-        BigDecimal newCoverage = getNewCoverage().isPresent() ? getNewCoverage().get() : BigDecimal.ZERO;
+        BigDecimal newCoverage = getNewCoverage().orElse(null);
 
-        BigDecimal newDuplications = getNewDuplications().isPresent() ? getNewDuplications().get() : BigDecimal.ZERO;
+        BigDecimal newDuplications = getNewDuplications().orElse(null);
 
         double coverage = findMeasure(CoreMetrics.COVERAGE_KEY).map(MeasureWrapper::getDoubleValue).orElse(0D);
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -109,11 +109,17 @@ public class AnalysisDetails {
 
         BigDecimal newCoverage = getNewCoverage().orElse(null);
 
-        BigDecimal newDuplications = getNewDuplications().orElse(null);
 
         double coverage = findMeasure(CoreMetrics.COVERAGE_KEY).map(MeasureWrapper::getDoubleValue).orElse(0D);
 
-        double duplications = findMeasure(CoreMetrics.DUPLICATED_LINES_DENSITY_KEY).map(MeasureWrapper::getDoubleValue).orElse(0D);
+        BigDecimal newDuplications = findQualityGateCondition(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY)
+                .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
+                .map(QualityGate.Condition::getValue)
+                .map(BigDecimal::new)
+                .orElse(null);
+
+        double duplications =
+                findMeasure(CoreMetrics.DUPLICATED_LINES_DENSITY_KEY).map(MeasureWrapper::getDoubleValue).orElse(0D);
 
         NumberFormat decimalFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
@@ -270,7 +276,7 @@ public class AnalysisDetails {
                 .map(MeasureWrapper::new);
     }
 
-    public Optional<QualityGate.Condition> findQualityGateCondition(String metricKey) {
+    private Optional<QualityGate.Condition> findQualityGateCondition(String metricKey) {
         return qualityGate.getConditions().stream().filter(c -> metricKey.equals(c.getMetricKey())).findFirst();
     }
 
@@ -307,13 +313,6 @@ public class AnalysisDetails {
                                  condition.getOperator() == QualityGate.Operator.GREATER_THAN ? "is greater than" :
                                  "is less than", condition.getErrorThreshold());
         }
-    }
-
-    public Optional<BigDecimal> getNewDuplications() {
-        return findQualityGateCondition(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY)
-                .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
-                .map(QualityGate.Condition::getValue)
-                .map(BigDecimal::new);
     }
 
     public Optional<BigDecimal> getNewCoverage(){

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -107,23 +107,13 @@ public class AnalysisDetails {
 
     public String createAnalysisSummary(FormatterFactory formatterFactory) {
 
-        BigDecimal newCoverage =
-                findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)
-                    .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
-                    .map(QualityGate.Condition::getValue)
-                    .map(BigDecimal::new)
-                    .orElse(null);
+        BigDecimal newCoverage = getNewCoverage().isPresent() ? getNewCoverage().get() : BigDecimal.ZERO;
+
+        BigDecimal newDuplications = getNewDuplications().isPresent() ? getNewDuplications().get() : BigDecimal.ZERO;
 
         double coverage = findMeasure(CoreMetrics.COVERAGE_KEY).map(MeasureWrapper::getDoubleValue).orElse(0D);
 
-        BigDecimal newDuplications = findQualityGateCondition(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY)
-            .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
-            .map(QualityGate.Condition::getValue)
-            .map(BigDecimal::new)
-            .orElse(null);
-
-        double duplications =
-                findMeasure(CoreMetrics.DUPLICATED_LINES_DENSITY_KEY).map(MeasureWrapper::getDoubleValue).orElse(0D);
+        double duplications = findMeasure(CoreMetrics.DUPLICATED_LINES_DENSITY_KEY).map(MeasureWrapper::getDoubleValue).orElse(0D);
 
         NumberFormat decimalFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
@@ -317,6 +307,20 @@ public class AnalysisDetails {
                                  condition.getOperator() == QualityGate.Operator.GREATER_THAN ? "is greater than" :
                                  "is less than", condition.getErrorThreshold());
         }
+    }
+
+    public Optional<BigDecimal> getNewDuplications() {
+        return findQualityGateCondition(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY)
+                .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
+                .map(QualityGate.Condition::getValue)
+                .map(BigDecimal::new);
+    }
+
+    public Optional<BigDecimal> getNewCoverage(){
+        return findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)
+                .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
+                .map(QualityGate.Condition::getValue)
+                .map(BigDecimal::new);
     }
 
     public static class BranchDetails {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -276,7 +276,7 @@ public class AnalysisDetails {
                 .map(MeasureWrapper::new);
     }
 
-    private Optional<QualityGate.Condition> findQualityGateCondition(String metricKey) {
+    public Optional<QualityGate.Condition> findQualityGateCondition(String metricKey) {
         return qualityGate.getConditions().stream().filter(c -> metricKey.equals(c.getMetricKey())).findFirst();
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -18,21 +18,6 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -60,13 +45,26 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.issue.Issue;
-import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.platform.Server;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.ce.task.projectanalysis.scm.Changeset;
 import org.sonar.ce.task.projectanalysis.scm.ScmInfoRepository;
-import org.sonar.core.issue.DefaultIssue;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusDecorator {
 
@@ -105,7 +103,8 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
 
             final String restURL = String.format("%s/api/v4", hostURL);
             final String userURL = restURL + "/user";
-            final String projectURL = restURL + String.format("/projects/%s", URLEncoder.encode(repositorySlug, StandardCharsets.UTF_8.name()));
+            final String projectURL = restURL + String.format("/projects/%s", URLEncoder
+                    .encode(repositorySlug, StandardCharsets.UTF_8.name()));
             final String statusUrl = projectURL + String.format("/statuses/%s", revision);
             final String mergeRequestURl = projectURL + String.format("/merge_requests/%s", pullRequestId);
             final String prCommitsURL = mergeRequestURl + "/commits";
@@ -150,9 +149,10 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
             List<PostAnalysisIssueVisitor.ComponentIssue> openIssues = analysis.getPostAnalysisIssueVisitor().getIssues().stream().filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().getStatus())).collect(Collectors.toList());
 
             String summaryComment = analysis.createAnalysisSummary(new MarkdownFormatterFactory());
-            List<NameValuePair> summaryContentParams = Collections.singletonList(new BasicNameValuePair("body", summaryComment));
+            List<NameValuePair> summaryContentParams = Collections
+                    .singletonList(new BasicNameValuePair("body", summaryComment));
 
-            String coverageValue = analysis.getNewCoverage().orElse(BigDecimal.valueOf(0)).toString();
+            String coverageValue = analysis.getNewCoverage().orElse(BigDecimal.ZERO).toString();
 
             postStatus(statusUrl, headers, analysis, coverageValue, true);
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -110,7 +110,6 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
             final String mergeRequestURl = projectURL + String.format("/merge_requests/%s", pullRequestId);
             final String prCommitsURL = mergeRequestURl + "/commits";
             final String mergeRequestDiscussionURL = mergeRequestURl + "/discussions";
-            final String mergeRequestNoteURL = mergeRequestURl + "/notes";
 
             LOGGER.info(String.format("Status url is: %s ", statusUrl));
             LOGGER.info(String.format("PR commits url is: %s ", prCommitsURL));
@@ -153,8 +152,7 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
             String summaryComment = analysis.createAnalysisSummary(new MarkdownFormatterFactory());
             List<NameValuePair> summaryContentParams = Collections.singletonList(new BasicNameValuePair("body", summaryComment));
 
-            boolean isNewCoverage = analysis.getNewCoverage().isPresent();
-            String coverageValue = isNewCoverage ? analysis.getNewCoverage().get().toString() : "0";
+            String coverageValue = analysis.getNewCoverage().orElse(BigDecimal.valueOf(0)).toString();
 
             postStatus(statusUrl, headers, analysis, coverageValue, true);
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -1,6 +1,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab;
 
 import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -72,15 +73,13 @@ public class GitlabServerPullRequestDecoratorTest {
 
         UnifyConfiguration unifyConfiguration = new UnifyConfiguration(configuration, scannerContext);
 
-        QualityGate.Condition coverage = mock(QualityGate.Condition.class);
-        when(coverage.getStatus()).thenReturn(QualityGate.EvaluationStatus.OK);
-        when(coverage.getValue()).thenReturn("10");
+        BigDecimal coverage = BigDecimal.TEN;
 
         AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
         when(analysisDetails.getAnalysisProjectKey()).thenReturn(projectKey);
         when(analysisDetails.getBranchName()).thenReturn(branchName);
         when(analysisDetails.getCommitSha()).thenReturn(commitSHA);
-        when(analysisDetails.findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)).thenReturn(Optional.of(coverage));
+        when(analysisDetails.getNewCoverage()).thenReturn(Optional.of(coverage));
         PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         DefaultIssue defaultIssue = mock(DefaultIssue.class);
@@ -139,7 +138,7 @@ public class GitlabServerPullRequestDecoratorTest {
                 .withQueryParam("name", equalTo("SonarQube"))
                 .withQueryParam("state", equalTo("failed"))
                 .withQueryParam("target_url", equalTo(sonarRootUrl + "/dashboard?id=" + projectKey + "&pullRequest=" + branchName))
-                .withQueryParam("coverage", equalTo(coverage.getValue()))
+                .withQueryParam("coverage", equalTo(coverage.toString()))
                 .willReturn(created()));
 
         wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/discussions"))


### PR DESCRIPTION
When in Sonar conditions there is no new_coverage condition (and I doubt that this condition is necessary) the plugin throws Exception. IllegalStateException("Could not find New Coverage Condition in analysis")