### PR TITLE
#154: Correctly report more than 50 issues to Github

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
@@ -217,7 +217,7 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
                         .requestMethod(GraphQLTemplate.GraphQLMethod.MUTATE)
                         .build();
 
-       executeRequest((r, t) -> graphqlProvider.createGraphQLTemplate().mutate(r, t), graphQLRequestEntity, CreateCheckRun.class);
+       executeRequest((r, t) -> graphqlProvider.createGraphQLTemplate().mutate(r, t), graphQLRequestEntity, UpdateCheckRun.class);
 
        reportRemainingIssues(issues, checkRunId, repositoryInputArguments, outputObjectBuilder, graphQLRequestEntityBuilder);
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/UpdateCheckRun.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/UpdateCheckRun.java
@@ -27,18 +27,11 @@ import io.aexp.nodes.graphql.annotations.GraphQLProperty;
 @GraphQLProperty(name = "updateCheckRun", arguments = {@GraphQLArgument(name = "input")})
 public class UpdateCheckRun {
 
-    private final String clientMutationId;
     private final CheckRun checkRun;
 
     @JsonCreator
-    public UpdateCheckRun(@JsonProperty("clientMutationId") String clientMutationId,
-                          @JsonProperty("checkRun") CheckRun checkRun) {
-        this.clientMutationId = clientMutationId;
+    public UpdateCheckRun(@JsonProperty("checkRun") CheckRun checkRun) {
         this.checkRun = checkRun;
-    }
-
-    public String getClientMutationId() {
-        return clientMutationId;
     }
 
     public CheckRun getCheckRun() {

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/CreateCheckRunTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/CreateCheckRunTest.java
@@ -38,6 +38,6 @@ public class CreateCheckRunTest {
         CreateCheckRun deserialised = objectMapper.readerFor(CreateCheckRun.class).readValue(serialised);
 
         assertEquals("mutation ID", deserialised.getClientMutationId());
-        assertEquals("check run ID", testCase.getCheckRun().getId());
+        assertEquals("check run ID", deserialised.getCheckRun().getId());
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
@@ -530,6 +530,9 @@ public class GraphqlCheckRunProviderTest {
         GraphQLResponseEntity<CreateCheckRun> graphQLResponseEntity =
                 new ObjectMapper().readValue("{\"response\": {\"checkRun\": {\"id\": \"ABC\"}}}", objectMapper.getTypeFactory().constructParametricType(GraphQLResponseEntity.class, CreateCheckRun.class));
         when(graphQLTemplate.mutate(any(), eq(CreateCheckRun.class))).thenReturn(graphQLResponseEntity);
+        GraphQLResponseEntity<UpdateCheckRun> graphQLResponseEntity2 =
+                new ObjectMapper().readValue("{\"response\": {\"checkRun\": {\"id\": \"ABC\"}}}", objectMapper.getTypeFactory().constructParametricType(GraphQLResponseEntity.class, UpdateCheckRun.class));
+        when(graphQLTemplate.mutate(any(), eq(UpdateCheckRun.class))).thenReturn(graphQLResponseEntity2);
         when(graphqlProvider.createGraphQLTemplate()).thenReturn(graphQLTemplate);
 
         Clock clock = mock(Clock.class);
@@ -548,7 +551,7 @@ public class GraphqlCheckRunProviderTest {
         ArgumentCaptor<Class<?>> classArgumentCaptor = ArgumentCaptor.forClass(Class.class);
         verify(graphQLTemplate, times(3)).mutate(any(GraphQLRequestEntity.class), classArgumentCaptor.capture());
 
-        assertThat(classArgumentCaptor.getAllValues()).containsExactly(CreateCheckRun.class, CreateCheckRun.class, CreateCheckRun.class);
+        assertThat(classArgumentCaptor.getAllValues()).containsExactly(CreateCheckRun.class, UpdateCheckRun.class, UpdateCheckRun.class);
 
         ArgumentCaptor<List<InputObject>> annotationsArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(builders.get(100), times(3)).put(eq("annotations"), annotationsArgumentCaptor.capture());

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/UpdateCheckRunTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/UpdateCheckRunTest.java
@@ -30,14 +30,13 @@ public class UpdateCheckRunTest {
 
     @Test
     public void deserialiseReturnsSerialiseInput() throws IOException {
-        UpdateCheckRun testCase = new UpdateCheckRun("mutation ID", new CheckRun("check run ID"));
+        UpdateCheckRun testCase = new UpdateCheckRun(new CheckRun("check run ID"));
 
         ObjectMapper objectMapper = new ObjectMapper();
         String serialised = objectMapper.writeValueAsString(testCase);
 
         UpdateCheckRun deserialised = objectMapper.readerFor(UpdateCheckRun.class).readValue(serialised);
 
-        assertEquals("mutation ID", deserialised.getClientMutationId());
-        assertEquals("check run ID", testCase.getCheckRun().getId());
+        assertEquals("check run ID", deserialised.getCheckRun().getId());
     }
 }


### PR DESCRIPTION
The previous fix for any pull request that had more than 50 issues had allowed an initial check run to be created, and then submitted the next batch of 50 issues to Github but failed to parse the response properly, so threw an error at that point, subsequently only submitting 100 issues to Github for each scan before causing the Compute Engine task to fail. The correct type is now being specified for the parse of Github's response, and unnecessary fields in the expected response object have been removed to allow the response to be parsed properly.