### PR TITLE
Fix execution of Sonarqube on forked repositories and pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,7 @@ jobs:
             ${{ runner.os }}-gradle-
       -
         name: Sonar
+        if: ${{ env.SONAR_TOKEN != null }}
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             ./gradlew sonarqube \
@@ -202,8 +203,8 @@ jobs:
               -Dsonar.host.url=https://sonarcloud.io \
               -Dsonar.organization=${SONAR_ORG_KEY} \
               -Dsonar.projectKey=${SONAR_PROJECT_KEY} \
-              -Dsonar.pullrequest.key=${{ github.event.number }}
-              -Dsonar.pullrequest.base=${{ github.event.base_ref }}
+              -Dsonar.pullrequest.key=${{ github.event.number }} \
+              -Dsonar.pullrequest.base=${{ github.base_ref }}
           else
             ./gradlew sonarqube \
               -Dsonar.pullrequest.provider=github \


### PR DESCRIPTION
Github does not expose secrets during the execution of actions on pull requests from forked projects, so the Sonar task would always fail on external pull requests. Additionally, anyone forking the project would have had the Sonarqube step fail unless they'd specifically setup Sonarqube secrets on their fork. To overcome this, the `sonar` step is now executed based on the condition of the `SONAR_TOKEN` secret being present in the current execution environment.

Includes a fix for incorrect syntax and variable references in the Pull Request Sonar analysis block.