### PR TITLE
If duplication and issues equal zero, to do repost "notes" instead "discussions" in GitLab

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -107,20 +107,11 @@ public class AnalysisDetails {
 
     public String createAnalysisSummary(FormatterFactory formatterFactory) {
 
-        BigDecimal newCoverage =
-                findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)
-                    .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
-                    .map(QualityGate.Condition::getValue)
-                    .map(BigDecimal::new)
-                    .orElse(null);
+        BigDecimal newCoverage = getNewCoverage().orElse(null);
 
         double coverage = findMeasure(CoreMetrics.COVERAGE_KEY).map(MeasureWrapper::getDoubleValue).orElse(0D);
 
-        BigDecimal newDuplications = findQualityGateCondition(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY)
-            .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
-            .map(QualityGate.Condition::getValue)
-            .map(BigDecimal::new)
-            .orElse(null);
+        BigDecimal newDuplications = getNewDuplications().orElse(null);
 
         double duplications =
                 findMeasure(CoreMetrics.DUPLICATED_LINES_DENSITY_KEY).map(MeasureWrapper::getDoubleValue).orElse(0D);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -108,6 +108,7 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
             final String mergeRequestURl = projectURL + String.format("/merge_requests/%s", pullRequestId);
             final String prCommitsURL = mergeRequestURl + "/commits";
             final String mergeRequestDiscussionURL = mergeRequestURl + "/discussions";
+            final String mergeRequestNoteURL = mergeRequestURl + "/notes";
 
 
             LOGGER.info(String.format("Status url is: %s ", statusUrl));
@@ -158,7 +159,7 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
 
             postStatus(statusUrl, headers, analysis, coverageValue, true);
 
-            postCommitComment(mergeRequestDiscussionURL, headers, summaryContentParams, summaryCommentEnabled);
+            postCommitComment(mergeRequestNoteURL, headers, summaryContentParams, summaryCommentEnabled);
 
             for (PostAnalysisIssueVisitor.ComponentIssue issue : openIssues) {
                 String path = analysis.getSCMPathForIssue(issue).orElse(null);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -142,7 +142,7 @@ public class GitlabServerPullRequestDecoratorTest {
                 .withQueryParam("coverage", equalTo(coverage.getValue()))
                 .willReturn(created()));
 
-        wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/discussions"))
+        wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/notes"))
                 .withRequestBody(equalTo("body=summary"))
                 .willReturn(created()));
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -1,6 +1,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab;
 
 import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -72,15 +73,13 @@ public class GitlabServerPullRequestDecoratorTest {
 
         UnifyConfiguration unifyConfiguration = new UnifyConfiguration(configuration, scannerContext);
 
-        QualityGate.Condition coverage = mock(QualityGate.Condition.class);
-        when(coverage.getStatus()).thenReturn(QualityGate.EvaluationStatus.OK);
-        when(coverage.getValue()).thenReturn("10");
+        BigDecimal coverage = BigDecimal.TEN;
 
         AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
         when(analysisDetails.getAnalysisProjectKey()).thenReturn(projectKey);
         when(analysisDetails.getBranchName()).thenReturn(branchName);
         when(analysisDetails.getCommitSha()).thenReturn(commitSHA);
-        when(analysisDetails.findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)).thenReturn(Optional.of(coverage));
+        when(analysisDetails.getNewCoverage()).thenReturn(Optional.of(coverage));
         PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         DefaultIssue defaultIssue = mock(DefaultIssue.class);
@@ -139,7 +138,7 @@ public class GitlabServerPullRequestDecoratorTest {
                 .withQueryParam("name", equalTo("SonarQube"))
                 .withQueryParam("state", equalTo("failed"))
                 .withQueryParam("target_url", equalTo(sonarRootUrl + "/dashboard?id=" + projectKey + "&pullRequest=" + branchName))
-                .withQueryParam("coverage", equalTo(coverage.getValue()))
+                .withQueryParam("coverage", equalTo(coverage.toString()))
                 .willReturn(created()));
 
         wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + urlEncode(repositorySlug) + "/merge_requests/" + branchName + "/notes"))


### PR DESCRIPTION
If duplication and issues equal zero, to do repost "notes" instead "discussions" in GitLab fixes #106 