### PR TITLE
Modify to limit the number of annotations

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
@@ -65,6 +65,8 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
     public static final String PULL_REQUEST_GITHUB_APP_ID = "sonar.alm.github.app.id";
     public static final String PULL_REQUEST_GITHUB_APP_NAME = "sonar.alm.github.app.name";
 
+    private static final int GITHUB_CHECKS_ANNOTATIONS_MAX_NUMBER_PER_REQUEST = 50;
+
     private static final Logger LOGGER = Loggers.get(GraphqlCheckRunProvider.class);
     private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ssXXX";
 
@@ -104,6 +106,7 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
         headers.put("Accept", "application/vnd.github.antiope-preview+json");
 
         List<InputObject<Object>> annotations = analysisDetails.getPostAnalysisIssueVisitor().getIssues().stream()
+                .limit(GITHUB_CHECKS_ANNOTATIONS_MAX_NUMBER_PER_REQUEST)
                 .filter(i -> i.getComponent().getReportAttributes().getScmPath().isPresent())
                 .filter(i -> i.getComponent().getType() == Component.Type.FILE).map(componentIssue -> {
                     InputObject<Object> issueLocation = graphqlProvider.createInputObject()


### PR DESCRIPTION
If there are more than 50 annotations, even if the response is 200, it is not exposed to Github Checks.
After limiting to 50, I confirmed that it works normally.

## reference
https://developer.github.com/v3/checks/runs/#parameters
![image](https://user-images.githubusercontent.com/2978067/76876288-117d1200-68b5-11ea-83e1-c16876cb01c0.png)
