### PR TITLE
Fix equals() to equalsIgnoreCase() when comparing pullRequestDecoder name

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTask.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTask.java
@@ -145,7 +145,7 @@ public class PullRequestPostAnalysisTask implements PostProjectAnalysisTask,
         String implementationName = optionalImplementationName.get();
 
         for (PullRequestBuildStatusDecorator pullRequestDecorator : pullRequestDecorators) {
-            if (pullRequestDecorator.name().equals(implementationName)) {
+            if (pullRequestDecorator.name().equalsIgnoreCase(implementationName)) {
                 return Optional.of(pullRequestDecorator);
             }
         }


### PR DESCRIPTION
If 'sonar.pullrequest.provider=github', decorator cannot be found as shown below.
```
49 2020.03.17 02:12:09 WARN  ce[AXDkVKnRxwo-yQCU2_VR][c.g.m.s.p.c.p.PullRequestPostAnalysisTask] No decorator could be found matching github
50 2020.03.17 02:12:09 INFO  ce[AXDkVKnRxwo-yQCU2_VR][c.g.m.s.p.c.p.PullRequestPostAnalysisTask] No decorator found for this Pull Request
```
Fix to find decorator even when provider is 'github' or 'GITHUB'.