### PR TITLE
BitBucket decoration fix

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketServerPullRequestDecorator.java
@@ -79,9 +79,9 @@ public class BitbucketServerPullRequestDecorator implements PullRequestBuildStat
                 LOGGER.warn("Your Bitbucket instances does not support the Code Insights API.");
                 return DEFAULT_DECORATION_RESULT;
             }
-            String project = projectAlmSettingDto.getAlmSlug();
+            String project = projectAlmSettingDto.getAlmRepo();
 
-            String repo = projectAlmSettingDto.getAlmRepo();
+            String repo = projectAlmSettingDto.getAlmSlug();
             client.createReport(project, repo,
                     analysisDetails.getCommitSha(),
                     toReport(analysisDetails),

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClient.java
@@ -93,7 +93,7 @@ public class BitbucketClient {
     public void deleteAnnotations(String project, String repository, String commit, AlmSettingDto almSettingDto) throws IOException {
         Request req = new Request.Builder()
                 .delete()
-                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", almSettingDto, project, repository, commit, REPORT_KEY))
+                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", almSettingDto.getUrl(), project, repository, commit, REPORT_KEY))
                 .build();
         try (Response response = getClient(almSettingDto).newCall(req).execute()) {
             validate(response);
@@ -118,6 +118,7 @@ public class BitbucketClient {
     }
 
     private void validate(Response response) throws IOException {
+        LOGGER.debug(format("Validate response %s", response));
         if (!response.isSuccessful()) {
             ErrorResponse errors = null;
             if (response.body() != null) {

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -63,8 +63,8 @@ public class BitbucketPullRequestDecoratorTest {
 
     @Before
     public void setUp() {
-        when(projectAlmSettingDto.getAlmSlug()).thenReturn(PROJECT);
-        when(projectAlmSettingDto.getAlmRepo()).thenReturn(REPO);
+        when(projectAlmSettingDto.getAlmRepo()).thenReturn(PROJECT);
+        when(projectAlmSettingDto.getAlmSlug()).thenReturn(REPO);
     }
 
     @Test


### PR DESCRIPTION
Below are couple of fixes of BitBucket decoration in sq-8_2-support branch

- replace .getAlmRepo() and getAlmSlug() calls (to get correct parameters order in "insights/1.0/projects/%s/repos/%s/" templates)
- fix almSettingDto.getUrl() call (missed method)
- add debug logging (well, for debug)