### PR TITLE
#67: Link back to the Pull Request from Sonarqube

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/DecorationResult.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/DecorationResult.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
+
+import java.util.Optional;
+
+public final class DecorationResult {
+
+    private final String pullRequestUrl;
+
+    private DecorationResult(Builder builder) {
+        super();
+        this.pullRequestUrl = builder.pullRequestUrl;
+    }
+
+    public Optional<String> getPullRequestUrl() {
+        return Optional.ofNullable(pullRequestUrl);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private String pullRequestUrl;
+
+        private Builder() {
+            super();
+        }
+
+        public Builder withPullRequestUrl(String pullRequestUrl) {
+            this.pullRequestUrl = pullRequestUrl;
+            return this;
+        }
+
+        public DecorationResult build() {
+            return new DecorationResult(this);
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestBuildStatusDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestBuildStatusDecorator.java
@@ -28,5 +28,5 @@ public interface PullRequestBuildStatusDecorator {
 
     String name();
 
-    void decorateQualityGateStatus(AnalysisDetails analysisDetails, UnifyConfiguration configuration);
+    DecorationResult decorateQualityGateStatus(AnalysisDetails analysisDetails, UnifyConfiguration configuration);
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketServerPullRequestDecorator.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketClient;
@@ -67,6 +68,8 @@ public class BitbucketServerPullRequestDecorator implements PullRequestBuildStat
 
     private static final int DEFAULT_MAX_ANNOTATIONS = 1000;
 
+    private static final DecorationResult DEFAULT_DECORATION_RESULT = DecorationResult.builder().build();
+
     private static final List<String> OPEN_ISSUE_STATUSES =
             Issue.STATUSES.stream().filter(s -> !Issue.STATUS_CLOSED.equals(s) && !Issue.STATUS_RESOLVED.equals(s))
                     .collect(Collectors.toList());
@@ -83,11 +86,11 @@ public class BitbucketServerPullRequestDecorator implements PullRequestBuildStat
     }
 
     @Override
-    public void decorateQualityGateStatus(AnalysisDetails analysisDetails, UnifyConfiguration configuration) {
+    public DecorationResult decorateQualityGateStatus(AnalysisDetails analysisDetails, UnifyConfiguration configuration) {
         try {
             if(!client.supportsCodeInsights()) {
                 LOGGER.warn("Your Bitbucket instances does not support the Code Insights API.");
-                return;
+                return DEFAULT_DECORATION_RESULT;
             }
             String project = configuration.getRequiredProperty(PULL_REQUEST_BITBUCKET_PROJECT_KEY);
 
@@ -100,6 +103,8 @@ public class BitbucketServerPullRequestDecorator implements PullRequestBuildStat
         } catch (IOException e) {
             LOGGER.error("Could not decorate pull request for project {}", analysisDetails.getAnalysisProjectKey(), e);
         }
+
+        return DEFAULT_DECORATION_RESULT;
     }
 
     private CreateReportRequest toReport(AnalysisDetails analysisDetails) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/CheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/CheckRunProvider.java
@@ -19,11 +19,12 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public interface CheckRunProvider {
-    void createCheckRun(AnalysisDetails analysisDetails, UnifyConfiguration unifyConfiguration) throws IOException, GeneralSecurityException;
+    DecorationResult createCheckRun(AnalysisDetails analysisDetails, UnifyConfiguration unifyConfiguration) throws IOException, GeneralSecurityException;
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
 
@@ -31,9 +32,9 @@ public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorat
     }
 
     @Override
-    public void decorateQualityGateStatus(AnalysisDetails analysisDetails, UnifyConfiguration unifyConfiguration) {
+    public DecorationResult decorateQualityGateStatus(AnalysisDetails analysisDetails, UnifyConfiguration unifyConfiguration) {
         try {
-            checkRunProvider.createCheckRun(analysisDetails, unifyConfiguration);
+            return checkRunProvider.createCheckRun(analysisDetails, unifyConfiguration);
         } catch (Exception ex) {
             throw new IllegalStateException("Could not decorate Pull Request on Github", ex);
         }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/RepositoryAuthenticationToken.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/RepositoryAuthenticationToken.java
@@ -22,11 +22,13 @@ public class RepositoryAuthenticationToken {
 
     private final String repositoryId;
     private final String authenticationToken;
+    private final String repositoryUrl;
 
-    public RepositoryAuthenticationToken(String repositoryId, String authenticationToken) {
+    public RepositoryAuthenticationToken(String repositoryId, String authenticationToken, String repositoryUrl) {
         super();
         this.repositoryId = repositoryId;
         this.authenticationToken = authenticationToken;
+        this.repositoryUrl = repositoryUrl;
     }
 
     public String getRepositoryId() {
@@ -35,5 +37,9 @@ public class RepositoryAuthenticationToken {
 
     public String getAuthenticationToken() {
         return authenticationToken;
+    }
+
+    public String getRepositoryUrl() {
+        return repositoryUrl;
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/RestApplicationAuthenticationProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/RestApplicationAuthenticationProvider.java
@@ -129,7 +129,7 @@ public class RestApplicationAuthenticationProvider implements GithubApplicationA
                     objectMapper.readerFor(InstallationRepositories.class).readValue(installationRepositoriesReader);
             for (Repository repository : installationRepositories.getRepositories()) {
                 if (projectPath.equals(repository.getFullName())) {
-                    return Optional.of(new RepositoryAuthenticationToken(repository.getNodeId(), appToken.getToken()));
+                    return Optional.of(new RepositoryAuthenticationToken(repository.getNodeId(), appToken.getToken(), repository.getHtmlUrl()));
                 }
             }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/model/Repository.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/model/Repository.java
@@ -25,11 +25,13 @@ public class Repository {
 
     private final String nodeId;
     private final String fullName;
+    private final String htmlUrl;
 
     @JsonCreator
-    public Repository(@JsonProperty("node_id") String nodeId, @JsonProperty("full_name") String fullName) {
+    public Repository(@JsonProperty("node_id") String nodeId, @JsonProperty("full_name") String fullName, @JsonProperty("html_url") String htmlUrl) {
         this.nodeId = nodeId;
         this.fullName = fullName;
+        this.htmlUrl = htmlUrl;
     }
 
     public String getFullName() {
@@ -38,5 +40,9 @@ public class Repository {
 
     public String getNodeId() {
         return nodeId;
+    }
+
+    public String getHtmlUrl() {
+        return htmlUrl;
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.CheckRunProvider;
@@ -94,7 +95,7 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
     }
 
     @Override
-    public void createCheckRun(AnalysisDetails analysisDetails, UnifyConfiguration unifyConfiguration) throws IOException, GeneralSecurityException {
+    public DecorationResult createCheckRun(AnalysisDetails analysisDetails, UnifyConfiguration unifyConfiguration) throws IOException, GeneralSecurityException {
         String apiUrl = unifyConfiguration.getRequiredServerProperty(PULL_REQUEST_GITHUB_URL);
         String apiPrivateKey = unifyConfiguration.getRequiredServerProperty(PULL_REQUEST_GITHUB_TOKEN);
         String projectPath = unifyConfiguration.getRequiredProperty(PULL_REQUEST_GITHUB_REPOSITORY);
@@ -165,6 +166,9 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
                               inputObjectArguments, checkRunOutputContentBuilder, graphQLRequestEntityBuilder);
 
 
+        return DecorationResult.builder()
+                .withPullRequestUrl(repositoryAuthenticationToken.getRepositoryUrl() + "/pull/" + analysisDetails.getBranchName())
+                .build();
 
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
@@ -87,7 +88,7 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
     }
 
     @Override
-    public void decorateQualityGateStatus(AnalysisDetails analysis, UnifyConfiguration unifyConfiguration) {
+    public DecorationResult decorateQualityGateStatus(AnalysisDetails analysis, UnifyConfiguration unifyConfiguration) {
         LOGGER.info("starting to analyze with " + analysis.toString());
         String revision = analysis.getCommitSha();
 
@@ -109,6 +110,8 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
             final String mergeRequestURl = projectURL + String.format("/merge_requests/%s", pullRequestId);
             final String prCommitsURL = mergeRequestURl + "/commits";
             final String mergeRequestDiscussionURL = mergeRequestURl + "/discussions";
+
+            final String prHtmlUrl = String.format("%s/%s/merge_requests/%s", hostURL, repositorySlug, pullRequestId);
 
             LOGGER.info(String.format("Status url is: %s ", statusUrl));
             LOGGER.info(String.format("PR commits url is: %s ", prCommitsURL));
@@ -188,6 +191,8 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
                     }
                 }
             }
+
+            return DecorationResult.builder().withPullRequestUrl(prHtmlUrl).build();
         } catch (IOException ex) {
             throw new IllegalStateException("Could not decorate Pull Request on Gitlab Server", ex);
         }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
 import org.junit.Test;
 
@@ -28,6 +29,7 @@ import java.security.GeneralSecurityException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -56,8 +58,11 @@ public class GithubPullRequestDecoratorTest {
 
     @Test
     public void testDecorateQualityGateReturnValue() throws IOException, GeneralSecurityException {
-        testCase.decorateQualityGateStatus(analysisDetails, unifyConfiguration);
+        DecorationResult expectedResult = DecorationResult.builder().build();
+        doReturn(expectedResult).when(checkRunProvider).createCheckRun(any(), any());
+        DecorationResult decorationResult = testCase.decorateQualityGateStatus(analysisDetails, unifyConfiguration);
 
         verify(checkRunProvider).createCheckRun(analysisDetails, unifyConfiguration);
+        assertThat(decorationResult).isSameAs(expectedResult);
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/RestApplicationAuthenticationProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v3/RestApplicationAuthenticationProviderTest.java
@@ -79,6 +79,7 @@ public class RestApplicationAuthenticationProviderTest {
         String expectedAuthenticationToken = "expected authentication token";
         String projectPath = "project path";
         String expectedRepositoryId = "expected repository Id";
+        String expectedHtmlUrl = "http://url.for/users/repo";
 
         URLConnection installationsUrlConnection = mock(URLConnection.class);
         doReturn(new ByteArrayInputStream(
@@ -95,7 +96,7 @@ public class RestApplicationAuthenticationProviderTest {
         HttpURLConnection repositoriesUrlConnection = mock(HttpURLConnection.class);
         doReturn(new ByteArrayInputStream(
                 ("{\"repositories\": [{\"node_id\": \"" + expectedRepositoryId + "\", \"full_name\": \"" + projectPath +
-                 "\"}]}").getBytes(StandardCharsets.UTF_8))).when(repositoriesUrlConnection).getInputStream();
+                 "\", \"html_url\": \"" + expectedHtmlUrl + "\"}]}").getBytes(StandardCharsets.UTF_8))).when(repositoriesUrlConnection).getInputStream();
         doReturn(repositoriesUrlConnection).when(urlProvider).createUrlConnection("repositories_url");
 
         doReturn(installationsUrlConnection).when(urlProvider).createUrlConnection(eq(fullUrl));
@@ -112,6 +113,7 @@ public class RestApplicationAuthenticationProviderTest {
 
         assertEquals(expectedAuthenticationToken, result.getAuthenticationToken());
         assertEquals(expectedRepositoryId, result.getRepositoryId());
+        assertEquals(expectedHtmlUrl, result.getRepositoryUrl());
 
         ArgumentCaptor<String> requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(installationsUrlConnection, times(2))


### PR DESCRIPTION
Sonarqube provides the ability to link back to the original Pull Request or Merge Request from the Pull Request overview screen if the Pull Request URL is persisted alongside the branch details. To allow this, decorators are now required to return a `DecorationResult` that contains an optional URL for the Pull Request's overview/summary page. The Gitlab and Github decorators have been updated to provide the new details, however the Bitbucket decorator defaults to returning no URL since the details are not readily available, so Bitbucket Pull Requests will continue to show no link back the the Pull Request from Sonarqube.