### PR TITLE
Support for bitbucket cloud code insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use the following table to find the correct plugin version for each SonarQube ve
 
 SonarQube Version | Plugin Version
 ------------------|---------------
-7.8 - 8.0         | 1.3.0
+7.8 - 8.0         | 1.3.1
 7.4 - 7.7         | 1.0.2
 
 # Features

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -147,10 +147,6 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                             "Repository Slug see for example https://docs.atlassian.com/bitbucket-server/rest/latest/bitbucket-rest.html")
                             .type(PropertyType.STRING).build(),
 
-                    PropertyDefinition.builder(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_USER_SLUG).category(PULL_REQUEST_CATEGORY_LABEL).subCategory(BITBUCKET_INTEGRATION_SUBCATEGORY_LABEL)
-                            .onlyOnQualifiers(Qualifiers.PROJECT).name("User Slug").description("This is used for '/users' repos. Only set one User Slug or ProjectKey!")
-                            .type(PropertyType.STRING).index(2).build(),
-
                     PropertyDefinition.builder(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_PROJECT_KEY).category(PULL_REQUEST_CATEGORY_LABEL).subCategory(BITBUCKET_INTEGRATION_SUBCATEGORY_LABEL)
                             .onlyOnQualifiers(Qualifiers.PROJECT).name("ProjectKey").description("This is used for '/projects' repos. Only set one User Slug or ProjectKey!")
                             .type(PropertyType.STRING).index(1).build(),

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
@@ -21,7 +21,9 @@ package com.github.mc1arke.sonarqube.plugin.ce;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestPostAnalysisTask;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.BitbucketServerPullRequestDecorator;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketClient;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketClientFacade;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketCloudClient;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketServerClient;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.GithubPullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v3.DefaultLinkHeaderReader;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v3.RestApplicationAuthenticationProvider;
@@ -42,8 +44,8 @@ public class CommunityReportAnalysisComponentProvider implements ReportAnalysisC
         return Arrays.asList(CommunityBranchLoaderDelegate.class, PullRequestPostAnalysisTask.class,
                              PostAnalysisIssueVisitor.class, GithubPullRequestDecorator.class,
                              GraphqlCheckRunProvider.class, DefaultLinkHeaderReader.class, RestApplicationAuthenticationProvider.class,
-                             BitbucketServerPullRequestDecorator.class, BitbucketClient.class,
-                             GitlabServerPullRequestDecorator.class);
+                             BitbucketServerPullRequestDecorator.class, BitbucketServerClient.class, BitbucketCloudClient.class,
+                             BitbucketClientFacade.class, GitlabServerPullRequestDecorator.class);
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTask.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTask.java
@@ -135,7 +135,7 @@ public class PullRequestPostAnalysisTask implements PostProjectAnalysisTask,
                                     projectAnalysis.getProject(), configuration, server.getPublicRootUrl());
 
         PullRequestBuildStatusDecorator pullRequestDecorator = optionalPullRequestDecorator.get();
