### PR TITLE
[GITLAB] Add code to reference project configuration for pull request decoration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '8.1.0.31237'
+def sonarqubeVersion = '8.2.0.32929'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -32,6 +32,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response.Note;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response.User;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -102,10 +103,11 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
         String revision = analysis.getCommitSha();
 
         try {
-            final String apiURL = analysis.getScannerProperty(PULLREQUEST_GITLAB_INSTANCE_URL).orElseThrow(
-                    () -> new IllegalStateException(String.format(
+            final String apiURL = Optional.ofNullable(StringUtils.stripToNull(almSettingDto.getUrl()))
+                .orElse(analysis.getScannerProperty(PULLREQUEST_GITLAB_INSTANCE_URL)
+                .orElseThrow(() -> new IllegalStateException(String.format(
                             "Could not decorate Gitlab merge request. '%s' has not been set in scanner properties",
-                            PULLREQUEST_GITLAB_INSTANCE_URL)));
+                            PULLREQUEST_GITLAB_INSTANCE_URL))));
             final String apiToken = almSettingDto.getPersonalAccessToken();
             final String projectId = analysis.getScannerProperty(PULLREQUEST_GITLAB_PROJECT_ID).orElseThrow(
                     () -> new IllegalStateException(String.format(

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
@@ -23,15 +23,18 @@ import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.ProjectConfiguration;
 
 import java.util.Optional;
 
 public class ScannerPullRequestPropertySensor implements Sensor {
 
+    private final ProjectConfiguration projectConfiguration;
     private final System2 system2;
 
-    public ScannerPullRequestPropertySensor(System2 system2) {
+    public ScannerPullRequestPropertySensor(ProjectConfiguration projectConfiguration, System2 system2) {
         super();
+        this.projectConfiguration = projectConfiguration;
         this.system2 = system2;
     }
 
@@ -42,6 +45,15 @@ public class ScannerPullRequestPropertySensor implements Sensor {
 
     @Override
     public void execute(SensorContext sensorContext) {
+        projectConfiguration.get(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL).ifPresent(v -> sensorContext
+                .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL, v));
+        projectConfiguration.get(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID).ifPresent(v -> sensorContext
+                .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID, v));
+        projectConfiguration.get(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL).ifPresent(v -> sensorContext
+                .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, v));
+        projectConfiguration.get(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID).ifPresent(v -> sensorContext
+                .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, v));
+
         if (Boolean.parseBoolean(system2.envVariable("GITLAB_CI"))) {
             Optional.ofNullable(system2.envVariable("CI_API_V4_URL")).ifPresent(v -> sensorContext
                     .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL, v));

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/DeleteBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/DeleteBindingAction.java
@@ -23,7 +23,7 @@ import org.sonar.api.server.ws.Response;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -43,7 +43,7 @@ public class DeleteBindingAction extends ProjectWsAction {
     }
 
     @Override
-    protected void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession) {
+    protected void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
         dbClient.projectAlmSettingDao().deleteByProject(dbSession, project);
         dbSession.commit();
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/GetBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/GetBindingAction.java
@@ -29,7 +29,7 @@ import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.exceptions.NotFoundException;
 import org.sonar.server.user.UserSession;
@@ -59,7 +59,7 @@ public class GetBindingAction extends ProjectWsAction {
     }
 
     @Override
-    protected void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession) {
+    protected void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
         ProjectAlmSettingDto projectAlmSetting = dbClient.projectAlmSettingDao().selectByProject(dbSession, project)
             .orElseThrow(() -> new NotFoundException(
                 format("Project '%s' is not bound to any ALM", project.getKey())));

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListAction.java
@@ -29,7 +29,7 @@ import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.alm.setting.AlmSettingDto;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 import org.sonar.server.ws.WsUtils;
@@ -59,7 +59,7 @@ public class ListAction extends ProjectWsAction {
     }
 
     @Override
-    protected void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession) {
+    protected void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
         List<AlmSettingDto> settings = dbClient.almSettingDao().selectAll(dbSession);
         List<AlmSetting> wsAlmSettings = settings.stream().map(almSetting -> {
             AlmSetting.Builder almSettingBuilder = AlmSetting.newBuilder().setKey(almSetting.getKey())

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsAction.java
@@ -32,6 +32,7 @@ import org.sonarqube.ws.AlmSettings.AlmSettingGithub;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
@@ -115,8 +116,12 @@ public class ListDefinitionsAction extends AlmSettingsWsAction {
     }
 
     private static AlmSettings.AlmSettingGitlab toGitlab(AlmSettingDto settingDto) {
-        return AlmSettings.AlmSettingGitlab.newBuilder()
+        AlmSettings.AlmSettingGitlab.Builder almSettingBuilder =  AlmSettings.AlmSettingGitlab.newBuilder()
             .setKey(settingDto.getKey())
-            .setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(), "Personal Access Token cannot be null for Gitlab ALM setting")).build();
+            .setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(), "Personal Access Token cannot be null for Gitlab ALM setting"));
+
+        Optional.ofNullable(settingDto.getUrl()).ifPresent(almSettingBuilder::setUrl);
+
+        return almSettingBuilder.build();
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ProjectWsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ProjectWsAction.java
@@ -7,7 +7,7 @@ import org.sonar.api.server.ws.Response;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -43,12 +43,12 @@ public abstract class ProjectWsAction extends AlmSettingsWsAction {
     public void handle(Request request, Response response) {
         String projectKey = request.mandatoryParam(PROJECT_PARAMETER);
         try (DbSession dbSession = dbClient.openSession(false)) {
-            ComponentDto project = componentFinder.getByKey(dbSession, projectKey);
-            userSession.checkComponentPermission(ADMIN, project);
+            ProjectDto project = componentFinder.getProjectByKey(dbSession, projectKey);
+            userSession.checkProjectPermission(ADMIN, project);
 
             handleProjectRequest(project, request, response, dbSession);
         }
     }
 
-    protected abstract void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession);
+    protected abstract void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession);
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingAction.java
@@ -25,7 +25,7 @@ import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -37,15 +37,17 @@ public abstract class SetBindingAction extends ProjectWsAction {
         super(actionName, dbClient, componentFinder, userSession);
     }
 
+    @Override
     protected void configureAction(WebService.NewAction action) {
         action.createParam(ALM_SETTING_PARAMETER).setRequired(true);
     }
 
-    protected void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession) {
+    @Override
+    protected void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
         String almSetting = request.mandatoryParam(ALM_SETTING_PARAMETER);
 
         AlmSettingDto almSettingDto = getAlmSetting(dbSession, almSetting);
-        getDbClient().projectAlmSettingDao().insertOrUpdate(dbSession, createProjectAlmSettingDto(project.uuid(), almSettingDto.getUuid(), request));
+        getDbClient().projectAlmSettingDao().insertOrUpdate(dbSession, createProjectAlmSettingDto(project.getUuid(), almSettingDto.getUuid(), request));
         dbSession.commit();
 
         response.noContent();

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/CreateGitlabAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/CreateGitlabAction.java
@@ -29,6 +29,7 @@ import static org.sonar.db.alm.setting.ALM.GITLAB;
 
 public class CreateGitlabAction extends CreateAction {
 
+    private static final String URL_PARAMETER = "url";
     private static final String PERSONAL_ACCESS_TOKEN_PARAMETER = "personalAccessToken";
 
     public CreateGitlabAction(DbClient dbClient, UserSession userSession) {
@@ -37,6 +38,7 @@ public class CreateGitlabAction extends CreateAction {
 
     @Override
     public void configureAction(WebService.NewAction action) {
+        action.createParam(URL_PARAMETER).setMaximumLength(2000);
         action.createParam(PERSONAL_ACCESS_TOKEN_PARAMETER).setRequired(true).setMaximumLength(2000);
     }
 
@@ -45,6 +47,7 @@ public class CreateGitlabAction extends CreateAction {
         return new AlmSettingDto()
                 .setAlm(GITLAB)
                 .setKey(key)
+                .setUrl(request.param(URL_PARAMETER))
                 .setPersonalAccessToken(request.mandatoryParam(PERSONAL_ACCESS_TOKEN_PARAMETER));
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/UpdateGitlabAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/UpdateGitlabAction.java
@@ -27,6 +27,7 @@ import org.sonar.server.user.UserSession;
 
 public class UpdateGitlabAction extends UpdateAction {
 
+    private static final String URL_PARAMETER = "url";
     private static final String PERSONAL_ACCESS_TOKEN_PARAMETER = "personalAccessToken";
 
     public UpdateGitlabAction(DbClient dbClient, UserSession userSession) {
@@ -35,12 +36,14 @@ public class UpdateGitlabAction extends UpdateAction {
 
     @Override
     protected void configureAction(WebService.NewAction action) {
+        action.createParam(URL_PARAMETER).setMaximumLength(2000);
         action.createParam(PERSONAL_ACCESS_TOKEN_PARAMETER).setRequired(true).setMaximumLength(2000);
     }
 
     @Override
     protected AlmSettingDto updateAlmSettingsDto(AlmSettingDto almSettingDto, Request request) {
-        return almSettingDto.setPersonalAccessToken(request.mandatoryParam(PERSONAL_ACCESS_TOKEN_PARAMETER));
+        return almSettingDto.setPersonalAccessToken(request.mandatoryParam(PERSONAL_ACCESS_TOKEN_PARAMETER))
+            .setUrl(request.param(URL_PARAMETER));
     }
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/DeleteBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/DeleteBindingActionTest.java
@@ -14,7 +14,7 @@ import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.alm.setting.AlmSettingDao;
 import org.sonar.db.alm.setting.ProjectAlmSettingDao;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -58,9 +58,9 @@ public class DeleteBindingActionTest {
 
         UserSession userSession = mock(UserSession.class);
 
-        ComponentDto componentDto = mock(ComponentDto.class);
+        ProjectDto componentDto = mock(ProjectDto.class);
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        when(componentFinder.getByKey(eq(dbSession), eq("projectKey"))).thenReturn(componentDto);
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("projectKey"))).thenReturn(componentDto);
 
         DeleteBindingAction testCase = new DeleteBindingAction(dbClient, userSession, componentFinder);
 
@@ -73,7 +73,7 @@ public class DeleteBindingActionTest {
         verify(dbSession).commit();
         verify(projectAlmSettingDao).deleteByProject(eq(dbSession), eq(componentDto));
         verify(response).noContent();
-        verify(userSession).checkComponentPermission("admin", componentDto);
+        verify(userSession).checkProjectPermission("admin", componentDto);
 
     }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/GetBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/GetBindingActionTest.java
@@ -25,7 +25,7 @@ import org.sonar.db.alm.setting.AlmSettingDao;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDao;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.exceptions.NotFoundException;
 import org.sonar.server.user.UserSession;
@@ -73,18 +73,18 @@ public class GetBindingActionTest {
         when(almSettingDto.getKey()).thenReturn("key");
         when(almSettingDto.getUrl()).thenReturn("url");
         when(dbClient.almSettingDao()).thenReturn(almSettingDao);
-        ComponentDto componentDto = mock(ComponentDto.class);
+        ProjectDto projectDto = mock(ProjectDto.class);
         ProjectAlmSettingDao projectAlmSettingDao = mock(ProjectAlmSettingDao.class);
         when(dbClient.projectAlmSettingDao()).thenReturn(projectAlmSettingDao);
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        when(componentDto.uuid()).thenReturn("projectUuid");
-        when(componentFinder.getByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
+        when(projectDto.getKey()).thenReturn("projectUuid");
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("project"))).thenReturn(projectDto);
         UserSession userSession = mock(UserSession.class);
         ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
         when(projectAlmSettingDto.getAlmSettingUuid()).thenReturn("almSettingUuid");
         when(projectAlmSettingDto.getAlmRepo()).thenReturn("repository");
         when(projectAlmSettingDto.getAlmSlug()).thenReturn("slug");
-        when(projectAlmSettingDao.selectByProject(eq(dbSession), eq(componentDto))).thenReturn(Optional.of(projectAlmSettingDto));
+        when(projectAlmSettingDao.selectByProject(eq(dbSession), eq(projectDto))).thenReturn(Optional.of(projectAlmSettingDto));
         ProtoBufWriter protoBufWriter = mock(ProtoBufWriter.class);
 
         GetBindingAction testCase = new GetBindingAction(dbClient, componentFinder, userSession, protoBufWriter);
@@ -122,12 +122,12 @@ public class GetBindingActionTest {
         when(projectAlmSettingDao.selectByProject(eq(dbSession), eq("projectUuid"))).thenReturn(Optional.empty());
         when(dbClient.projectAlmSettingDao()).thenReturn(projectAlmSettingDao);
 
-        ComponentDto componentDto = mock(ComponentDto.class);
-        when(componentDto.getKey()).thenReturn("projectKey");
+        ProjectDto projectDto = mock(ProjectDto.class);
+        when(projectDto.getKey()).thenReturn("project");
 
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        when(componentDto.uuid()).thenReturn("projectUuid");
-        when(componentFinder.getByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
+        when(projectDto.getKey()).thenReturn("project");
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("project"))).thenReturn(projectDto);
         UserSession userSession = mock(UserSession.class);
 
         GetBindingAction testCase = new GetBindingAction(dbClient, componentFinder, userSession);
@@ -139,7 +139,7 @@ public class GetBindingActionTest {
         when(request.mandatoryParam("project")).thenReturn("project");
         when(request.getMediaType()).thenReturn("dummy");
 
-        assertThatThrownBy(() -> testCase.handle(request, response)).isInstanceOf(NotFoundException.class).hasMessage("Project 'projectKey' is not bound to any ALM");
+        assertThatThrownBy(() -> testCase.handle(request, response)).isInstanceOf(NotFoundException.class).hasMessage("Project 'project' is not bound to any ALM");
     }
 
     @Test
@@ -151,10 +151,10 @@ public class GetBindingActionTest {
         ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
         when(projectAlmSettingDto.getAlmSettingUuid()).thenReturn("settingUuid");
 
-        ComponentDto componentDto = mock(ComponentDto.class);
-        when(componentDto.getKey()).thenReturn("projectKey");
+        ProjectDto projectDto = mock(ProjectDto.class);
+        when(projectDto.getKey()).thenReturn("project");
 
-        when(projectAlmSettingDao.selectByProject(eq(dbSession), eq(componentDto))).thenReturn(Optional.of(projectAlmSettingDto));
+        when(projectAlmSettingDao.selectByProject(eq(dbSession), eq(projectDto))).thenReturn(Optional.of(projectAlmSettingDto));
         when(dbClient.projectAlmSettingDao()).thenReturn(projectAlmSettingDao);
 
         AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
@@ -162,8 +162,8 @@ public class GetBindingActionTest {
         when(almSettingDao.selectByKey(eq(dbSession), eq("settingUuid"))).thenReturn(Optional.empty());
 
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        when(componentDto.uuid()).thenReturn("projectUuid");
-        when(componentFinder.getByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
+        when(projectDto.getKey()).thenReturn("projectUuid");
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("project"))).thenReturn(projectDto);
         UserSession userSession = mock(UserSession.class);
 
         GetBindingAction testCase = new GetBindingAction(dbClient, componentFinder, userSession);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsActionTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -110,6 +111,49 @@ public class ListDefinitionsActionTest {
                 .build())
             .addGitlab(AlmSettings.AlmSettingGitlab.newBuilder()
                 .setKey("gitlabKey")
+                .setPersonalAccessToken("gitlabPersonalAccessToken")
+                .build())
+            .build();
+
+        assertThat(message).isInstanceOf(AlmSettings.ListDefinitionsWsResponse.class).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    public void testHandleWithGitlabUrl() {
+        DbClient dbClient = mock(DbClient.class);
+        DbSession dbSession = mock(DbSession.class);
+        when(dbClient.openSession(eq(false))).thenReturn(dbSession);
+        AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
+
+        AlmSettingDto gitlabAlmSettingDto = mock(AlmSettingDto.class);
+        when(gitlabAlmSettingDto.getAlm()).thenReturn(ALM.GITLAB);
+        when(gitlabAlmSettingDto.getKey()).thenReturn("gitlabKey");
+        when(gitlabAlmSettingDto.getUrl()).thenReturn("url");
+        when(gitlabAlmSettingDto.getPersonalAccessToken()).thenReturn("gitlabPersonalAccessToken");
+        when(gitlabAlmSettingDto.getUrl()).thenReturn("url");
+
+        when(almSettingDao.selectAll(eq(dbSession))).thenReturn(Collections.singletonList(gitlabAlmSettingDto));
+        when(dbClient.almSettingDao()).thenReturn(almSettingDao);
+
+        UserSession userSession = mock(UserSession.class);
+
+        ProtoBufWriter protoBufWriter = mock(ProtoBufWriter.class);
+
+        ListDefinitionsAction testCase = new ListDefinitionsAction(dbClient, userSession, protoBufWriter);
+
+        Request request = mock(Request.class, Mockito.RETURNS_DEEP_STUBS);
+        Response response = mock(Response.class, Mockito.RETURNS_DEEP_STUBS);
+
+        testCase.handle(request, response);
+
+        ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(protoBufWriter).write(messageArgumentCaptor.capture(), eq(request), eq(response));
+        Message message = messageArgumentCaptor.getValue();
+
+        AlmSettings.ListDefinitionsWsResponse expectedResponse = AlmSettings.ListDefinitionsWsResponse.newBuilder()
+           .addGitlab(AlmSettings.AlmSettingGitlab.newBuilder()
+                .setKey("gitlabKey")
+                .setUrl("url")
                 .setPersonalAccessToken("gitlabPersonalAccessToken")
                 .build())
             .build();

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingActionTest.java
@@ -22,6 +22,7 @@ import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDao;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -74,9 +75,9 @@ public class SetBindingActionTest {
         ProjectAlmSettingDao projectAlmSettingDao = mock(ProjectAlmSettingDao.class);
         when(dbClient.projectAlmSettingDao()).thenReturn(projectAlmSettingDao);
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        ComponentDto componentDto = mock(ComponentDto.class);
-        when(componentDto.uuid()).thenReturn("projectUuid");
-        when(componentFinder.getByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
+        ProjectDto componentDto = mock(ProjectDto.class);
+        when(componentDto.getUuid()).thenReturn("projectUuid");
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
         UserSession userSession = mock(UserSession.class);
         ThreadLocal<WebService.NewAction> capturedAction = new ThreadLocal<>();
         ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/CreateGitlabActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/CreateGitlabActionTest.java
@@ -30,11 +30,17 @@ public class CreateGitlabActionTest {
         when(personalAccessTokenParameter.setRequired(anyBoolean())).thenReturn(personalAccessTokenParameter);
         when(newAction.createParam(eq("personalAccessToken"))).thenReturn(personalAccessTokenParameter);
 
+        WebService.NewParam urlParameter = mock(WebService.NewParam.class);
+        when(urlParameter.setMaximumLength(any(Integer.class))).thenReturn(urlParameter);
+        when(newAction.createParam(eq("url"))).thenReturn(urlParameter);
+
         CreateGitlabAction testCase = new CreateGitlabAction(dbClient, userSession);
         testCase.configureAction(newAction);
 
         verify(personalAccessTokenParameter).setRequired(eq(true));
         verify(personalAccessTokenParameter).setMaximumLength(2000);
+
+        verify(urlParameter).setMaximumLength(2000);
     }
 
     @Test
@@ -49,5 +55,24 @@ public class CreateGitlabActionTest {
         AlmSettingDto result = testCase.createAlmSettingDto("key", request);
 
         assertThat(result).isEqualToComparingFieldByField(new AlmSettingDto().setAlm(ALM.GITLAB).setKey("key").setPersonalAccessToken("personalAccessToken"));
+    }
+
+    @Test
+    public void testCreateAlmSettingDtoWithUrl() {
+        DbClient dbClient = mock(DbClient.class);
+        UserSession userSession = mock(UserSession.class);
+
+        Request request = mock(Request.class);
+        when(request.mandatoryParam(eq("personalAccessToken"))).thenReturn("personalAccessToken");
+        when(request.param(eq("url"))).thenReturn("url");
+
+        CreateGitlabAction testCase = new CreateGitlabAction(dbClient, userSession);
+        AlmSettingDto result = testCase.createAlmSettingDto("key", request);
+
+        assertThat(result).isEqualToComparingFieldByField(new AlmSettingDto()
+            .setAlm(ALM.GITLAB)
+            .setKey("key")
+            .setUrl("url")
+            .setPersonalAccessToken("personalAccessToken"));
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/UpdateGitlabActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/UpdateGitlabActionTest.java
@@ -29,11 +29,17 @@ public class UpdateGitlabActionTest {
         when(personalAccessTokenParameter.setRequired(anyBoolean())).thenReturn(personalAccessTokenParameter);
         when(newAction.createParam(eq("personalAccessToken"))).thenReturn(personalAccessTokenParameter);
 
+        WebService.NewParam urlParameter = mock(WebService.NewParam.class);
+        when(urlParameter.setMaximumLength(any(Integer.class))).thenReturn(urlParameter);
+        when(newAction.createParam(eq("url"))).thenReturn(urlParameter);
+
         UpdateGitlabAction testCase = new UpdateGitlabAction(dbClient, userSession);
         testCase.configureAction(newAction);
 
         verify(personalAccessTokenParameter).setRequired(eq(true));
         verify(personalAccessTokenParameter).setMaximumLength(2000);
+
+        verify(urlParameter).setMaximumLength(2000);
     }
 
     @Test
@@ -48,5 +54,23 @@ public class UpdateGitlabActionTest {
         AlmSettingDto result = testCase.updateAlmSettingsDto(new AlmSettingDto().setKey("originalKey"), request);
 
         assertThat(result).isEqualToComparingFieldByField(new AlmSettingDto().setKey("originalKey").setPersonalAccessToken("personalAccessToken"));
+    }
+
+    @Test
+    public void testUpdateAlmSettingsDtoWithUrl() {
+        DbClient dbClient = mock(DbClient.class);
+        UserSession userSession = mock(UserSession.class);
+
+        Request request = mock(Request.class);
+        when(request.mandatoryParam(eq("personalAccessToken"))).thenReturn("personalAccessToken");
+        when(request.param(eq("url"))).thenReturn("url");
+
+        UpdateGitlabAction testCase = new UpdateGitlabAction(dbClient, userSession);
+        AlmSettingDto result = testCase.updateAlmSettingsDto(new AlmSettingDto().setKey("originalKey").setUrl("url"), request);
+
+        assertThat(result).isEqualToComparingFieldByField(new AlmSettingDto()
+            .setKey("originalKey")
+            .setUrl("url")
+            .setPersonalAccessToken("personalAccessToken"));
     }
 }


### PR DESCRIPTION
Hello, I am running the sonarqube server using the sq-8_2-support branch (I use 8.3.1 but it seems to work). I don't use gitlab CI or maven plugins for scanner, I use raw sonar scanner in jenkins.
However, when I use pull request decorator on gitlab, the properties written in scanner properties (sonar-project.properties) are not received. 

- below properties
sonar.pullrequest.gitlab.instanceUrl=${apiUrl}
sonar.pullrequest.gitlab.projectId=${projectId}
sonar.pullrequest.gitlab.projectUrl=${projectUrl}

- I got the error below
```
java.lang.IllegalStateException: Could not decorate Gitlab merge request. 'sonar.pullrequest.gitlab.instanceUrl' has not been set in scanner properties
        at com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabServerPullRequestDecorator.lambda$decorateQualityGate
        at java.base/java.util.Optional.orElseThrow(Unknown Source)
```
On the other hand, the above variables were recognized normally in the Sonarqube web server.
It seems that ScannerPullRequestPropertySensor class can't receive scanner properties as env properties or system properties. 

So I added the code to find the ProjectConfiguration and insert the properties, and it worked fine. 
I'm using this way.. but If you use it better, it would be nice to show you how. Thanks.