### PR TITLE
Fix #189 - Annotation on wrong line

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
@@ -227,7 +227,7 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
                 .filter(i -> i.getComponent().getType() == Component.Type.FILE).map(componentIssue -> {
             InputObject<Object> issueLocation = graphqlProvider.createInputObject()
                     .put("startLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0))
-                    .put("endLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0) + 1)
+                    .put("endLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0))
                     .build();
             return graphqlProvider.createInputObject()
                     .put("path", componentIssue.getComponent().getReportAttributes().getScmPath().get())

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
@@ -423,7 +423,7 @@ public class GraphqlCheckRunProviderTest {
             }
             int line = (null == issueList.get(i).getIssue().getLine() ? 0 : issueList.get(i).getIssue().getLine());
             verify(inputObjectBuilders.get(position)).put(eq("startLine"), eq(line));
-            verify(inputObjectBuilders.get(position)).put(eq("endLine"), eq(line + 1));
+            verify(inputObjectBuilders.get(position)).put(eq("endLine"), eq(line));
             verify(inputObjectBuilders.get(position)).build();
             position++;
 


### PR DESCRIPTION
Fix proposal for https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/189

On Github PR decoration, annotation for single line issues are reported on the wrong line, because end line of the annotated error is incremented by one.