### PR TITLE
Fix #190 - Don't decorate with fixed issue

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
@@ -36,6 +36,7 @@ import io.aexp.nodes.graphql.GraphQLTemplate;
 import io.aexp.nodes.graphql.InputObject;
 import io.aexp.nodes.graphql.internal.Error;
 import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.issue.Issue;
 import org.sonar.api.platform.Server;
 import org.sonar.api.rule.Severity;
 import org.sonar.api.utils.log.Logger;
@@ -72,6 +73,10 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
     private final Clock clock;
     private final GithubApplicationAuthenticationProvider githubApplicationAuthenticationProvider;
     private final Server server;
+
+    private static final List<String> OPEN_ISSUE_STATUSES =
+            Issue.STATUSES.stream().filter(s -> !Issue.STATUS_CLOSED.equals(s) && !Issue.STATUS_RESOLVED.equals(s))
+                    .collect(Collectors.toList());
 
     public GraphqlCheckRunProvider(Clock clock,
                                    GithubApplicationAuthenticationProvider githubApplicationAuthenticationProvider,
@@ -224,7 +229,9 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
         return issues.stream()
                 .limit(50)
                 .filter(i -> i.getComponent().getReportAttributes().getScmPath().isPresent())
-                .filter(i -> i.getComponent().getType() == Component.Type.FILE).map(componentIssue -> {
+                .filter(i -> i.getComponent().getType() == Component.Type.FILE)
+                .filter(i -> i.getIssue().resolution() == null)
+                .filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().status())).map(componentIssue -> {
             InputObject<Object> issueLocation = graphqlProvider.createInputObject()
                     .put("startLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0))
                     .put("endLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0) + 1)

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
@@ -34,6 +34,7 @@ import io.aexp.nodes.graphql.InputObject;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.issue.Issue;
 import org.sonar.api.platform.Server;
 import org.sonar.api.rule.Severity;
 import org.sonar.ce.task.projectanalysis.component.Component;
@@ -147,6 +148,8 @@ public class GraphqlCheckRunProviderTest {
 
         DefaultIssue defaultIssue = mock(DefaultIssue.class);
         when(defaultIssue.severity()).thenReturn("dummy");
+        when(defaultIssue.status()).thenReturn(Issue.STATUS_OPEN);
+        when(defaultIssue.resolution()).thenReturn(null);
 
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue.getIssue()).thenReturn(defaultIssue);
@@ -240,6 +243,8 @@ public class GraphqlCheckRunProviderTest {
         when(issue1.getLine()).thenReturn(2);
         when(issue1.getMessage()).thenReturn(messageInput[0]);
         when(issue1.severity()).thenReturn(Severity.INFO);
+        when(issue1.status()).thenReturn(Issue.STATUS_OPEN);
+        when(issue1.resolution()).thenReturn(null);
 
         ReportAttributes reportAttributes = mock(ReportAttributes.class);
         when(reportAttributes.getScmPath()).thenReturn(Optional.of("path/to.file"));
@@ -254,6 +259,8 @@ public class GraphqlCheckRunProviderTest {
         DefaultIssue issue2 = mock(DefaultIssue.class);
         when(issue2.getLine()).thenReturn(null);
         when(issue2.getMessage()).thenReturn(messageInput[1]);
+        when(issue2.status()).thenReturn(Issue.STATUS_OPEN);
+        when(issue2.resolution()).thenReturn(null);
 
         PostAnalysisIssueVisitor.ComponentIssue componentIssue2 = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue2.getComponent()).thenReturn(component1);
@@ -270,6 +277,8 @@ public class GraphqlCheckRunProviderTest {
         when(issue3.getLine()).thenReturn(9);
         when(issue3.severity()).thenReturn(Severity.CRITICAL);
         when(issue3.getMessage()).thenReturn(messageInput[2]);
+        when(issue3.status()).thenReturn(Issue.STATUS_OPEN);
+        when(issue3.resolution()).thenReturn(null);
 
         PostAnalysisIssueVisitor.ComponentIssue componentIssue3 = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue3.getComponent()).thenReturn(component2);
@@ -285,6 +294,8 @@ public class GraphqlCheckRunProviderTest {
         when(issue4.getLine()).thenReturn(2);
         when(issue4.severity()).thenReturn(Severity.CRITICAL);
         when(issue4.getMessage()).thenReturn(messageInput[3]);
+        when(issue4.status()).thenReturn(Issue.STATUS_OPEN);
+        when(issue4.resolution()).thenReturn(null);
 
         PostAnalysisIssueVisitor.ComponentIssue componentIssue4 = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue4.getComponent()).thenReturn(component3);
@@ -294,6 +305,8 @@ public class GraphqlCheckRunProviderTest {
         when(issue5.getLine()).thenReturn(1999);
         when(issue5.severity()).thenReturn(Severity.MAJOR);
         when(issue5.getMessage()).thenReturn(messageInput[4]);
+        when(issue5.status()).thenReturn(Issue.STATUS_OPEN);
+        when(issue5.resolution()).thenReturn(null);
 
         PostAnalysisIssueVisitor.ComponentIssue componentIssue5 = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue5.getComponent()).thenReturn(component2);
@@ -303,6 +316,8 @@ public class GraphqlCheckRunProviderTest {
         when(issue6.getLine()).thenReturn(42);
         when(issue6.severity()).thenReturn(Severity.MINOR);
         when(issue6.getMessage()).thenReturn(messageInput[5]);
+        when(issue6.status()).thenReturn(Issue.STATUS_OPEN);
+        when(issue6.resolution()).thenReturn(null);
 
         PostAnalysisIssueVisitor.ComponentIssue componentIssue6 = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue6.getComponent()).thenReturn(component2);
@@ -312,14 +327,26 @@ public class GraphqlCheckRunProviderTest {
         when(issue7.getLine()).thenReturn(42);
         when(issue7.severity()).thenReturn(Severity.MINOR);
         when(issue7.getMessage()).thenReturn(messageInput[6]);
+        when(issue7.status()).thenReturn(Issue.STATUS_OPEN);
+        when(issue7.resolution()).thenReturn(null);
 
         PostAnalysisIssueVisitor.ComponentIssue componentIssue7 = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue7.getComponent()).thenReturn(component2);
         when(componentIssue7.getIssue()).thenReturn(issue7);
 
+        DefaultIssue issue8 = mock(DefaultIssue.class);
+        when(issue8.getLine()).thenReturn(42);
+        when(issue8.severity()).thenReturn(Severity.MINOR);
+        when(issue8.status()).thenReturn(Issue.STATUS_RESOLVED);
+        when(issue8.resolution()).thenReturn(Issue.RESOLUTION_FIXED);
+
+        PostAnalysisIssueVisitor.ComponentIssue componentIssue8 = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
+        when(componentIssue8.getComponent()).thenReturn(component2);
+        when(componentIssue8.getIssue()).thenReturn(issue8);
+
         List<PostAnalysisIssueVisitor.ComponentIssue> issueList =
                 Arrays.asList(componentIssue1, componentIssue2, componentIssue3, componentIssue4, componentIssue5,
-                              componentIssue6, componentIssue7);
+                              componentIssue6, componentIssue7, componentIssue8);
         PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
         when(postAnalysisIssueVisitor.getIssues()).thenReturn(issueList);
 
@@ -418,7 +445,8 @@ public class GraphqlCheckRunProviderTest {
         int position = 0;
         for (int i = 0; i < issueList.size(); i++) {
             if (issueList.get(i).getComponent().getType() != Component.Type.FILE ||
-                !issueList.get(i).getComponent().getReportAttributes().getScmPath().isPresent()) {
+                !issueList.get(i).getComponent().getReportAttributes().getScmPath().isPresent() ||
+                issueList.get(i).getIssue().resolution() != null) {
                 continue;
             }
             int line = (null == issueList.get(i).getIssue().getLine() ? 0 : issueList.get(i).getIssue().getLine());
@@ -485,6 +513,8 @@ public class GraphqlCheckRunProviderTest {
                     DefaultIssue defaultIssue = mock(DefaultIssue.class);
                     when(defaultIssue.severity()).thenReturn(Severity.INFO);
                     when(defaultIssue.getMessage()).thenReturn("message");
+                    when(defaultIssue.status()).thenReturn(Issue.STATUS_OPEN);
+                    when(defaultIssue.resolution()).thenReturn(null);
                     return defaultIssue;
                 })
                 .map(i -> {


### PR DESCRIPTION
Fix proposal for https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/190

Only decorate with unresolved and non closed issues on Github pull requests.
Currently, fixed issues are still displayed on line 0 of the file, although it is correctly marked as fixed in Sonarqube