### PR TITLE
#154: Submit annotations in batches of 50 to Github

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.CheckRunProvider;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.GithubApplicationAuthenticationProvider;
@@ -55,7 +56,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+
+import static org.apache.commons.lang.ArrayUtils.isEmpty;
 
 public class GraphqlCheckRunProvider implements CheckRunProvider {
 
@@ -103,67 +107,75 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
         headers.put("Authorization", "Bearer " + repositoryAuthenticationToken.getAuthenticationToken());
         headers.put("Accept", "application/vnd.github.antiope-preview+json");
 
-        List<InputObject<Object>> annotations = analysisDetails.getPostAnalysisIssueVisitor().getIssues().stream()
-                .filter(i -> i.getComponent().getReportAttributes().getScmPath().isPresent())
-                .filter(i -> i.getComponent().getType() == Component.Type.FILE).map(componentIssue -> {
-                    InputObject<Object> issueLocation = graphqlProvider.createInputObject()
-                            .put("startLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0))
-                            .put("endLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0) + 1)
-                            .build();
-                    return graphqlProvider.createInputObject()
-                            .put("path", componentIssue.getComponent().getReportAttributes().getScmPath().get())
-                            .put("location", issueLocation)
-                            .put("annotationLevel", mapToGithubAnnotationLevel(componentIssue.getIssue().severity()))
-                            .put("message", componentIssue.getIssue().getMessage().replaceAll("\"", "\\\\\"")).build();
-                }).collect(Collectors.toList());
+        List<PostAnalysisIssueVisitor.ComponentIssue> issues = analysisDetails.getPostAnalysisIssueVisitor().getIssues();
 
-        InputObject<Object> checkRunOutputContent = graphqlProvider.createInputObject().put("title", "Quality Gate " +
+        List<InputObject<Object>> annotations = createAnnotations(issues);
+
+        InputObject.Builder<Object> checkRunOutputContentBuilder = graphqlProvider.createInputObject().put("title", "Quality Gate " +
                                                                                                      (analysisDetails
                                                                                                               .getQualityGateStatus() ==
                                                                                                       QualityGate.Status.OK ?
                                                                                                       "success" :
                                                                                                       "failed"))
                 .put("summary", analysisDetails.createAnalysisSummary(new MarkdownFormatterFactory()))
-                .put("annotations", annotations).build();
+                .put("annotations", annotations);
 
         SimpleDateFormat startedDateFormat = new SimpleDateFormat(DATE_TIME_PATTERN);
         startedDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-        InputObject<Object> repositoryInputObject =
-                graphqlProvider.createInputObject().put("repositoryId", repositoryAuthenticationToken.getRepositoryId())
-                        .put("name", appName + " Results").put("headSha", analysisDetails.getCommitSha())
-                        .put("status", RequestableCheckStatusState.COMPLETED).put("conclusion", QualityGate.Status.OK ==
-                                                                                                analysisDetails
-                                                                                                        .getQualityGateStatus() ?
-                                                                                                CheckConclusionState.SUCCESS :
-                                                                                                CheckConclusionState.FAILURE)
-                        .put("detailsUrl", String.format("%s/dashboard?id=%s&pullRequest=%s", server.getPublicRootUrl(),
-                                                         URLEncoder.encode(analysisDetails.getAnalysisProjectKey(),
-                                                                           StandardCharsets.UTF_8.name()), URLEncoder
-                                                                 .encode(analysisDetails.getBranchName(),
-                                                                         StandardCharsets.UTF_8.name())))
-                        .put("startedAt", startedDateFormat.format(analysisDetails.getAnalysisDate()))
-                        .put("completedAt", DateTimeFormatter.ofPattern(DATE_TIME_PATTERN).withZone(ZoneId.of("UTC"))
-                                .format(clock.instant())).put("externalId", analysisDetails.getAnalysisId())
-                        .put("output", checkRunOutputContent).build();
+        Map<String, Object> inputObjectArguments = new HashMap<>();
+        inputObjectArguments.put("repositoryId", repositoryAuthenticationToken.getRepositoryId());
+        inputObjectArguments.put("name", appName + " Results");
+        inputObjectArguments.put("status", RequestableCheckStatusState.COMPLETED);
+        inputObjectArguments.put("conclusion", QualityGate.Status.OK == analysisDetails.getQualityGateStatus() ?
+                                   CheckConclusionState.SUCCESS : CheckConclusionState.FAILURE);
+        inputObjectArguments.put("detailsUrl", String.format("%s/dashboard?id=%s&pullRequest=%s", server.getPublicRootUrl(),
+                                                 URLEncoder.encode(analysisDetails.getAnalysisProjectKey(),
+                                                                   StandardCharsets.UTF_8.name()), URLEncoder
+                                                         .encode(analysisDetails.getBranchName(),
+                                                                 StandardCharsets.UTF_8.name())));
+        inputObjectArguments.put("startedAt", startedDateFormat.format(analysisDetails.getAnalysisDate()));
+        inputObjectArguments.put("completedAt", DateTimeFormatter.ofPattern(DATE_TIME_PATTERN).withZone(ZoneId.of("UTC"))
+                        .format(clock.instant()));
+        inputObjectArguments.put("externalId", analysisDetails.getAnalysisId());
+        inputObjectArguments.put("output", checkRunOutputContentBuilder.build());
 
 
-        GraphQLRequestEntity graphQLRequestEntity =
-                graphqlProvider.createRequestBuilder().url(apiUrl + "/graphql").headers(headers)
+        InputObject.Builder<Object> repositoryInputObjectBuilder = graphqlProvider.createInputObject();
+        inputObjectArguments.forEach(repositoryInputObjectBuilder::put);
+
+
+        GraphQLRequestEntity.RequestBuilder graphQLRequestEntityBuilder =
+                graphqlProvider.createRequestBuilder()
+                        .url(apiUrl + "/graphql")
+                        .headers(headers)
                         .request(CreateCheckRun.class)
-                        .arguments(new Arguments("createCheckRun", new Argument<>("input", repositoryInputObject)))
-                        .requestMethod(GraphQLTemplate.GraphQLMethod.MUTATE).build();
+                        .arguments(new Arguments("createCheckRun", new Argument<>("input", repositoryInputObjectBuilder
+                                .put("headSha", analysisDetails.getCommitSha())
+                                .build())))
+                        .requestMethod(GraphQLTemplate.GraphQLMethod.MUTATE);
 
+        GraphQLRequestEntity graphQLRequestEntity = graphQLRequestEntityBuilder.build();
+
+        GraphQLResponseEntity<CreateCheckRun> graphQLResponseEntity = executeRequest((r, t) -> graphqlProvider.createGraphQLTemplate().mutate(r, t),
+                                                                                     graphQLRequestEntity, CreateCheckRun.class);
+
+        reportRemainingIssues(issues, graphQLResponseEntity.getResponse().getCheckRun().getId(),
+                              inputObjectArguments, checkRunOutputContentBuilder, graphQLRequestEntityBuilder);
+
+
+
+    }
+
+    private static <R> GraphQLResponseEntity<R> executeRequest(
+            BiFunction<GraphQLRequestEntity, Class<R>, GraphQLResponseEntity<R>> executor, GraphQLRequestEntity graphQLRequestEntity, Class<R> responseType) {
         LOGGER.debug("Using request: " + graphQLRequestEntity.getRequest());
 
-        GraphQLTemplate graphQLTemplate = graphqlProvider.createGraphQLTemplate();
-
-        GraphQLResponseEntity<CreateCheckRun> response =
-                graphQLTemplate.mutate(graphQLRequestEntity, CreateCheckRun.class);
+        GraphQLResponseEntity<R> response = executor.apply(graphQLRequestEntity, responseType);
 
         LOGGER.debug("Received response: " + response.toString());
 
-        if (null != response.getErrors() && response.getErrors().length > 0) {
+        if (!isEmpty(response.getErrors())) {
             List<String> errors = new ArrayList<>();
             for (Error error : response.getErrors()) {
                 errors.add("- " + error.toString());
@@ -172,6 +184,58 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
                     "An error was returned in the response from the Github API:" + System.lineSeparator() +
                     errors.stream().collect(Collectors.joining(System.lineSeparator())));
         }
+
+        return response;
+    }
+
+    private void reportRemainingIssues(List<PostAnalysisIssueVisitor.ComponentIssue> outstandingIssues, String checkRunId,
+                                       Map<String, Object> repositoryInputArguments, InputObject.Builder<Object> outputObjectBuilder,
+                                       GraphQLRequestEntity.RequestBuilder graphQLRequestEntityBuilder) {
+
+        if (outstandingIssues.size() <= 50) {
+            return;
+        }
+
+        List<PostAnalysisIssueVisitor.ComponentIssue> issues = outstandingIssues.subList(50, outstandingIssues.size());
+
+        InputObject<Object> outputObject = outputObjectBuilder
+                .put("annotations", createAnnotations(issues))
+                .build();
+
+        InputObject.Builder<Object> repositoryInputObjectBuilder = graphqlProvider.createInputObject();
+        repositoryInputArguments.forEach(repositoryInputObjectBuilder::put);
+
+        InputObject<Object> repositoryInputObject = repositoryInputObjectBuilder
+                .put("checkRunId", checkRunId)
+                .put("output", outputObject)
+                .build();
+
+       GraphQLRequestEntity graphQLRequestEntity = graphQLRequestEntityBuilder
+               .request(UpdateCheckRun.class)
+               .arguments(new Arguments("updateCheckRun", new Argument<>("input", repositoryInputObject)))
+                        .requestMethod(GraphQLTemplate.GraphQLMethod.MUTATE)
+                        .build();
+
+       executeRequest((r, t) -> graphqlProvider.createGraphQLTemplate().mutate(r, t), graphQLRequestEntity, CreateCheckRun.class);
+
+       reportRemainingIssues(issues, checkRunId, repositoryInputArguments, outputObjectBuilder, graphQLRequestEntityBuilder);
+    }
+
+    private List<InputObject<Object>> createAnnotations(List<PostAnalysisIssueVisitor.ComponentIssue> issues) {
+        return issues.stream()
+                .limit(50)
+                .filter(i -> i.getComponent().getReportAttributes().getScmPath().isPresent())
+                .filter(i -> i.getComponent().getType() == Component.Type.FILE).map(componentIssue -> {
+            InputObject<Object> issueLocation = graphqlProvider.createInputObject()
+                    .put("startLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0))
+                    .put("endLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0) + 1)
+                    .build();
+            return graphqlProvider.createInputObject()
+                    .put("path", componentIssue.getComponent().getReportAttributes().getScmPath().get())
+                    .put("location", issueLocation)
+                    .put("annotationLevel", mapToGithubAnnotationLevel(componentIssue.getIssue().severity()))
+                    .put("message", componentIssue.getIssue().getMessage().replaceAll("\"", "\\\\\"")).build();
+        }).collect(Collectors.toList());
     }
 
     private static CheckAnnotationLevel mapToGithubAnnotationLevel(String sonarqubeSeverity) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/UpdateCheckRun.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/UpdateCheckRun.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4.model.CheckRun;
+import io.aexp.nodes.graphql.annotations.GraphQLArgument;
+import io.aexp.nodes.graphql.annotations.GraphQLProperty;
+
+@GraphQLProperty(name = "updateCheckRun", arguments = {@GraphQLArgument(name = "input")})
+public class UpdateCheckRun {
+
+    private final String clientMutationId;
+    private final CheckRun checkRun;
+
+    @JsonCreator
+    public UpdateCheckRun(@JsonProperty("clientMutationId") String clientMutationId,
+                          @JsonProperty("checkRun") CheckRun checkRun) {
+        this.clientMutationId = clientMutationId;
+        this.checkRun = checkRun;
+    }
+
+    public String getClientMutationId() {
+        return clientMutationId;
+    }
+
+    public CheckRun getCheckRun() {
+        return checkRun;
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
@@ -57,6 +57,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -68,6 +70,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -325,9 +328,9 @@ public class GraphqlCheckRunProviderTest {
             return requestBuilder;
         }).when(graphqlProvider).createRequestBuilder();
 
+        ObjectMapper objectMapper = new ObjectMapper();
         GraphQLResponseEntity<CreateCheckRun> graphQLResponseEntity =
-                new ObjectMapper().readerFor(GraphQLResponseEntity.class)
-                        .readValue(status == QualityGate.Status.ERROR ? "{\"errors\": []}" : "{\"response\": {}}}");
+                new ObjectMapper().readValue("{\"response\": {\"checkRun\": {\"id\": \"ABC\"}}}", objectMapper.getTypeFactory().constructParametricType(GraphQLResponseEntity.class, CreateCheckRun.class));
 
         ArgumentCaptor<GraphQLRequestEntity> requestEntityArgumentCaptor =
                 ArgumentCaptor.forClass(GraphQLRequestEntity.class);
@@ -420,6 +423,85 @@ public class GraphqlCheckRunProviderTest {
         verify(inputObjectBuilders.get(position + 1)).put(eq("externalId"), eq("analysis ID"));
         verify(inputObjectBuilders.get(position + 1)).put(eq("output"), eq(inputObjects.get(position)));
         verify(inputObjectBuilders.get(position + 1)).build();
+    }
+
+    @Test
+    public void checkExcessIssuesCorrectlyReported() throws IOException, GeneralSecurityException {
+        ReportAttributes reportAttributes = mock(ReportAttributes.class);
+        when(reportAttributes.getScmPath()).thenReturn(Optional.of("abc"));
+        Component component = mock(Component.class);
+        when(component.getType()).thenReturn(Component.Type.FILE);
+        when(component.getReportAttributes()).thenReturn(reportAttributes);
+        List<PostAnalysisIssueVisitor.ComponentIssue> issues = IntStream.range(0, 120)
+                .mapToObj(i -> {
+                    DefaultIssue defaultIssue = mock(DefaultIssue.class);
+                    when(defaultIssue.severity()).thenReturn(Severity.INFO);
+                    when(defaultIssue.getMessage()).thenReturn("message");
+                    return defaultIssue;
+                })
+                .map(i -> {
+                    PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(
+                            PostAnalysisIssueVisitor.ComponentIssue.class);
+                    when(componentIssue.getComponent()).thenReturn(component);
+                    when(componentIssue.getIssue()).thenReturn(i);
+                    return componentIssue;
+                }).collect(Collectors.toList());
+
+        PostAnalysisIssueVisitor postAnalysisIssuesVisitor = mock(PostAnalysisIssueVisitor.class);
+        when(postAnalysisIssuesVisitor.getIssues()).thenReturn(issues);
+
+        AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
+        when(analysisDetails.getPostAnalysisIssueVisitor()).thenReturn(postAnalysisIssuesVisitor);
+        when(analysisDetails.getBranchName()).thenReturn("branchName");
+        when(analysisDetails.getAnalysisProjectKey()).thenReturn("projectKey");
+        when(analysisDetails.getAnalysisDate()).thenReturn(new Date());
+
+        UnifyConfiguration unifyConfiguration = mock(UnifyConfiguration.class);
+        when(unifyConfiguration.getRequiredServerProperty(GraphqlCheckRunProvider.PULL_REQUEST_GITHUB_URL)).thenReturn("http://dummy.url");
+
+        List<InputObject.Builder> builders = new ArrayList<>();
+
+        GraphqlProvider graphqlProvider = mock(GraphqlProvider.class);
+        when(graphqlProvider.createInputObject()).thenAnswer(i -> {
+            InputObject.Builder builder = spy(new InputObject.Builder<>());
+            builders.add(builder);
+            return builder;
+        });
+
+        GraphQLRequestEntity.RequestBuilder requestBuilder = GraphQLRequestEntity.Builder();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        when(graphqlProvider.createRequestBuilder()).thenReturn(requestBuilder);
+
+        GraphQLTemplate graphQLTemplate = mock(GraphQLTemplate.class);
+        GraphQLResponseEntity<CreateCheckRun> graphQLResponseEntity =
+                new ObjectMapper().readValue("{\"response\": {\"checkRun\": {\"id\": \"ABC\"}}}", objectMapper.getTypeFactory().constructParametricType(GraphQLResponseEntity.class, CreateCheckRun.class));
+        when(graphQLTemplate.mutate(any(), eq(CreateCheckRun.class))).thenReturn(graphQLResponseEntity);
+        when(graphqlProvider.createGraphQLTemplate()).thenReturn(graphQLTemplate);
+
+        Clock clock = mock(Clock.class);
+        when(clock.instant()).thenReturn(Instant.now());
+
+        RepositoryAuthenticationToken repositoryAuthenticationToken = mock(RepositoryAuthenticationToken.class);
+        when(repositoryAuthenticationToken.getAuthenticationToken()).thenReturn("dummy");
+        GithubApplicationAuthenticationProvider githubApplicationAuthenticationProvider = mock(GithubApplicationAuthenticationProvider.class);
+        when(githubApplicationAuthenticationProvider.getInstallationToken(any(), any(), any(), any())).thenReturn(repositoryAuthenticationToken);
+
+        Server server = mock(Server.class);
+
+        GraphqlCheckRunProvider testCase = new GraphqlCheckRunProvider(graphqlProvider, clock, githubApplicationAuthenticationProvider, server);
+        testCase.createCheckRun(analysisDetails, unifyConfiguration);
+
+        ArgumentCaptor<Class<?>> classArgumentCaptor = ArgumentCaptor.forClass(Class.class);
+        verify(graphQLTemplate, times(3)).mutate(any(GraphQLRequestEntity.class), classArgumentCaptor.capture());
+
+        assertThat(classArgumentCaptor.getAllValues()).containsExactly(CreateCheckRun.class, CreateCheckRun.class, CreateCheckRun.class);
+
+        ArgumentCaptor<List<InputObject>> annotationsArgumentCaptor = ArgumentCaptor.forClass(List.class);
+        verify(builders.get(100), times(3)).put(eq("annotations"), annotationsArgumentCaptor.capture());
+        assertThat(annotationsArgumentCaptor.getAllValues().get(0)).hasSize(50);
+        assertThat(annotationsArgumentCaptor.getAllValues().get(1)).hasSize(50);
+        assertThat(annotationsArgumentCaptor.getAllValues().get(2)).hasSize(20);
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/UpdateCheckRunTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/UpdateCheckRunTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4.model.CheckRun;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class UpdateCheckRunTest {
+
+    @Test
+    public void deserialiseReturnsSerialiseInput() throws IOException {
+        UpdateCheckRun testCase = new UpdateCheckRun("mutation ID", new CheckRun("check run ID"));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String serialised = objectMapper.writeValueAsString(testCase);
+
+        UpdateCheckRun deserialised = objectMapper.readerFor(UpdateCheckRun.class).readValue(serialised);
+
+        assertEquals("mutation ID", deserialised.getClientMutationId());
+        assertEquals("check run ID", testCase.getCheckRun().getId());
+    }
+}


### PR DESCRIPTION
Creating a check run on Github limits the number of annotations in the initial report to a maximum of 50, otherwise the request is silently ignored with no error returned in the response. To overcome this, the initial report is limited to 50 annotations, with any remaining annotations submitted in groups of 50 in subsequent update calls.