### PR TITLE
#103: Handle pagination on repositories response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
 plugins {
     id('java')
     id('jacoco')
-    id('org.sonarqube') version('2.7')
+    id('org.sonarqube') version('2.8')
     id('info.solidsoft.pitest') version('1.4.0')
     id('com.github.johnrengelman.shadow') version('5.1.0')
     id('net.researchgate.release') version('2.6.0')
@@ -120,4 +120,14 @@ assemble.dependsOn('shadowJar')
 pitest {
     timestampedReports = false
     avoidCallsTo = ['org.sonar.api.utils.log.Logger']
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+}
+
+plugins.withType(JacocoPlugin) {
+    tasks["test"].finalizedBy 'jacocoTestReport'
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
@@ -20,11 +20,12 @@ package com.github.mc1arke.sonarqube.plugin.ce;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestPostAnalysisTask;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.server.BitbucketServerPullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.GithubPullRequestDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v3.DefaultLinkHeaderReader;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v3.RestApplicationAuthenticationProvider;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4.GraphqlCheckRunProvider;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabServerPullRequestDecorator;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.server.BitbucketServerPullRequestDecorator;
 import org.sonar.ce.task.projectanalysis.container.ReportAnalysisComponentProvider;
 
 import java.util.Arrays;
@@ -39,7 +40,7 @@ public class CommunityReportAnalysisComponentProvider implements ReportAnalysisC
     public List<Object> getComponents() {
         return Arrays.asList(CommunityBranchLoaderDelegate.class, PullRequestPostAnalysisTask.class,
                              PostAnalysisIssueVisitor.class, GithubPullRequestDecorator.class,
-                             GraphqlCheckRunProvider.class, RestApplicationAuthenticationProvider.class,
+                             GraphqlCheckRunProvider.class, DefaultLinkHeaderReader.class, RestApplicationAuthenticationProvider.class,
                              BitbucketServerPullRequestDecorator.class, GitlabServerPullRequestDecorator.class);
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/DefaultLinkHeaderReader.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/DefaultLinkHeaderReader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v3;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class DefaultLinkHeaderReader implements LinkHeaderReader {
+
+    @Override
+    public Optional<String> findNextLink(String linkHeader) {
+        return Optional.ofNullable(linkHeader)
+                .flatMap(l -> Arrays.stream(l.split(","))
+                .map(i -> i.split(";"))
+                .filter(i -> i.length > 1)
+                .filter(i -> {
+                    String[] relParts = i[1].trim().split("=");
+
+                    if (relParts.length < 2) {
+                        return false;
+                    }
+
+                    if (!"rel".equals(relParts[0])) {
+                        return false;
+                    }
+
+                    return "next".equals(relParts[1]) || "\"next\"".equals(relParts[1]);
+                })
+                .map(i -> i[0])
+                .map(String::trim)
+                .filter(i -> i.startsWith("<") && i.endsWith(">"))
+                .map(i -> i.substring(1, i.length() - 1))
+                .findFirst());
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/LinkHeaderReader.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/LinkHeaderReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2020 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,23 +16,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-package com.github.mc1arke.sonarqube.plugin.ce;
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v3;
 
-import org.junit.Test;
+import java.util.Optional;
 
-import java.util.List;
+interface LinkHeaderReader {
 
-import static org.junit.Assert.assertEquals;
+    Optional<String> findNextLink(String linkHeader);
 
-/**
- * @author Michael Clarke
- */
-public class CommunityReportAnalysisComponentProviderTest {
-
-    @Test
-    public void testGetComponents() {
-        List<Object> result = new CommunityReportAnalysisComponentProvider().getComponents();
-        assertEquals(9, result.size());
-        assertEquals(CommunityBranchLoaderDelegate.class, result.get(0));
-    }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/DefaultLinkHeaderReaderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/DefaultLinkHeaderReaderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v3;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultLinkHeaderReaderTest {
+
+    @Test
+    public void findNextLinkEmptyForNoHeader() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink(null)).isEmpty();
+    }
+
+    @Test
+    public void findNextLinkEmptyForEmptyHeader() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("")).isEmpty();
+    }
+
+    @Test
+    public void findNextLinkEmptyForMissingRelContent() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("<http://url>; rel")).isEmpty();
+    }
+
+    @Test
+    public void findNextLinkEmptyForInvalidRelContent() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("<http://url>; abc=\"xyz\"")).isEmpty();
+    }
+
+    @Test
+    public void findNextLinkEmptyForIncorrectHeader() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("dummy")).isEmpty();
+    }
+
+    @Test
+    public void findNextLinkEmptyForMissingUrlPrefix() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("http://other>; rel=\"next\"")).isEmpty();
+    }
+
+    @Test
+    public void findNextLinkEmptyForMissingUrlPostfix() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("<http://other; rel=\"next\"")).isEmpty();
+    }
+
+    @Test
+    public void findNextLinkEmptyForMissingUrlWrapper() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("http://other; rel=\"next\"")).isEmpty();
+    }
+
+    @Test
+    public void findNextLinkReturnsCorrectUrlOnMatch() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("<http://other>; rel=\"next\"")).hasValue("http://other");
+    }
+
+    @Test
+    public void findNextLinkReturnsCorrectUrlOnMatchNoSpeechMarksAroundRel() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("<http://other>; rel=next")).hasValue("http://other");
+    }
+
+    @Test
+    public void findNextLinkReturnsCorrectUrlOnMatchWithOtherRelEntries() {
+        DefaultLinkHeaderReader underTest = new DefaultLinkHeaderReader();
+        assertThat(underTest.findNextLink("<http://other>; rel=\"last\", <http://other2>; rel=\"next\"")).hasValue("http://other2");
+    }
+}


### PR DESCRIPTION
When trying to find authentication tokens for accessing a repository, the list of repositories attached to a token are currently iterated over until one is found with a matching name, or the end of the retrieved list is reached. However, this search is not taking into account pagination in the response from Github, so any list of repositories that is greater than the default page size fails to find a matching authentication token if the repository is not present on the first page of the repository list. To resolve this, the response is checked for a `Link` header with a `rel="next"` element, with the link in this header being followed for each response until a matching repository is found, or the header is not present.