### PR TITLE
if duplication and issues equal zero, to do repost "notes" instead "discussions" in Gitlab

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -37,6 +37,7 @@ import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
 import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -74,9 +75,8 @@ public class GitlabServerPullRequestDecoratorTest {
         String filePath = "/path/to/file";
         int lineNumber = 5;
 
-        QualityGate.Condition coverage = mock(QualityGate.Condition.class);
-        when(coverage.getStatus()).thenReturn(QualityGate.EvaluationStatus.OK);
-        when(coverage.getValue()).thenReturn("10");
+        BigDecimal coverage = BigDecimal.TEN;
+
 
         ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
@@ -91,7 +91,7 @@ public class GitlabServerPullRequestDecoratorTest {
         when(analysisDetails.getAnalysisProjectKey()).thenReturn(projectKey);
         when(analysisDetails.getBranchName()).thenReturn(branchName);
         when(analysisDetails.getCommitSha()).thenReturn(commitSHA);
-        when(analysisDetails.findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)).thenReturn(Optional.of(coverage));
+        when(analysisDetails.getNewCoverage()).thenReturn(Optional.of(coverage));
         PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         DefaultIssue defaultIssue = mock(DefaultIssue.class);
@@ -150,10 +150,10 @@ public class GitlabServerPullRequestDecoratorTest {
                 .withQueryParam("name", equalTo("SonarQube"))
                 .withQueryParam("state", equalTo("failed"))
                 .withQueryParam("target_url", equalTo(sonarRootUrl + "/dashboard?id=" + projectKey + "&pullRequest=" + branchName))
-                .withQueryParam("coverage", equalTo(coverage.getValue()))
+                .withQueryParam("coverage", equalTo(coverage.toString()))
                 .willReturn(created()));
 
-        wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/discussions"))
+        wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/notes"))
                 .withRequestBody(equalTo("body=summary"))
                 .willReturn(created()));
 


### PR DESCRIPTION
If duplication and issues equal zero, to do repost "notes" instead "discussions" in GitLab. Also changed if in Sonar conditions there is no new coverage condition