-        LOGGER.info("using pull request decorator" + pullRequestDecorator.name());
+        LOGGER.info("using pull request decorator " + pullRequestDecorator.name());
         DecorationResult decorationResult = pullRequestDecorator.decorateQualityGateStatus(analysisDetails, unifyConfiguration);
 
         decorationResult.getPullRequestUrl().ifPresent(pullRequestUrl -> persistPullRequestUrl(pullRequestUrl, projectAnalysis, optionalBranchName.get()));

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/AbstractBitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/AbstractBitbucketClient.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Marvin Wichmann
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.BitbucketServerPullRequestDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server.ErrorResponse;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+abstract class AbstractBitbucketClient {
+    private UnifyConfiguration configuration;
+
+    ObjectMapper getObjectMapper() {
+        return new ObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    String baseUrl() {
+        return configuration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL);
+    }
+
+    String getToken() {
+        return configuration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_TOKEN);
+    }
+
+    void validate(Response response) throws IOException {
+        if (!response.isSuccessful()) {
+            ErrorResponse errors = null;
+            if (response.body() != null) {
+                errors = getObjectMapper().reader().forType(ErrorResponse.class)
+                        .readValue(response.body().string());
+            }
+            throw new BitbucketException(response.code(), errors);
+        }
+    }
+
+    public void setConfiguration(UnifyConfiguration configuration) {
+        this.configuration = configuration;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClientFacade.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClientFacade.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2020 Marvin Wichmann
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.BitbucketServerPullRequestDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.DataValue;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.IAnnotation;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.ReportData;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.cloud.CloudAnnotation;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.cloud.CloudCreateReportRequest;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server.Annotation;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server.CreateAnnotationsRequest;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server.CreateReportRequest;
+import org.sonar.api.ce.ComputeEngineSide;
+import org.sonar.api.ce.posttask.QualityGate;
+
+import java.io.IOException;
+import java.sql.Date;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This facade provides the ability to delegate the pull request decoration
+ * between the cloud and the server version of bitbucket.
+ * <p>
+ * The URL is used in order to identify the cloud version.
+ */
+@ComputeEngineSide
+public class BitbucketClientFacade {
+
+    private final BitbucketServerClient bitbucketServerClient;
+    private final BitbucketCloudClient bitbucketCloudClient;
+    private UnifyConfiguration configuration;
+
+    public BitbucketClientFacade(BitbucketServerClient bitbucketServerClient, BitbucketCloudClient cloudClient) {
+        this.bitbucketServerClient = bitbucketServerClient;
+        this.bitbucketCloudClient = cloudClient;
+    }
+
+    public void withConfiguration(UnifyConfiguration configuration) {
+        this.configuration = configuration;
+        this.bitbucketServerClient.setConfiguration(configuration);
+        this.bitbucketCloudClient.setConfiguration(configuration);
+    }
+
+    /**
+     * <p>
+     * Creates an annotation for the given parameters based on the fact if the cloud
+     * or the on prem bitbucket solution is used.
+     * </p>
+     *
+     * @return IAnnotation either from the server or the cloud version
+     */
+    public IAnnotation createAnnotation(String issueKey, int line, String issueUrl, String message, String path, String severity, String type) {
+        if (isCloud()) {
+            return new CloudAnnotation(issueKey,
+                    line,
+                    issueUrl,
+                    message,
+                    path,
+                    severity,
+                    type);
+        }
+
+        return new Annotation(issueKey,
+                line,
+                issueUrl,
+                message,
+                path,
+                severity,
+                type);
+    }
+
+    public void deleteAnnotations(String project, String repo, String commitSha) throws IOException {
+        if (!isCloud()) {
+            bitbucketServerClient.deleteAnnotations(project, repo, commitSha);
+        }
+        // Cloud version doesn't have that endpoint. Instead we delete the complete report before we continue.
+    }
+
+    public void createAnnotations(String project, String repo, String commitSha, Set<IAnnotation> annotations) throws IOException {
+        if (isCloud()) {
+            Set<CloudAnnotation> annotationSet = annotations.stream().map(annotation -> (CloudAnnotation) annotation).collect(Collectors.toSet());
+            bitbucketCloudClient.createAnnotations(project, repo, commitSha, annotationSet);
+        } else {
+            Set<Annotation> annotationSet = annotations.stream().map(annotation -> (Annotation) annotation).collect(Collectors.toSet());
+            bitbucketServerClient.createAnnotations(project, repo, commitSha, new CreateAnnotationsRequest(annotationSet));
+        }
+    }
+
+    public DataValue createLinkDataValue(String dashboardUrl) {
+        if (isCloud()) {
+            return new DataValue.CloudLink("Go to SonarQube", dashboardUrl);
+        }
+
+        return new DataValue.Link("Go to SonarQube", dashboardUrl);
+    }
+
+    public void createReport(String project, String repo, String commitSha, List<ReportData> reportData,
+                             String reportDescription, Instant creationDate, String dashboardUrl,
+                             String logoUrl, QualityGate.Status status) throws IOException {
+        if (isCloud()) {
+            // delete report first for cloud here then create new one
+            bitbucketCloudClient.deleteReport(project, repo, commitSha);
+
+            CloudCreateReportRequest report = new CloudCreateReportRequest(
+                    reportData,
+                    reportDescription,
+                    "SonarQube",
+                    "SonarQube",
+                    Date.from(creationDate),
+                    dashboardUrl, // you need to change this to a real https URL for local debugging since localhost will get declined by the API
+                    logoUrl,
+                    "COVERAGE",
+                    QualityGate.Status.ERROR.equals(status) ? "FAILED" : "PASSED"
+            );
+
+            bitbucketCloudClient.createReport(project, repo, commitSha, report);
+        } else {
+            CreateReportRequest report = new CreateReportRequest(
+                    reportData,
+                    reportDescription,
+                    "SonarQube",
+                    "SonarQube",
+                    creationDate,
+                    dashboardUrl,
+                    logoUrl,
+                    QualityGate.Status.ERROR.equals(status) ? "FAIL" : "PASS"
+            );
+
+            bitbucketServerClient.createReport(project, repo, commitSha, report);
+        }
+    }
+
+    /**
+     * <p>
+     * Determines if the used bitbucket endpoint supports the code insights feature.
+     * <p>
+     * For the cloud version we simply return true and for the server version a version
+     * check is implemented that tests if the given server version is higher than 5.15
+     * </p>
+     *
+     * @return boolean
+     */
+    public boolean supportsCodeInsights() {
+        return isCloud() || bitbucketServerClient.supportsCodeInsights();
+    }
+
+    private boolean isCloud() {
+        return baseUrl().contains("https://api.bitbucket.org");
+    }
+
+    private String baseUrl() {
+        return configuration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL);
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClient.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2020 Marvin Wichmann
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.cloud.CloudAnnotation;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.cloud.CloudCreateReportRequest;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.sonar.api.ce.ComputeEngineSide;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static java.lang.String.format;
+
+@ComputeEngineSide
+public class BitbucketCloudClient extends AbstractBitbucketClient {
+    private static final Logger LOGGER = Loggers.get(BitbucketCloudClient.class);
+    private static final String REPORT_KEY = "com.github.mc1arke.sonarqube";
+    private static final MediaType APPLICATION_JSON_MEDIA_TYPE = MediaType.get("application/json");
+
+    void createReport(String project, String repository, String commit, CloudCreateReportRequest request) throws IOException {
+        String body = getObjectMapper().writeValueAsString(request);
+        Request req = new Request.Builder()
+                .put(RequestBody.create(APPLICATION_JSON_MEDIA_TYPE, body))
+                .url(format("%s/2.0/repositories/%s/%s/commit/%s/reports/%s", baseUrl(), project, repository, commit, REPORT_KEY))
+                .build();
+
+        LOGGER.info("Create report on bitbucket cloud");
+        LOGGER.debug("Create report: " + body);
+
+        try (Response response = getClient().newCall(req).execute()) {
+            validate(response);
+        }
+    }
+
+    void createAnnotations(String project, String repository, String commit, Set<CloudAnnotation> annotations) throws IOException {
+        if (annotations.isEmpty()) {
+            return;
+        }
+
+        Request req = new Request.Builder()
+                .post(RequestBody.create(APPLICATION_JSON_MEDIA_TYPE, getObjectMapper().writeValueAsString(annotations)))
+                .url(format("%s/2.0/repositories/%s/%s/commit/%s/reports/%s/annotations", baseUrl(), project, repository, commit, REPORT_KEY))
+                .build();
+
+        LOGGER.info("Creating annotations on bitbucket cloud");
+        LOGGER.debug("Create annotations: " + getObjectMapper().writeValueAsString(annotations));
+
+        try (Response response = getClient().newCall(req).execute()) {
+            validate(response);
+        }
+    }
+
+    void deleteReport(String project, String repository, String commit) throws IOException {
+        Request req = new Request.Builder()
+                .delete()
+                .url(format("%s/2.0/repositories/%s/%s/commit/%s/reports/%s", baseUrl(), project, repository, commit, REPORT_KEY))
+                .build();
+
+        LOGGER.info("Deleting existing reports on bitbucket cloud");
+
+        try (Response response = getClient().newCall(req).execute()) {
+            // we dont need to validate the output here since most of the time this call will just return a 404
+        }
+    }
+
+    private OkHttpClient getClient() {
+        return new OkHttpClient.Builder()
+                .addInterceptor(chain -> {
+                    Request newRequest = chain.request().newBuilder()
+                            .addHeader("Authorization", format("Basic %s", getToken()))
+                            .addHeader("Accept", APPLICATION_JSON_MEDIA_TYPE.toString())
+                            .build();
+                    return chain.proceed(newRequest);
+                })
+                .build();
+    }
+
+    void validate(Response response) throws IOException {
+        if (!response.isSuccessful()) {
+            String error = null;
+            if (response.body() != null) {
+                error = response.body().string();
+            }
+            throw new RuntimeException("Bitbucket returned the following error: " + error);
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketException.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketException.java
@@ -18,7 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.ErrorResponse;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server.ErrorResponse;
 
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/DataValue.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/DataValue.java
@@ -46,6 +46,25 @@ public interface DataValue extends Serializable {
         }
     }
 
+    class CloudLink implements DataValue {
+        private final String text;
+        private final String href;
+
+        @JsonCreator
+        public CloudLink(@JsonProperty("text") String text, @JsonProperty("href") String href) {
+            this.text = text;
+            this.href = href;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public String getHref() {
+            return href;
+        }
+    }
+
     class Text implements DataValue {
         private final String value;
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/IAnnotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/IAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Mathias Åhsberg
+ * Copyright (C) 2020 Marvin Wichmann
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,34 +18,8 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.Set;
-
-public class ErrorResponse implements Serializable {
-    private final Set<Error> errors;
-
-    ErrorResponse(@JsonProperty("errors") Set<Error> errors) {
-        this.errors = errors;
-    }
-
-    public Set<Error> getErrors() {
-        return Collections.unmodifiableSet(errors);
-    }
-
-    public static class Error implements Serializable {
-
-        private final String message;
-
-        Error(@JsonProperty("message") String message) {
-            this.message = message;
-        }
-
-        public String getMessage() {
-            return this.message;
-        }
-    }
+/**
+ * Interface for reusing models between the cloud and the server version
+ */
+public interface IAnnotation {
 }
-

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/ReportData.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/ReportData.java
@@ -34,6 +34,16 @@ public class ReportData {
         this.type = typeFrom(value);
     }
 
+    private static String typeFrom(DataValue value) {
+        if (value instanceof DataValue.Link || value instanceof DataValue.CloudLink) {
+            return "LINK";
+        } else if (value instanceof DataValue.Percentage) {
+            return "PERCENTAGE";
+        } else {
+            return "TEXT";
+        }
+    }
+
     public String getTitle() {
         return title;
     }
@@ -44,15 +54,5 @@ public class ReportData {
 
     public String getType() {
         return type;
-    }
-
-    private static String typeFrom(DataValue value) {
-        if (value instanceof DataValue.Link) {
-            return "LINK";
-        } else if (value instanceof DataValue.Percentage) {
-            return "PERCENTAGE";
-        } else {
-            return "TEXT";
-        }
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudAnnotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Mathias Åhsberg
+ * Copyright (C) 2020 Marvin Wichmann
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,37 +16,45 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model;
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.cloud;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.IAnnotation;
 
 import java.io.Serializable;
 
-public class Annotation implements Serializable {
+public class CloudAnnotation implements Serializable, IAnnotation {
+    @JsonProperty("external_id")
     private final String externalId;
+    @JsonProperty("line")
     private final int line;
+    @JsonProperty("summary")
     private final String link;
+    @JsonProperty("message")
     private final String message;
+    @JsonProperty("path")
     private final String path;
+    @JsonProperty("severity")
     private final String severity;
-    private final String type;
+    @JsonProperty("annotation_type")
+    private final String annotationType;
 
     @JsonCreator
-    public Annotation(@JsonProperty("externalId") String externalId,
-                      @JsonProperty("line") int line,
-                      @JsonProperty("link") String link,
-                      @JsonProperty("message") String message,
-                      @JsonProperty("path") String path,
-                      @JsonProperty("severity") String severity,
-                      @JsonProperty("type") String type) {
+    public CloudAnnotation(String externalId,
+                           int line,
+                           String link,
+                           String message,
+                           String path,
+                           String severity,
+                           String annotationType) {
         this.externalId = externalId;
         this.line = line;
         this.link = link;
         this.message = message;
         this.path = path;
         this.severity = severity;
-        this.type = type;
+        this.annotationType = annotationType;
     }
 
     public String getExternalId() {
@@ -73,7 +81,7 @@ public class Annotation implements Serializable {
         return severity;
     }
 
-    public String getType() {
-        return type;
+    public String getAnnotationType() {
+        return annotationType;
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudCreateReportRequest.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudCreateReportRequest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 Marvin Wichmann
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.cloud;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.ReportData;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CloudCreateReportRequest implements Serializable {
+    @JsonProperty("data")
+    private final List<ReportData> data;
+    @JsonProperty("details")
+    private final String details;
+    @JsonProperty("title")
+    private final String title;
+    @JsonProperty("reporter")
+    private final String reporter;
+    @JsonProperty("created_on")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ")
+    private final Date createdDate;
+    @JsonProperty("link")
+    private final String link;
+    @JsonProperty("logo_url")
+    private final String logoUrl;
+    @JsonProperty("report_type")
+    private final String reportType;
+    @JsonProperty("result")
+    private final String result;
+
+    @JsonProperty("remote_link_enabled")
+    private final Boolean remoteLinkEnabled = true;
+
+    @JsonCreator
+    public CloudCreateReportRequest(
+            List<ReportData> data,
+            String details,
+            String title,
+            String reporter,
+            Date createdDate,
+            String link,
+            String logoUrl,
+            String reportType,
+            String result) {
+        this.data = data.stream().filter(report -> !report.getType().equals("LINK")).collect(Collectors.toList());
+        this.details = details;
+        this.title = title;
+        this.reporter = reporter;
+        this.createdDate = createdDate;
+        this.link = link;
+        this.logoUrl = logoUrl;
+        this.reportType = reportType;
+        this.result = result;
+    }
+
+    public List<ReportData> getData() {
+        return data;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getReporter() {
+        return reporter;
+    }
+
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public String getLogoUrl() {
+        return logoUrl;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public String getReportType() {
+        return reportType;
+    }
+
+    public Boolean getRemoteLinkEnabled() {
+        return remoteLinkEnabled;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/Annotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/Annotation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 Mathias Åhsberg
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.IAnnotation;
+
+import java.io.Serializable;
+
+public class Annotation implements Serializable, IAnnotation {
+    private final String externalId;
+    private final int line;
+    private final String link;
+    private final String message;
+    private final String path;
+    private final String severity;
+    private final String type;
+
+    @JsonCreator
+    public Annotation(@JsonProperty("externalId") String externalId,
+                      @JsonProperty("line") int line,
+                      @JsonProperty("link") String link,
+                      @JsonProperty("message") String message,
+                      @JsonProperty("path") String path,
+                      @JsonProperty("severity") String severity,
+                      @JsonProperty("type") String type) {
+        this.externalId = externalId;
+        this.line = line;
+        this.link = link;
+        this.message = message;
+        this.path = path;
+        this.severity = severity;
+        this.type = type;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public int getLine() {
+        return line;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getSeverity() {
+        return severity;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/CreateAnnotationsRequest.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/CreateAnnotationsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2020 Mathias Åhsberg
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,23 +16,20 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-package com.github.mc1arke.sonarqube.plugin.ce;
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server;
 
-import org.junit.Test;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
 
-import java.util.List;
+public class CreateAnnotationsRequest implements Serializable {
+    private final Set<Annotation> annotations;
 
-import static org.junit.Assert.assertEquals;
+    public CreateAnnotationsRequest(Set<Annotation> annotations) {
+        this.annotations = annotations == null ? Collections.emptySet() : annotations;
+    }
 
-/**
- * @author Michael Clarke
- */
-public class CommunityReportAnalysisComponentProviderTest {
-
-    @Test
-    public void testGetComponents() {
-        List<Object> result = new CommunityReportAnalysisComponentProvider().getComponents();
-        assertEquals(12, result.size());
-        assertEquals(CommunityBranchLoaderDelegate.class, result.get(0));
+    public Set<Annotation> getAnnotations() {
+        return annotations;
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/CreateReportRequest.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/CreateReportRequest.java
@@ -16,10 +16,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model;
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.ReportData;
 
 import java.time.Instant;
 import java.util.List;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/ErrorResponse.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/ErrorResponse.java
@@ -16,20 +16,36 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model;
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Set;
 
-public class CreateAnnotationsRequest implements Serializable {
-    private final Set<Annotation> annotations;
+public class ErrorResponse implements Serializable {
+    private final Set<Error> errors;
 
-    public CreateAnnotationsRequest(Set<Annotation> annotations) {
-        this.annotations = annotations == null ? Collections.emptySet() : annotations;
+    ErrorResponse(@JsonProperty("errors") Set<Error> errors) {
+        this.errors = errors;
     }
 
-    public Set<Annotation> getAnnotations() {
-        return annotations;
+    public Set<Error> getErrors() {
+        return Collections.unmodifiableSet(errors);
+    }
+
+    public static class Error implements Serializable {
+
+        private final String message;
+
+        Error(@JsonProperty("message") String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return this.message;
+        }
     }
 }
+

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/ServerProperties.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/ServerProperties.java
@@ -16,7 +16,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model;
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerConfigurationLoaderSensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerConfigurationLoaderSensor.java
@@ -38,7 +38,6 @@ public class ScannerConfigurationLoaderSensor implements Sensor {
         this(Sets.newHashSet(
                 CommunityBranchPlugin.PULL_REQUEST_PROVIDER,
                 BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_PROJECT_KEY,
-                BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_USER_SLUG,
                 BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_REPOSITORY_SLUG,
                 GraphqlCheckRunProvider.PULL_REQUEST_GITHUB_REPOSITORY,
                 GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_REPOSITORY_SLUG

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -119,7 +119,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(22, argumentCaptor.getAllValues().size());
+        assertEquals(21, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/AbstractBitbucketClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/AbstractBitbucketClientUnitTest.java
@@ -1,0 +1,52 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.BitbucketServerPullRequestDecorator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractBitbucketClientUnitTest {
+
+    @Mock
+    private UnifyConfiguration unifyConfiguration;
+
+    private AbstractBitbucketClient client = new AbstractBitbucketClient() {
+    };
+
+    @Before
+    public void before() {
+        this.client.setConfiguration(unifyConfiguration);
+    }
+
+    @Test
+    public void testURLConfiguration() {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://api.bitbucket.org");
+
+        // when
+        String result = client.baseUrl();
+
+        // then
+        assertEquals("https://api.bitbucket.org", result);
+    }
+
+    @Test
+    public void testTokenConfiguration() {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_TOKEN)).thenReturn("iohoisdjfsdf==");
+
+        // when
+        String result = client.getToken();
+
+        // then
+        assertEquals("iohoisdjfsdf==", result);
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClientFacadeUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClientFacadeUnitTest.java
@@ -1,0 +1,201 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.BitbucketServerPullRequestDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.DataValue;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.IAnnotation;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.cloud.CloudAnnotation;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server.Annotation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.sonar.api.ce.posttask.QualityGate;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BitbucketClientFacadeUnitTest {
+
+    @Mock
+    private BitbucketCloudClient bitbucketCloudClient;
+
+    @Mock
+    private BitbucketServerClient bitbucketServerClient;
+
+    @Mock
+    private UnifyConfiguration unifyConfiguration;
+
+    @InjectMocks
+    private BitbucketClientFacade underTest;
+
+    @Before
+    public void before() {
+        this.underTest.withConfiguration(unifyConfiguration);
+
+        verify(bitbucketCloudClient).setConfiguration(unifyConfiguration);
+        verify(bitbucketServerClient).setConfiguration(unifyConfiguration);
+    }
+
+    @Test
+    public void testCreateAnnotationForCloud() {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://api.bitbucket.org");
+
+        // when
+        IAnnotation annotation = underTest.createAnnotation("issueKey", 12, "http://localhost:9000/dashboard", "Failed", "/path/to/file", "MAJOR", "BUG");
+
+        // then
+        assertTrue(annotation instanceof CloudAnnotation);
+        assertEquals("issueKey", ((CloudAnnotation)annotation).getExternalId());
+        assertEquals(12, ((CloudAnnotation)annotation).getLine());
+        assertEquals("http://localhost:9000/dashboard", ((CloudAnnotation)annotation).getLink());
+        assertEquals("/path/to/file", ((CloudAnnotation)annotation).getPath());
+        assertEquals("MAJOR", ((CloudAnnotation)annotation).getSeverity());
+        assertEquals("BUG", ((CloudAnnotation)annotation).getAnnotationType());
+    }
+
+    @Test
+    public void testCreateAnnotationForServer() {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://my-server.bitbucket.org");
+
+        // when
+        IAnnotation annotation = underTest.createAnnotation("issueKey", 12, "http://localhost:9000/dashboard", "Failed", "/path/to/file", "MAJOR", "BUG");
+
+        // then
+        assertTrue(annotation instanceof Annotation);
+        assertEquals("issueKey", ((Annotation)annotation).getExternalId());
+        assertEquals(12, ((Annotation)annotation).getLine());
+        assertEquals("http://localhost:9000/dashboard", ((Annotation)annotation).getLink());
+        assertEquals("/path/to/file", ((Annotation)annotation).getPath());
+        assertEquals("MAJOR", ((Annotation)annotation).getSeverity());
+        assertEquals("BUG", ((Annotation)annotation).getType());
+    }
+
+    @Test
+    public void testDeleteAnnotationsForCloudVersion() throws IOException {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://api.bitbucket.org");
+
+        // when
+        underTest.deleteAnnotations("any", "any", "any");
+
+        // then
+        verify(bitbucketServerClient, times(0)).deleteAnnotations("any", "any", "any");
+    }
+
+    @Test
+    public void testDeleteAnnotationsForServerVersion() throws IOException {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://my-git.org");
+
+        // when
+        underTest.deleteAnnotations("any", "any", "any");
+
+        // then
+        verify(bitbucketServerClient, times(1)).deleteAnnotations("any", "any", "any");
+    }
+
+    @Test
+    public void testCreateDataLinkForCloud() throws IOException {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://api.bitbucket.org");
+
+        // when
+        DataValue data = underTest.createLinkDataValue("https://localhost:9000/any/project");
+
+        // then
+        assertTrue(data instanceof DataValue.CloudLink);
+        assertEquals("https://localhost:9000/any/project", ((DataValue.CloudLink) data).getHref());
+    }
+
+    @Test
+    public void testCreateDataLinkForServer() throws IOException {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://my-git.org");
+
+        // when
+        DataValue data = underTest.createLinkDataValue("https://localhost:9000/any/project");
+
+        // then
+        assertTrue(data instanceof DataValue.Link);
+        assertEquals("https://localhost:9000/any/project", ((DataValue.Link) data).getHref());
+    }
+
+    @Test
+    public void testCloudAlwaysSupportsCodeInsights() throws IOException {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://api.bitbucket.org");
+
+        // when
+        boolean result = underTest.supportsCodeInsights();
+
+        // then
+        assertTrue(result);
+        verify(bitbucketServerClient, times(0)).supportsCodeInsights();
+    }
+
+    @Test
+    public void testBitbucketServerUnsupportedCodeInsights() throws IOException {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://api.my-git.org");
+        when(bitbucketServerClient.supportsCodeInsights()).thenReturn(false);
+
+        // when
+        boolean result = underTest.supportsCodeInsights();
+
+        // then
+        assertFalse(result);
+        verify(bitbucketServerClient, times(1)).supportsCodeInsights();
+    }
+
+    @Test
+    public void testBitbucketSupportsCodeInsights() throws IOException {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://api.my-git.org");
+        when(bitbucketServerClient.supportsCodeInsights()).thenReturn(true);
+
+        // when
+        boolean result = underTest.supportsCodeInsights();
+
+        // then
+        assertTrue(result);
+        verify(bitbucketServerClient, times(1)).supportsCodeInsights();
+    }
+
+    @Test
+    public void testCreateCloudReport() throws IOException {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://api.bitbucket.org");
+
+        // when
+        underTest.createReport("project", "repo", "commitSha", new ArrayList<>(), "reportDescription", Instant.now(), "dashboardUrl", "logoUrl", QualityGate.Status.ERROR);
+
+        // then
+        verify(bitbucketServerClient, times(0)).createReport(eq("project"), eq("repo"), eq("commitSha"), any());
+        verify(bitbucketCloudClient, times(1)).deleteReport("project", "repo", "commitSha");
+        verify(bitbucketCloudClient, times(1)).createReport(eq("project"), eq("repo"), eq("commitSha"), any());
+    }
+
+    @Test
+    public void testCreateServerReport() throws IOException {
+        // given
+        when(unifyConfiguration.getRequiredProperty(BitbucketServerPullRequestDecorator.PULL_REQUEST_BITBUCKET_URL)).thenReturn("https://api.my-git.org");
+
+        // when
+        underTest.createReport("project", "repo", "commitSha", new ArrayList<>(), "reportDescription", Instant.now(), "dashboardUrl", "logoUrl", QualityGate.Status.ERROR);
+
+        // then
+        verify(bitbucketServerClient, times(1)).createReport(eq("project"), eq("repo"), eq("commitSha"), any());
+        verify(bitbucketCloudClient, times(0)).deleteReport("project", "repo", "commitSha");
+        verify(bitbucketCloudClient, times(0)).createReport(eq("project"), eq("repo"), eq("commitSha"), any());
+    }
+}


### PR DESCRIPTION
### Intention

This PR intends to provide support for the code insights feature for bitbucket cloud.

### History

Since about 2 months bitbucket cloud also has a code insights feature that one can use. After checking the differences between the cloud and the server implementation it is however not possible to completely reuse the server logic due to renamed/missing fields in the cloud version.

I haven't changed any public facing API (configs, properties, decorators) in this PR which allows @mc1arke to keep it up to date with the other sonarqube versions.

### Additions

* The API is fully functional now for both the server and the cloud version. One development limitation is that Bitbucket actually checks the URL and doesn't allow localhost URLs. That's why someone testing this with a local instance or an instance whose DNS isn't publicly accessible (not confirmed) might have troubles.
* I tried to create a wiki page for this new decorator, however according to https://github.community/t/how-to-fork-a-wiki-and-send-a-pr/2006 it is currently not possible to fork a wiki repository. Is it possible to be granted access to feature branches for the wiki git - then I could create a PR. Alternatively, setting up a dedicated wiki repository could also make sense in case other people are interested in contributing to it.

### Screenshots

![image](https://user-images.githubusercontent.com/708887/83976314-99dde280-a8f9-11ea-848e-393860c02a0b.png)

![image](https://user-images.githubusercontent.com/708887/83976327-a5c9a480-a8f9-11ea-8d69-e068e9f08f50.png)


