### PR TITLE
Sq 8 2+azure devops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,11 @@ tasks.shadowJar.configure {
     classifier = null
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs << '-Xlint:unchecked'
+    options.deprecation = true
+}
+
 assemble.dependsOn('shadowJar')
 
 pitest {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '8.1.0.31237'
+def sonarqubeVersion = '8.2.0.32929'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
@@ -20,6 +20,7 @@ package com.github.mc1arke.sonarqube.plugin.ce;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestPostAnalysisTask;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.AzureDevOpsServerPullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.BitbucketServerPullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketClient;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.GithubPullRequestDecorator;
@@ -43,7 +44,8 @@ public class CommunityReportAnalysisComponentProvider implements ReportAnalysisC
                              PostAnalysisIssueVisitor.class, GithubPullRequestDecorator.class,
                              GraphqlCheckRunProvider.class, DefaultLinkHeaderReader.class, RestApplicationAuthenticationProvider.class,
                              BitbucketServerPullRequestDecorator.class, BitbucketClient.class,
-                             GitlabServerPullRequestDecorator.class);
+                             GitlabServerPullRequestDecorator.class,
+                             AzureDevOpsServerPullRequestDecorator.class);
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -62,6 +62,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.Map;
 
 public class AnalysisDetails {
 
@@ -119,6 +120,10 @@ public class AnalysisDetails {
 
     public QualityGate.Status getQualityGateStatus() {
         return qualityGate.getStatus();
+    }
+
+    public Map<String,String> getScannerProperties() {
+        return scannerContext.getProperties();
     }
 
     public Optional<String> getScannerProperty(String propertyName) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecorator.java
@@ -1,0 +1,401 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.Comment;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.CommentThread;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.GitStatusContext;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.GitPullRequestStatus;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.CommentThreadResponse;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.enums.CommentThreadStatus;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.mappers.GitStatusStateMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.platform.Server;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonar.ce.task.projectanalysis.scm.ScmInfoRepository;
+import org.sonar.db.alm.setting.ALM;
+import org.sonar.db.alm.setting.AlmSettingDto;
+import org.sonar.db.alm.setting.ProjectAlmSettingDto;
+import org.sonar.db.protobuf.DbIssues;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+
+
+public class AzureDevOpsServerPullRequestDecorator implements PullRequestBuildStatusDecorator {
+
+    private String authorizationHeader;
+    private static final String AZURE_API_VERSION = "?api-version=5.0-preview.1";
+    private static final Logger LOGGER = Loggers.get(AzureDevOpsServerPullRequestDecorator.class);
+
+    private String azureUrl = "";
+    private String baseBranch = "";
+    private String branch = "";
+    private String pullRequestId = "";
+    private String azureRepositoryName = "";
+    private String azureProjectId = "";
+
+    /*private static final List<String> OPEN_ISSUE_STATUSES =
+            Issue.STATUSES.stream().filter(s -> !Issue.STATUS_CLOSED.equals(s) && !Issue.STATUS_RESOLVED.equals(s))
+                    .collect(Collectors.toList());*/
+    // SCANNER PROPERTY
+    public static final String PULLREQUEST_AZUREDEVOPS_INSTANCE_URL = "sonar.pullrequest.vsts.instanceUrl"; // sonar.pullrequest.vsts.instanceUrl=https://dev.azure.com/fabrikam/
+    public static final String PULLREQUEST_AZUREDEVOPS_BASE_BRANCH = "sonar.pullrequest.base";              // sonar.pullrequest.base=master
+    public static final String PULLREQUEST_AZUREDEVOPS_BRANCH = "sonar.pullrequest.branch";                 // sonar.pullrequest.branch=feature/some-feature
+    public static final String PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID = "sonar.pullrequest.key";            // sonar.pullrequest.key=222
+    public static final String PULLREQUEST_AZUREDEVOPS_PROJECT_ID = "sonar.pullrequest.vsts.project";       // sonar.pullrequest.vsts.project=MyProject
+    public static final String PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME = "sonar.pullrequest.vsts.repository";//sonar.pullrequest.vsts.repository=MyReposytory
+    // SONAR URL MASK
+    public static final String SONAR_ISSUE_URL_MASK = "%s/project/issues?id=%s&issues=%s&open=%s&pullRequest=%s"; //http://localhost/project/issues?id=ProjId&issues=AXCuh6CgT2BpyN1RPU03&open=AXCuh6CgT2BpyN1RPU03&pullRequest=8513
+    public static final String SONAR_RULE_URL_MASK = "%s/coding_rules?open=%s&rule_key=%s"; //http://localhost/coding_rules?open=csharpsquid%3AS1135&rule_key=csharpsquid%3AS1135
+
+    private final Server server;
+    private final ScmInfoRepository scmInfoRepository;
+
+    public AzureDevOpsServerPullRequestDecorator(Server server, ScmInfoRepository scmInfoRepository) {
+        super();
+        this.server = server;
+        this.scmInfoRepository = scmInfoRepository;
+    }
+
+    @Override
+    public DecorationResult decorateQualityGateStatus(AnalysisDetails analysisDetails, AlmSettingDto almSettingDto, ProjectAlmSettingDto projectAlmSettingDto) {
+        LOGGER.info("starting to analyze with " + analysisDetails.toString());
+
+        try {
+            azureUrl = analysisDetails.getScannerProperty(PULLREQUEST_AZUREDEVOPS_INSTANCE_URL).orElseThrow(
+                    () -> new IllegalStateException(String.format(
+                            "Could not decorate AzureDevOps pullRequest. '%s' has not been set in scanner properties",
+                            PULLREQUEST_AZUREDEVOPS_INSTANCE_URL)));
+            baseBranch = analysisDetails.getScannerProperty(PULLREQUEST_AZUREDEVOPS_BASE_BRANCH).orElseThrow(
+                    () -> new IllegalStateException(String.format(
+                            "Could not decorate AzureDevOps pullRequest. '%s' has not been set in scanner properties",
+                            PULLREQUEST_AZUREDEVOPS_BASE_BRANCH)));
+            branch = analysisDetails.getScannerProperty(PULLREQUEST_AZUREDEVOPS_BRANCH).orElseThrow(
+                    () -> new IllegalStateException(String.format(
+                            "Could not decorate AzureDevOps pullRequest. '%s' has not been set in scanner properties",
+                            PULLREQUEST_AZUREDEVOPS_BRANCH)));
+            pullRequestId = analysisDetails.getScannerProperty(PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID).orElseThrow(
+                    () -> new IllegalStateException(String.format(
+                            "Could not decorate AzureDevOps pullRequest. '%s' has not been set in scanner properties",
+                            PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID)));
+            azureRepositoryName = analysisDetails.getScannerProperty(PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME).orElseThrow(
+                    () -> new IllegalStateException(String.format(
+                            "Could not decorate AzureDevOps pullRequest. '%s' has not been set in scanner properties",
+                            PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME)));
+            azureProjectId = analysisDetails.getScannerProperty(PULLREQUEST_AZUREDEVOPS_PROJECT_ID).orElseThrow(
+                    () -> new IllegalStateException(String.format(
+                            "Could not decorate AzureDevOps pullRequest. '%s' has not been set in scanner properties",
+                            PULLREQUEST_AZUREDEVOPS_PROJECT_ID)));
+            if (almSettingDto.getPersonalAccessToken() == null) {
+                throw new IllegalStateException("Could not decorate AzureDevOps pullRequest. Access token has not been set");
+            }
+            setAuthorizationHeader(almSettingDto.getPersonalAccessToken());
+
+            LOGGER.trace(String.format("azureUrl is: %s ", azureUrl));
+            LOGGER.trace(String.format("baseBranch is: %s ", baseBranch));
+            LOGGER.trace(String.format("branch is: %s ", branch));
+            LOGGER.trace(String.format("pullRequestId is: %s ", pullRequestId));
+            LOGGER.trace(String.format("azureProjectId is: %s ", azureProjectId));
+            LOGGER.trace(String.format("azureRepositoryName is: %s ", azureRepositoryName));
+
+            sendPost(
+                    getStatusApiUrl(),
+                    getGitPullRequestStatus(analysisDetails),
+                    "Status set successfully"
+            );
+
+            List<PostAnalysisIssueVisitor.ComponentIssue> openIssues = analysisDetails.getPostAnalysisIssueVisitor()
+                    .getIssues();
+                    /*.stream()
+                    .filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().getStatus()))
+                    .collect(Collectors.toList());*/
+            LOGGER.trace(String.format("Analyze issue count: %s ", openIssues.size()));
+
+            ArrayList<CommentThread> azureCommentThreads = new ArrayList<CommentThread>(Arrays.asList(sendGet(getThreadApiUrl(), CommentThreadResponse.class).getValue()));
+            LOGGER.trace(String.format("Azure commentThreads count: %s ", azureCommentThreads.size()));
+            azureCommentThreads.removeIf(x -> x.getThreadContext() == null || x.isDeleted());
+            LOGGER.trace(String.format("Azure commentThreads AFTER REMOVE count: %s ", azureCommentThreads.size()));
+
+            for (PostAnalysisIssueVisitor.ComponentIssue issue : openIssues) {
+                String filePath = analysisDetails.getSCMPathForIssue(issue).orElse(null);
+                Integer line = issue.getIssue().getLine();
+                if (filePath != null) {
+                    try {
+                        filePath = "/" + filePath;
+                        LOGGER.trace(String.format("ISSUE: authorLogin: %s ", issue.getIssue().authorLogin()));
+                        LOGGER.trace(String.format("ISSUE: key: %s ", issue.getIssue().key()));
+                        LOGGER.trace(String.format("ISSUE: type: %s ", issue.getIssue().type().toString()));
+                        LOGGER.trace(String.format("ISSUE: severity: %s ", issue.getIssue().severity()));
+                        LOGGER.trace(String.format("ISSUE: componentKey: %s ", issue.getIssue().componentKey()));
+                        LOGGER.trace(String.format("ISSUE: getLocations: %s ", Objects.requireNonNull(issue.getIssue().getLocations()).toString()));
+                        LOGGER.trace(String.format("ISSUE: getRuleKey: %s ", issue.getIssue().getRuleKey()));
+                        LOGGER.trace(String.format("COMPONENT: getDescription: %s ", issue.getComponent().getDescription()));
+                        DbIssues.Locations locate = Objects.requireNonNull(issue.getIssue().getLocations());
+                        boolean isExitsThread = false;
+                        for (CommentThread azureThread : azureCommentThreads) {
+                            LOGGER.trace(String.format("azureFilePath: %s", azureThread.getThreadContext().getFilePath()));
+                            LOGGER.trace(String.format("filePath: %s (%s)", filePath, azureThread.getThreadContext().getFilePath().equals(filePath)));
+                            LOGGER.trace(String.format("azureLine: %d", azureThread.getThreadContext().getRightFileStart().getLine()));
+                            LOGGER.trace(String.format("line: %d (%s)", line, azureThread.getThreadContext().getRightFileStart().getLine() == locate.getTextRange().getEndLine()));
+
+                            if (azureThread.getThreadContext().getFilePath().equals(filePath)
+                                    && azureThread.getComments()
+                                    .stream()
+                                    .filter(c -> c.getContent().contains(issue.getIssue().key()))
+                                    .count() > 0 ) {
+
+                                if(!issue.getIssue().getStatus().equals(Issue.STATUS_OPEN)
+                                        && azureThread.getStatus().equals(CommentThreadStatus.ACTIVE)) {
+                                    Comment comment = new Comment("Closed in SonarQube");
+                                    LOGGER.info("Issue closed in Sonar. try close in Azure");
+                                    sendPost(
+                                            azureThread.getLinks().getSelf().getHref() + "/comments" + AZURE_API_VERSION,
+                                            new ObjectMapper().writeValueAsString(comment),
+                                            "Comment added success"
+                                    );
+                                    sendPatch(
+                                            azureThread.getLinks().getSelf().getHref() + AZURE_API_VERSION,
+                                            "{\"status\":\"closed\"}"
+                                    );
+                                }
+                                isExitsThread = true;
+                                break;
+                            }
+                        }
+                        if (!issue.getIssue().getStatus().equals(Issue.STATUS_OPEN)) {
+                            LOGGER.info(String.format("SKIPPED ISSUE: Issue status is %s", issue.getIssue().getStatus()));
+                            continue;
+                        }
+
+                        if (isExitsThread || !issue.getIssue().getStatus().equals(Issue.STATUS_OPEN)) {
+                            LOGGER.info(String.format("SKIPPED ISSUE: %s"
+                                            + System.lineSeparator()
+                                            + "File: %s"
+                                            + System.lineSeparator()
+                                            + "Line: %d"
+                                            + System.lineSeparator()
+                                            + "Issue is already exist in azure",
+                                    issue.getIssue().getMessage(),
+                                    filePath,
+                                    line));
+                            continue;
+                        }
+
+                        String message = String.format("%s: %s ([rule](%s))" + System.lineSeparator()
+                                        + System.lineSeparator()
+                                        + "[See in SonarQube](%s)",
+                                issue.getIssue().type().name(),
+                                issue.getIssue().getMessage(),
+                                getRuleUrlWithRuleKey(issue.getIssue().getRuleKey().toString()),
+                                getIssueUrl(
+                                        analysisDetails.getAnalysisProjectKey(),
+                                        issue.getIssue().key(),
+                                        pullRequestId)
+                        );
+
+                        CommentThread thread = new CommentThread(filePath, locate, message);
+                        LOGGER.info(String.format("Creating thread: %s ", new ObjectMapper().writeValueAsString(thread)));
+                        sendPost(
+                                getThreadApiUrl(),
+                                new ObjectMapper().writeValueAsString(thread),
+                                "Thread created successfully"
+                        );
+                    } catch (Exception e) {
+                        LOGGER.error(e.toString());
+                        throw new IllegalStateException(e); // Uncomment to run unit tests
+                    }
+                }
+            }
+            return DecorationResult.builder().withPullRequestUrl(getPullRequestUrl()).build();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not decorate Pull Request on AzureDevOps Server", ex);
+        }
+    }
+
+    private void setAuthorizationHeader(String apiToken) {
+        String encodeBytes = Base64.getEncoder().encodeToString((":" + apiToken).getBytes());
+        authorizationHeader = "Basic " + encodeBytes;
+    }
+
+    public String getIssueUrl(String sonarProjectKey, String issueKey, String pullRequestId) throws IOException {
+        //ISSUE http://localhost/project/issues?id=ProjId&issues=AXCuh6CgT2BpyN1RPU03&open=AXCuh6CgT2BpyN1RPU03&pullRequest=8513
+        return String.format(SONAR_ISSUE_URL_MASK,
+                server.getPublicRootUrl(),
+                URLEncoder.encode(sonarProjectKey, StandardCharsets.UTF_8.name()),
+                URLEncoder.encode(issueKey, StandardCharsets.UTF_8.name()),
+                URLEncoder.encode(issueKey, StandardCharsets.UTF_8.name()),
+                URLEncoder.encode(pullRequestId, StandardCharsets.UTF_8.name())
+        );
+    }
+
+    public String getRuleUrlWithRuleKey(String ruleKey) throws IOException {
+        //RULE http://localhost/coding_rules?open=csharpsquid%3AS1135&rule_key=csharpsquid%3AS1135
+        return String.format(SONAR_RULE_URL_MASK,
+                server.getPublicRootUrl(),
+                URLEncoder.encode(ruleKey, StandardCharsets.UTF_8.name()),
+                URLEncoder.encode(ruleKey, StandardCharsets.UTF_8.name())
+        );
+    }
+
+    private String getPullRequestUrl() {
+        // GET https://{instance}/{collection}/{project}/_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}
+        return azureUrl + azureProjectId +
+                "/_apis/git/repositories/" +
+                azureRepositoryName +
+                "/pullRequests/" +
+                pullRequestId;
+    }
+
+    private String getStatusApiUrl() {
+        // POST https://{instance}/{collection}/{project}/_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}/statuses?api-version=5.0-preview.1
+        return azureUrl + azureProjectId +
+                "/_apis/git/repositories/" +
+                azureRepositoryName +
+                "/pullRequests/" +
+                pullRequestId +
+                "/statuses" +
+                AZURE_API_VERSION;
+    }
+
+    private String getThreadApiUrl(){
+        //POST https://{instance}/{collection}/{project}/_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}/threads?api-version=5.0
+        return azureUrl + azureProjectId +
+                "/_apis/git/repositories/" +
+                azureRepositoryName +
+                "/pullRequests/" +
+                pullRequestId +
+                "/threads" +
+                AZURE_API_VERSION;
+    }
+
+    private String getGitPullRequestStatus(AnalysisDetails analysisDetails) throws IOException {
+        final String GIT_STATUS_CONTEXT_GENRE = "SonarQube";
+        final String GIT_STATUS_CONTEXT_NAME = "QualityGate";
+        final String GIT_STATUS_DESCRIPTION = "SonarQube Gate";
+
+        GitPullRequestStatus status = new GitPullRequestStatus(
+                GitStatusStateMapper.toGitStatusState(analysisDetails.getQualityGateStatus()),
+                GIT_STATUS_DESCRIPTION,
+                new GitStatusContext(GIT_STATUS_CONTEXT_GENRE, GIT_STATUS_CONTEXT_NAME), // "SonarQube/PullRequestDecoration",
+                String.format("%s/dashboard?id=%s&pullRequest=%s", server.getPublicRootUrl(),
+                        URLEncoder.encode(analysisDetails.getAnalysisProjectKey(),
+                                StandardCharsets.UTF_8.name()),
+                        URLEncoder.encode(analysisDetails.getBranchName(),
+                                StandardCharsets.UTF_8.name())
+                )
+        );
+        return new ObjectMapper().writeValueAsString(status);
+    }
+
+    private void sendPost(String apiUrl, String body, String successMessage) throws IOException {
+        LOGGER.trace(String.format("sendPost: URL: %s ", apiUrl));
+        LOGGER.trace(String.format("sendPost: BODY: %s ", body));
+        HttpPost httpPost = new HttpPost(apiUrl);
+        httpPost.addHeader("Accept", "application/json");
+        httpPost.addHeader("Content-Type", "application/json; charset=utf-8");
+        httpPost.addHeader("Authorization", authorizationHeader);
+        StringEntity entity = new StringEntity(body, StandardCharsets.UTF_8);
+        httpPost.setEntity(entity);
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpResponse httpResponse = httpClient.execute(httpPost);
+            if (null != httpResponse && httpResponse.getStatusLine().getStatusCode() != 200) {
+                LOGGER.error("sendPost: " + httpResponse.toString());
+                LOGGER.error("sendPost: " + EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8));
+                throw new IllegalStateException("An error was returned in the response from the Azure DevOps server. See the previous log messages for details");
+            } else if (null != httpResponse) {
+                LOGGER.debug("sendPost: " + httpResponse.toString());
+                LOGGER.info("sendPost: " + successMessage);
+            }
+        }
+    }
+
+    private <T> T sendGet(String apiUrl, Class<T> type) throws IOException {
+        LOGGER.info(String.format("sendGet: URL: %s ", apiUrl));
+        HttpGet httpGet = new HttpGet(apiUrl);
+        httpGet.addHeader("Accept", "application/json");
+        httpGet.addHeader("Content-Type", "application/json; charset=utf-8");
+        httpGet.addHeader("Authorization", authorizationHeader);
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpResponse httpResponse = httpClient.execute(httpGet);
+            if (null != httpResponse && httpResponse.getStatusLine().getStatusCode() != 200) {
+                LOGGER.error(httpResponse.toString());
+                LOGGER.error(EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8));
+                throw new IllegalStateException("An error was returned in the response from the Azure DevOps server. See the previous log messages for details");
+            } else if (null != httpResponse) {
+                //LOGGER.info(httpResponse.toString());
+                HttpEntity entity = httpResponse.getEntity();
+                T obj = new ObjectMapper()
+                        .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+                        .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+                        .configure(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true)
+                        .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                        .readValue(IOUtils.toString(entity.getContent(), StandardCharsets.UTF_8), type);
+
+                LOGGER.info(type + " received");
+
+                return obj;
+            } else {
+                throw new IOException("No response reveived");
+            }
+        }
+    }
+
+    private void sendPatch(String apiUrl, String body) throws IOException {
+        LOGGER.trace(String.format("sendPatch: URL: %s ", apiUrl));
+        LOGGER.trace(String.format("sendPatch: BODY: %s ", body));
+        HttpPatch httpPatch = new HttpPatch(apiUrl);
+        httpPatch.addHeader("Accept", "application/json");
+        httpPatch.addHeader("Content-Type", "application/json; charset=utf-8");
+        httpPatch.addHeader("Authorization", authorizationHeader);
+        StringEntity entity = new StringEntity(body, StandardCharsets.UTF_8);
+        httpPatch.setEntity(entity);
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpResponse httpResponse = httpClient.execute(httpPatch);
+            if (null != httpResponse && httpResponse.getStatusLine().getStatusCode() != 200) {
+                LOGGER.error("sendPatch: " + httpResponse.toString());
+                LOGGER.error("sendPatch: " + EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8));
+                throw new IllegalStateException("An error was returned in the response from the Azure DevOps server. See the previous log messages for details");
+            } else if (null != httpResponse) {
+                LOGGER.debug("sendPatch: " + httpResponse.toString());
+                LOGGER.info("sendPatch: Patch success!");
+            }
+        }
+    }
+    
+    public String name() {
+        return "Azure";
+    }
+
+    @Override
+    public ALM alm() {
+        return ALM.AZURE_DEVOPS;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecorator.java
@@ -42,13 +42,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Map;
 
 
 
 public class AzureDevOpsServerPullRequestDecorator implements PullRequestBuildStatusDecorator {
 
     private String authorizationHeader;
-    private static final String AZURE_API_VERSION = "?api-version=5.0-preview.1";
+    public static final String AZURE_API_VERSION = "?api-version=6.0-preview.1";
     private static final Logger LOGGER = Loggers.get(AzureDevOpsServerPullRequestDecorator.class);
 
     private String azureUrl = "";
@@ -84,6 +85,13 @@ public class AzureDevOpsServerPullRequestDecorator implements PullRequestBuildSt
     @Override
     public DecorationResult decorateQualityGateStatus(AnalysisDetails analysisDetails, AlmSettingDto almSettingDto, ProjectAlmSettingDto projectAlmSettingDto) {
         LOGGER.info("starting to analyze with " + analysisDetails.toString());
+        
+        Map<String,String> properties = analysisDetails.getScannerProperties();
+        
+        LOGGER.info("Found " + properties.size() + " scanner properties...");
+
+        for (Map.Entry<String,String> entry : properties.entrySet())  
+            LOGGER.debug("Key = " + entry.getKey() + ", Value = " + entry.getValue()); 
 
         try {
             azureUrl = analysisDetails.getScannerProperty(PULLREQUEST_AZUREDEVOPS_INSTANCE_URL).orElseThrow(
@@ -271,7 +279,7 @@ public class AzureDevOpsServerPullRequestDecorator implements PullRequestBuildSt
     }
 
     private String getStatusApiUrl() {
-        // POST https://{instance}/{collection}/{project}/_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}/statuses?api-version=5.0-preview.1
+        // POST https://{instance}/{project}/_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}/statuses?api-version=6.0-preview.1
         return azureUrl + azureProjectId +
                 "/_apis/git/repositories/" +
                 azureRepositoryName +
@@ -282,7 +290,7 @@ public class AzureDevOpsServerPullRequestDecorator implements PullRequestBuildSt
     }
 
     private String getThreadApiUrl(){
-        //POST https://{instance}/{collection}/{project}/_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}/threads?api-version=5.0
+        //POST https://{instance}/{project}/_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}/threads?api-version=6.0-preview.1
         return azureUrl + azureProjectId +
                 "/_apis/git/repositories/" +
                 azureRepositoryName +

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/Comment.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/Comment.java
@@ -1,0 +1,113 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.enums.CommentType;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+
+
+/**
+ * Represents a comment which is one of potentially many in a comment thread.
+ */
+public class Comment implements Serializable {
+
+    private String content;
+    private CommentType commentType;
+    private Integer parentCommentId;
+    private int id;
+    private int threadId;
+    private IdentityRef author;
+    private Date publishedDate;
+    private Date lastUpdatedDate;
+    private Date lastContentUpdatedDate;
+    @JsonProperty("isDeleted")
+    private Boolean deleted;
+    private List<IdentityRef> usersLiked;
+    @JsonProperty("_links")
+    private ReferenceLinks links;
+
+    public Comment() {
+    }
+
+    public Comment(String content) {
+        this.content = content;
+        this.parentCommentId = 0;
+        this.commentType = CommentType.TEXT;
+    }
+
+    /**
+     * The ID of the parent comment. This is used for replies.
+     */
+    public Integer getParentCommentId() {
+        return this.parentCommentId;
+    }
+    /**
+     * The comment content.
+     */
+    public String getContent() {
+        return this.content;
+    }
+    /**
+     * The comment type at the time of creation.
+     */
+    public CommentType getCommentType() {
+        return this.commentType;
+    }
+    /**
+     * The comment ID. IDs start at 1 and are unique to a pull request.
+     */
+    public int getId() {
+        return this.id;
+    }
+    /**
+     * The parent thread ID. Used for internal server purposes only -- note
+     * that this field is not exposed to the REST client.
+     */
+    public int getThreadId() {
+        return this.threadId;
+    }
+    /**
+     * The author of the comment.
+     */
+    public IdentityRef getAuthor() {
+        return this.author;
+    }
+    /**
+     * The date the comment was first published.;
+     */
+    public Date getPublishedDate() {
+        return this.publishedDate;
+    }
+    /**
+     * The date the comment was last updated.
+     */
+    public Date getLastUpdatedDate() {
+        return this.lastUpdatedDate;
+    }
+    /**
+     * The date the comment's content was last updated.
+     */
+    public Date getLastContentUpdatedDate() {
+        return this.lastContentUpdatedDate;
+    }
+    /**
+     * Whether or not this comment was soft-deleted.
+     */
+    public Boolean isDeleted() {
+        return this.deleted;
+    }
+    /**
+     * A list of the users who have liked this comment.
+     */
+    public List<IdentityRef> getUsersLiked() {
+        return this.usersLiked;
+    }
+    /**
+     * Links to other related objects.
+     */
+    public ReferenceLinks getLinks() {
+        return this.links;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/CommentPosition.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/CommentPosition.java
@@ -1,0 +1,31 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+
+public class CommentPosition implements Serializable {
+    private final int line;
+    private final int offset;
+
+    @JsonCreator
+    public CommentPosition(@JsonProperty("line") int line, @JsonProperty("offset") int offset){
+        this.line = line;
+        this.offset = offset + 1;
+    }
+    /**
+     *The line number of a thread's position. Starts at 1. ///
+     */
+    public int getLine()
+    {
+        return this.line;
+    };
+
+    /**
+     *The character offset of a thread's position inside of a line. Starts at 0.
+     */
+    public int getOffset(){
+        return this.offset;
+    };
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/CommentThread.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/CommentThread.java
@@ -1,0 +1,103 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.enums.CommentThreadStatus;
+import org.sonar.db.protobuf.DbIssues;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Represents a comment thread of a pull request. A thread contains meta data about the file
+ * it was left on along with one or more comments (an initial comment and the subsequent replies).
+ */
+public class CommentThread implements Serializable {
+
+    private CommentThreadStatus status;
+    private List<Comment> comments;
+    private CommentThreadContext threadContext;
+    private int id;
+    private Date publishedDate;
+    private Date lastUpdatedDate;
+    private HashMap<String, IdentityRef> identities;
+    @JsonProperty("isDeleted")
+    private Boolean deleted;
+    @JsonProperty("_links")
+    private ReferenceLinks links;
+    public CommentThread(){};
+
+    public CommentThread(String filePath, DbIssues.Locations locations, String message){
+        comments = Arrays.asList(
+                new Comment(message)
+        );
+        status = CommentThreadStatus.ACTIVE; //CommentThreadStatusMapper.toCommentThreadStatus(issue.status());
+        threadContext = new CommentThreadContext(
+                filePath,
+                locations
+        );
+
+    }
+    /**
+     * A list of the comments.
+     */
+    public List<Comment> getComments(){
+        return this.comments;
+    };
+    /**
+     * The status of the comment thread.
+     */
+    public CommentThreadStatus getStatus(){
+        return this.status;
+    };
+    /**
+     * Specify thread context such as position in left/right file.
+     */
+    public CommentThreadContext getThreadContext() {
+        return this.threadContext;
+    };
+    /**
+     * The comment thread id.
+     */
+    public int getId()
+    {
+        return this.id;
+    };
+    /**
+     * The time this thread was published.
+     */
+    public Date getPublishedDate()
+    {
+        return this.publishedDate;
+    };
+    /**
+     * The time this thread was last updated.
+     */
+    public Date getLastUpdatedDate()
+    {
+        return this.lastUpdatedDate;
+    };
+    /**
+     * Set of identities related to this thread
+     */
+    public HashMap<String, IdentityRef> getIdentities()
+    {
+        return this.identities;
+    };
+    /**
+     * Specify if the thread is deleted which happens when all comments are deleted.
+     */
+    public Boolean isDeleted()
+    {
+        return this.deleted;
+    };
+    /**
+     * Links to other related objects.
+     */
+    public ReferenceLinks getLinks()
+    {
+        return this.links;
+    };
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/CommentThreadContext.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/CommentThreadContext.java
@@ -1,0 +1,60 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import org.sonar.db.protobuf.DbIssues;
+
+import java.io.Serializable;
+
+public class CommentThreadContext implements Serializable {
+
+    private String filePath;
+    private CommentPosition leftFileStart;
+    private CommentPosition leftFileEnd;
+    private CommentPosition rightFileStart;
+    private CommentPosition rightFileEnd;
+
+    public CommentThreadContext() {};
+
+    public CommentThreadContext(String filePath, DbIssues.Locations locations){
+        this.filePath = filePath;
+        this.leftFileEnd = null;
+        this.leftFileStart = null;
+        this.rightFileEnd = new CommentPosition(
+                locations.getTextRange().getEndLine(),
+                locations.getTextRange().getEndOffset()
+        );
+        this.rightFileStart = new CommentPosition(
+                locations.getTextRange().getStartLine(),
+                locations.getTextRange().getStartOffset()
+        );
+    }
+    /**
+     * File path relative to the root of the repository. It's up to the client to
+     */
+    public String getFilePath(){
+        return this.filePath;
+    };
+    /**
+     * Position of first character of the thread's span in left file. ///
+     */
+    public CommentPosition getLeftFileStart(){
+        return this.leftFileStart;
+    };
+    /**
+     * Position of last character of the thread's span in left file. ///
+     */
+    public CommentPosition getLeftFileEnd(){
+        return this.leftFileEnd;
+    };
+    /**
+     * Position of first character of the thread's span in right file. ///
+     */
+    public CommentPosition getRightFileStart(){
+        return this.rightFileStart;
+    };
+    /**
+     * Position of last character of the thread's span in right file. ///
+     */
+    public CommentPosition getRightFileEnd(){
+        return this.rightFileEnd;
+    };
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/CommentThreadResponse.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/CommentThreadResponse.java
@@ -1,0 +1,16 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CommentThreadResponse {
+    private final CommentThread[] value;
+
+    @JsonCreator
+    public CommentThreadResponse(@JsonProperty("value") CommentThread[] value){
+        this.value = value;
+    }
+    public CommentThread[] getValue(){
+        return this.value;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/GitPullRequestStatus.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/GitPullRequestStatus.java
@@ -1,0 +1,54 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.enums.GitStatusState;
+
+public class GitPullRequestStatus {
+    final GitStatusState state;
+    final String description;
+    final GitStatusContext context;
+    final String targetUrl;
+
+    @JsonCreator
+    public GitPullRequestStatus(
+            @JsonProperty("state") GitStatusState state,
+            @JsonProperty("description") String description,
+            @JsonProperty("context") GitStatusContext context,
+            @JsonProperty("targetUrl") String targetUrl)
+    {
+        this.state = state;
+        this.description = description;
+        this.context = context;
+        this.targetUrl = targetUrl;
+    }
+
+    /**
+     * State of the status.
+     */
+    public GitStatusState getState()
+    {
+        return this.state;
+    }
+    /**
+     * Description of the status
+     */
+    public String getDescription()
+    {
+        return this.description;
+    }
+    /**
+     * Status context that uniquely identifies the status.
+     */
+    public GitStatusContext getContext()
+    {
+        return this.context;
+    }
+    /**
+     * TargetUrl of the status
+     */
+    public String getTargetUrl()
+    {
+        return this.targetUrl;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/GitStatusContext.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/GitStatusContext.java
@@ -1,0 +1,31 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Status context that uniquely identifies the status.
+ */
+public class GitStatusContext {
+    final String name;
+    final String genre;
+    @JsonCreator
+    public GitStatusContext(@JsonProperty("genre") String genre, @JsonProperty("name") String name){
+        this.genre = genre;
+        this.name = name;
+    }
+    /**
+     *  Genre of the status. Typically name of the service/tool generating the status, can be empty.
+     */
+    public String getGenre()
+    {
+        return this.genre;
+    };
+    /**
+     * Name identifier of the status, cannot be null or empty.
+     */
+    public String getName()
+    {
+        return this.name;
+    };
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/IdentityRef.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/IdentityRef.java
@@ -1,0 +1,117 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+
+public class IdentityRef implements Serializable {
+    private String displayName;
+    private String url;
+    @JsonProperty("_links")
+    private ReferenceLinks links;
+    private String id;
+    private String uniqueName;
+    private String directoryAlias;
+    private String profileUrl;
+    private String imageUrl;
+    @JsonProperty("isContainer")
+    private Boolean container;
+    @JsonProperty("isAadIdentity")
+    private Boolean aadIdentity;
+    @JsonProperty("isInactive")
+    private Boolean inactive;
+    @JsonProperty("isDeletedInOrigin")
+    private Boolean deletedInOrigin;
+    private String displayNameForXmlSerialization;
+    private String urlForXmlSerialization;
+
+    public IdentityRef()
+    {};
+
+    public String getDisplayName()
+    {
+        return this.displayName;
+    }
+    public String getUrl()
+    {
+        return this.url;
+    }
+    public ReferenceLinks getLinks()
+    {
+        return this.links;
+    }
+    public String getId()
+    {
+        return this.id;
+    }
+    /**
+     * Deprecated - use Domain+PrincipalName instead
+     */
+    public String getUniqueName()
+    {
+        return this.uniqueName;
+    }
+    /**
+     * Deprecated - Can be retrieved by querying the Graph user referenced in the
+     * "self" entry of the IdentityRef "_links" dictionary
+     */
+    public String getDirectoryAlias()
+    {
+        return this.directoryAlias;
+    }
+    /**
+     * Deprecated - not in use in most preexisting implementations of ToIdentityRef
+     */
+    public String getProfileUrl()
+    {
+        return this.profileUrl;
+    }
+    /**
+     * Deprecated - Available in the "avatar" entry of the IdentityRef "_links" dictionary
+     */
+    public String getImageUrl()
+    {
+        return this.imageUrl;
+    }
+    /**
+     * Deprecated - Can be inferred from the subject type of the descriptor (Descriptor.IsGroupType)
+     */
+    public Boolean isContainer()
+    {
+        return this.container;
+    }
+
+    /**
+     * Deprecated - Can be inferred from the subject type of the descriptor (Descriptor.IsAadUserType/Descriptor.IsAadGroupType)
+     */
+    public Boolean isAadIdentity()
+    {
+        return this.aadIdentity;
+    }
+    /**
+     * Deprecated - Can be retrieved by querying the Graph membership state referenced
+     * in the "membershipState" entry of the GraphUser "_links" dictionary
+     */
+    public Boolean getInactive()
+    {
+        return this.inactive;
+    }
+    public Boolean getIsDeletedInOrigin()
+    {
+        return this.deletedInOrigin;
+    }
+    /**
+     * This property is for xml compat only.
+     */
+    public String getdisplayNameForXmlSerialization()
+    {
+        return this.displayNameForXmlSerialization;
+    }
+    /**
+     * This property is for xml compat only.
+     */
+    public String getUrlForXmlSerialization()
+    {
+        return this.urlForXmlSerialization;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/Link.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/Link.java
@@ -1,0 +1,17 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Link {
+    final String href;
+    @JsonCreator
+    public Link(@JsonProperty("href") String href)
+    {
+        this.href = href;
+    };
+    public String getHref()
+    {
+        return this.href;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/ReferenceLinks.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/ReferenceLinks.java
@@ -1,0 +1,17 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ReferenceLinks {
+    final Link self;
+    @JsonCreator
+    public ReferenceLinks(@JsonProperty("self") Link self)
+    {
+        this.self = self;
+    }
+    public Link getSelf()
+    {
+        return this.self;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/enums/CommentThreadStatus.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/enums/CommentThreadStatus.java
@@ -1,0 +1,36 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.enums;
+
+/**
+ * The status of a comment thread
+ */
+public enum CommentThreadStatus {
+    /**
+     * The thread status is unknown.
+     */
+    UNKNOWN,
+    /**
+     * The thread status is active.
+     */
+    ACTIVE,
+    /**
+     * The thread status is resolved as fixed.
+     */
+    FIXED,
+    /**
+     * The thread status is resolved as won't fix.
+     */
+    WONT_FIX,
+    /**
+     * The thread status is closed.
+     */
+    CLOSED,
+    /**
+     * The thread status is resolved as by design.
+     */
+    BY_DESIGN,
+    /**
+     * The thread status is pending.
+     */
+    PENDING
+}
+

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/enums/CommentType.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/enums/CommentType.java
@@ -1,0 +1,20 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.enums;
+
+public enum CommentType {
+    /**
+     * The comment type is not known.
+     */
+    UNKNOWN,
+    /**
+     * This is a regular user comment.
+     */
+    TEXT,
+    /**
+     * The comment comes as a result of a code change.
+     */
+    CODE_CHANGE,
+    /**
+     * The comment represents a system message.
+     */
+    SYSTEM
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/enums/GitStatusState.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/enums/GitStatusState.java
@@ -1,0 +1,32 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.enums;
+
+/**
+ * State of the status.
+ */
+public enum GitStatusState
+{
+    /**
+     * Status state not set. Default state.
+     */
+    NOT_SET,
+    /**
+     * Status pending.
+     */
+    PENDING,
+    /**
+     * Status succeeded.
+     */
+    SUCCEEDED,
+    /**
+     * Status failed.
+     */
+    FAILED,
+    /**
+     * Status with an error.
+     */
+    ERROR,
+    /**
+     * Status is not applicable to the target object.
+     */
+    NOT_APPLICABLE
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/mappers/CommentThreadStatusMapper.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/mappers/CommentThreadStatusMapper.java
@@ -1,0 +1,31 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.mappers;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.enums.CommentThreadStatus;
+
+import static org.sonar.api.issue.Issue.STATUS_OPEN;
+import static org.sonar.api.issue.Issue.STATUS_CLOSED;
+
+
+public final class CommentThreadStatusMapper {
+
+    private CommentThreadStatusMapper() {
+        super();
+    }
+
+    public static CommentThreadStatus toCommentThreadStatus(String issueStatus) {
+        switch (issueStatus) {
+            case STATUS_OPEN:
+                return CommentThreadStatus.ACTIVE;
+            default:
+                return CommentThreadStatus.FIXED;
+        }
+    }
+    public static String toIssueStatus(CommentThreadStatus commentThreadStatus) {
+        switch (commentThreadStatus) {
+            case ACTIVE:
+                return STATUS_OPEN;
+            default:
+                return STATUS_CLOSED;
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/mappers/GitStatusStateMapper.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/model/mappers/GitStatusStateMapper.java
@@ -1,0 +1,22 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.mappers;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.model.enums.GitStatusState;
+import org.sonar.api.ce.posttask.QualityGate;
+
+public final class GitStatusStateMapper {
+
+    private GitStatusStateMapper() {
+        super();
+    }
+
+    public static GitStatusState toGitStatusState(QualityGate.Status AnnalyzeStatus) {
+        switch (AnnalyzeStatus) {
+            case OK:
+                return GitStatusState.SUCCEEDED;
+            case ERROR:
+                return GitStatusState.ERROR;
+            default:
+                return GitStatusState.NOT_SET;
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -32,6 +32,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response.Note;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.response.User;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -102,10 +103,11 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
         String revision = analysis.getCommitSha();
 
         try {
-            final String apiURL = analysis.getScannerProperty(PULLREQUEST_GITLAB_INSTANCE_URL).orElseThrow(
-                    () -> new IllegalStateException(String.format(
+            final String apiURL = Optional.ofNullable(StringUtils.stripToNull(almSettingDto.getUrl()))
+                .orElse(analysis.getScannerProperty(PULLREQUEST_GITLAB_INSTANCE_URL)
+                .orElseThrow(() -> new IllegalStateException(String.format(
                             "Could not decorate Gitlab merge request. '%s' has not been set in scanner properties",
-                            PULLREQUEST_GITLAB_INSTANCE_URL)));
+                            PULLREQUEST_GITLAB_INSTANCE_URL))));
             final String apiToken = almSettingDto.getPersonalAccessToken();
             final String projectId = analysis.getScannerProperty(PULLREQUEST_GITLAB_PROJECT_ID).orElseThrow(
                     () -> new IllegalStateException(String.format(

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
@@ -89,20 +89,24 @@ public class ScannerPullRequestPropertySensor implements Sensor {
                 .addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BRANCH, v));
         projectConfiguration.get(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID).ifPresent(v -> sensorContext
                 .addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID, v));
+        projectConfiguration.get(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_API_VERSION).ifPresent(v -> sensorContext
+                .addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_API_VERSION, v));
         
         
         Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_INSTANCE_URL)).ifPresent(
-                        v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_INSTANCE_URL, v));
+                v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_INSTANCE_URL, v));
         Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PROJECT_ID)).ifPresent(
                 v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PROJECT_ID, v));        
         Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME)).ifPresent(
                 v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME, v));
         Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BASE_BRANCH)).ifPresent(
-                        v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BASE_BRANCH, v));
+                v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BASE_BRANCH, v));
         Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BRANCH)).ifPresent(
                 v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BRANCH, v));        
         Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID)).ifPresent(
                 v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID, v));
+        Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_API_VERSION)).ifPresent(
+                v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_API_VERSION, v));
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
@@ -19,19 +19,23 @@
 package com.github.mc1arke.sonarqube.plugin.scanner;
 
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabServerPullRequestDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.AzureDevOpsServerPullRequestDecorator;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.ProjectConfiguration;
 
 import java.util.Optional;
 
 public class ScannerPullRequestPropertySensor implements Sensor {
 
+    private final ProjectConfiguration projectConfiguration;
     private final System2 system2;
 
-    public ScannerPullRequestPropertySensor(System2 system2) {
+    public ScannerPullRequestPropertySensor(ProjectConfiguration projectConfiguration, System2 system2) {
         super();
+        this.projectConfiguration = projectConfiguration;
         this.system2 = system2;
     }
 
@@ -42,6 +46,15 @@ public class ScannerPullRequestPropertySensor implements Sensor {
 
     @Override
     public void execute(SensorContext sensorContext) {
+        projectConfiguration.get(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL).ifPresent(v -> sensorContext
+                .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL, v));
+        projectConfiguration.get(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID).ifPresent(v -> sensorContext
+                .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_ID, v));
+        projectConfiguration.get(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL).ifPresent(v -> sensorContext
+                .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, v));
+        projectConfiguration.get(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID).ifPresent(v -> sensorContext
+                .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, v));
+
         if (Boolean.parseBoolean(system2.envVariable("GITLAB_CI"))) {
             Optional.ofNullable(system2.envVariable("CI_API_V4_URL")).ifPresent(v -> sensorContext
                     .addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_INSTANCE_URL, v));
@@ -61,6 +74,35 @@ public class ScannerPullRequestPropertySensor implements Sensor {
                 v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, v));
         Optional.ofNullable(system2.property(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID)).ifPresent(
                 v -> sensorContext.addContextProperty(GitlabServerPullRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, v));
+
+        // AZURE DEVOPS
+
+        projectConfiguration.get(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_INSTANCE_URL).ifPresent(v -> sensorContext
+                .addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_INSTANCE_URL, v));        
+        projectConfiguration.get(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PROJECT_ID).ifPresent(v -> sensorContext
+                .addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PROJECT_ID, v));
+        projectConfiguration.get(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME).ifPresent(v -> sensorContext
+                .addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME, v));
+        projectConfiguration.get(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BASE_BRANCH).ifPresent(v -> sensorContext
+                .addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BASE_BRANCH, v));
+        projectConfiguration.get(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BRANCH).ifPresent(v -> sensorContext
+                .addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BRANCH, v));
+        projectConfiguration.get(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID).ifPresent(v -> sensorContext
+                .addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID, v));
+        
+        
+        Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_INSTANCE_URL)).ifPresent(
+                        v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_INSTANCE_URL, v));
+        Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PROJECT_ID)).ifPresent(
+                v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PROJECT_ID, v));        
+        Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME)).ifPresent(
+                v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME, v));
+        Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BASE_BRANCH)).ifPresent(
+                        v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BASE_BRANCH, v));
+        Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BRANCH)).ifPresent(
+                v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BRANCH, v));        
+        Optional.ofNullable(system2.property(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID)).ifPresent(
+                v -> sensorContext.addContextProperty(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID, v));
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/DeleteBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/DeleteBindingAction.java
@@ -23,7 +23,7 @@ import org.sonar.api.server.ws.Response;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -43,7 +43,7 @@ public class DeleteBindingAction extends ProjectWsAction {
     }
 
     @Override
-    protected void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession) {
+    protected void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
         dbClient.projectAlmSettingDao().deleteByProject(dbSession, project);
         dbSession.commit();
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/GetBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/GetBindingAction.java
@@ -29,7 +29,7 @@ import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.exceptions.NotFoundException;
 import org.sonar.server.user.UserSession;
@@ -59,7 +59,7 @@ public class GetBindingAction extends ProjectWsAction {
     }
 
     @Override
-    protected void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession) {
+    protected void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
         ProjectAlmSettingDto projectAlmSetting = dbClient.projectAlmSettingDao().selectByProject(dbSession, project)
             .orElseThrow(() -> new NotFoundException(
                 format("Project '%s' is not bound to any ALM", project.getKey())));

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListAction.java
@@ -29,7 +29,7 @@ import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.alm.setting.AlmSettingDto;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 import org.sonar.server.ws.WsUtils;
@@ -59,7 +59,7 @@ public class ListAction extends ProjectWsAction {
     }
 
     @Override
-    protected void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession) {
+    protected void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
         List<AlmSettingDto> settings = dbClient.almSettingDao().selectAll(dbSession);
         List<AlmSetting> wsAlmSettings = settings.stream().map(almSetting -> {
             AlmSetting.Builder almSettingBuilder = AlmSetting.newBuilder().setKey(almSetting.getKey())

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsAction.java
@@ -32,6 +32,7 @@ import org.sonarqube.ws.AlmSettings.AlmSettingGithub;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
@@ -115,8 +116,12 @@ public class ListDefinitionsAction extends AlmSettingsWsAction {
     }
 
     private static AlmSettings.AlmSettingGitlab toGitlab(AlmSettingDto settingDto) {
-        return AlmSettings.AlmSettingGitlab.newBuilder()
+        AlmSettings.AlmSettingGitlab.Builder almSettingBuilder =  AlmSettings.AlmSettingGitlab.newBuilder()
             .setKey(settingDto.getKey())
-            .setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(), "Personal Access Token cannot be null for Gitlab ALM setting")).build();
+            .setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(), "Personal Access Token cannot be null for Gitlab ALM setting"));
+
+        Optional.ofNullable(settingDto.getUrl()).ifPresent(almSettingBuilder::setUrl);
+
+        return almSettingBuilder.build();
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ProjectWsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ProjectWsAction.java
@@ -7,7 +7,7 @@ import org.sonar.api.server.ws.Response;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -43,12 +43,12 @@ public abstract class ProjectWsAction extends AlmSettingsWsAction {
     public void handle(Request request, Response response) {
         String projectKey = request.mandatoryParam(PROJECT_PARAMETER);
         try (DbSession dbSession = dbClient.openSession(false)) {
-            ComponentDto project = componentFinder.getByKey(dbSession, projectKey);
-            userSession.checkComponentPermission(ADMIN, project);
+            ProjectDto project = componentFinder.getProjectByKey(dbSession, projectKey);
+            userSession.checkProjectPermission(ADMIN, project);
 
             handleProjectRequest(project, request, response, dbSession);
         }
     }
 
-    protected abstract void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession);
+    protected abstract void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession);
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingAction.java
@@ -25,7 +25,7 @@ import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -37,15 +37,17 @@ public abstract class SetBindingAction extends ProjectWsAction {
         super(actionName, dbClient, componentFinder, userSession);
     }
 
+    @Override
     protected void configureAction(WebService.NewAction action) {
         action.createParam(ALM_SETTING_PARAMETER).setRequired(true);
     }
 
-    protected void handleProjectRequest(ComponentDto project, Request request, Response response, DbSession dbSession) {
+    @Override
+    protected void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
         String almSetting = request.mandatoryParam(ALM_SETTING_PARAMETER);
 
         AlmSettingDto almSettingDto = getAlmSetting(dbSession, almSetting);
-        getDbClient().projectAlmSettingDao().insertOrUpdate(dbSession, createProjectAlmSettingDto(project.uuid(), almSettingDto.getUuid(), request));
+        getDbClient().projectAlmSettingDao().insertOrUpdate(dbSession, createProjectAlmSettingDto(project.getUuid(), almSettingDto.getUuid(), request));
         dbSession.commit();
 
         response.noContent();

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/CreateGitlabAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/CreateGitlabAction.java
@@ -29,6 +29,7 @@ import static org.sonar.db.alm.setting.ALM.GITLAB;
 
 public class CreateGitlabAction extends CreateAction {
 
+    private static final String URL_PARAMETER = "url";
     private static final String PERSONAL_ACCESS_TOKEN_PARAMETER = "personalAccessToken";
 
     public CreateGitlabAction(DbClient dbClient, UserSession userSession) {
@@ -37,6 +38,7 @@ public class CreateGitlabAction extends CreateAction {
 
     @Override
     public void configureAction(WebService.NewAction action) {
+        action.createParam(URL_PARAMETER).setMaximumLength(2000);
         action.createParam(PERSONAL_ACCESS_TOKEN_PARAMETER).setRequired(true).setMaximumLength(2000);
     }
 
@@ -45,6 +47,7 @@ public class CreateGitlabAction extends CreateAction {
         return new AlmSettingDto()
                 .setAlm(GITLAB)
                 .setKey(key)
+                .setUrl(request.param(URL_PARAMETER))
                 .setPersonalAccessToken(request.mandatoryParam(PERSONAL_ACCESS_TOKEN_PARAMETER));
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/UpdateGitlabAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/UpdateGitlabAction.java
@@ -27,6 +27,7 @@ import org.sonar.server.user.UserSession;
 
 public class UpdateGitlabAction extends UpdateAction {
 
+    private static final String URL_PARAMETER = "url";
     private static final String PERSONAL_ACCESS_TOKEN_PARAMETER = "personalAccessToken";
 
     public UpdateGitlabAction(DbClient dbClient, UserSession userSession) {
@@ -35,12 +36,14 @@ public class UpdateGitlabAction extends UpdateAction {
 
     @Override
     protected void configureAction(WebService.NewAction action) {
+        action.createParam(URL_PARAMETER).setMaximumLength(2000);
         action.createParam(PERSONAL_ACCESS_TOKEN_PARAMETER).setRequired(true).setMaximumLength(2000);
     }
 
     @Override
     protected AlmSettingDto updateAlmSettingsDto(AlmSettingDto almSettingDto, Request request) {
-        return almSettingDto.setPersonalAccessToken(request.mandatoryParam(PERSONAL_ACCESS_TOKEN_PARAMETER));
+        return almSettingDto.setPersonalAccessToken(request.mandatoryParam(PERSONAL_ACCESS_TOKEN_PARAMETER))
+            .setUrl(request.param(URL_PARAMETER));
     }
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProviderTest.java
@@ -32,7 +32,7 @@ public class CommunityReportAnalysisComponentProviderTest {
     @Test
     public void testGetComponents() {
         List<Object> result = new CommunityReportAnalysisComponentProvider().getComponents();
-        assertEquals(10, result.size());
+        assertEquals(11, result.size());
         assertEquals(CommunityBranchLoaderDelegate.class, result.get(0));
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
@@ -1,0 +1,303 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.platform.Server;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.rules.RuleType;
+import org.sonar.ce.task.projectanalysis.component.Component;
+import org.sonar.ce.task.projectanalysis.scm.ScmInfoRepository;
+import org.sonar.core.issue.DefaultIssue;
+import org.sonar.db.alm.setting.AlmSettingDto;
+import org.sonar.db.alm.setting.ProjectAlmSettingDto;
+import org.sonar.db.protobuf.DbIssues;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Optional;
+
+
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AzureDevOpsServerPullRequestDecoratorTest {
+    @Rule
+    public final WireMockRule wireMockRule = new WireMockRule(wireMockConfig());
+
+    @Test
+    public void testName() {
+        assertEquals("Azure", new AzureDevOpsServerPullRequestDecorator( mock(Server.class), mock(ScmInfoRepository.class) ).name());
+    }
+
+    @Test
+    public void decorateQualityGateStatus() {
+        String azureProject = "azureProject";
+        String sonarProject = "sonarProject";
+        String pullRequestId = "8513";
+        String baseBranchName = "master";
+        String branchName = "feature/some-feature";
+        String azureRepository = "myRepository";
+        String sonarRootUrl = "http://sonar:9000/sonar";
+        String filePath = "path/to/file";
+        String issueMessage = "issueMessage";
+        String issueKeyVal = "issueKeyVal";
+        String ruleKeyVal = "ruleKeyVal";
+        int lineNumber = 5;
+        String token = "token";
+        String authorizationHeader = "Basic " + Base64.getEncoder().encodeToString((":" + token).getBytes());
+
+        ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
+        AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
+        when(almSettingDto.getPersonalAccessToken()).thenReturn(token);
+
+        AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
+        PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
+        PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
+        DefaultIssue defaultIssue = mock(DefaultIssue.class);
+        Component component = mock(Component.class);
+
+        when(analysisDetails.getScannerProperty(eq(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_INSTANCE_URL)))
+                .thenReturn(Optional.of(wireMockRule.baseUrl()));
+        when(analysisDetails.getScannerProperty(eq(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_REPOSITORY_NAME)))
+                .thenReturn(Optional.of(azureRepository));
+        when(analysisDetails.getScannerProperty(eq(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PULLREQUEST_ID)))
+                .thenReturn(Optional.of(pullRequestId));
+        when(analysisDetails.getScannerProperty(eq(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_PROJECT_ID)))
+                .thenReturn(Optional.of(azureProject));
+        when(analysisDetails.getScannerProperty(eq(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BASE_BRANCH)))
+                .thenReturn(Optional.of(baseBranchName));
+        when(analysisDetails.getScannerProperty(eq(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BRANCH)))
+                .thenReturn(Optional.of(branchName));
+        when(analysisDetails.getAnalysisProjectKey()).thenReturn(sonarProject);
+        when(analysisDetails.getQualityGateStatus()).thenReturn(QualityGate.Status.OK);
+        when(analysisDetails.getBranchName()).thenReturn(pullRequestId);
+        when(analysisDetails.getPostAnalysisIssueVisitor()).thenReturn(issueVisitor);
+        when(analysisDetails.getSCMPathForIssue(componentIssue)).thenReturn(Optional.of(filePath));
+        when(issueVisitor.getIssues()).thenReturn(Collections.singletonList(componentIssue));
+
+        DbIssues.Locations locate = DbIssues.Locations.newBuilder().build();
+        RuleType rule = RuleType.CODE_SMELL;
+        RuleKey ruleKey = mock(RuleKey.class);
+        when(componentIssue.getIssue()).thenReturn(defaultIssue);
+        when(componentIssue.getComponent()).thenReturn(component);
+        when(defaultIssue.getStatus()).thenReturn(Issue.STATUS_OPEN);
+        when(defaultIssue.getLine()).thenReturn(lineNumber);
+        when(defaultIssue.getLocations()).thenReturn(locate);
+        when(defaultIssue.type()).thenReturn(rule);
+        when(defaultIssue.getMessage()).thenReturn(issueMessage);
+        when(defaultIssue.getRuleKey()).thenReturn(ruleKey);
+        when(defaultIssue.key()).thenReturn(issueKeyVal);
+        when(ruleKey.toString()).thenReturn(ruleKeyVal);
+
+        ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
+        wireMockRule.stubFor(get(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads?api-version=5.0-preview.1"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .withHeader("Authorization", equalTo(authorizationHeader))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(
+                        "{\n" +
+                        "    \"value\": [\n" +
+                        "        {\n" +
+                        "            \"pullRequestThreadContext\": {\n" +
+                        "                \"iterationContext\": {\n" +
+                        "                    \"firstComparingIteration\": 1,\n" +
+                        "                    \"secondComparingIteration\": 1\n" +
+                        "                },\n" +
+                        "                \"changeTrackingId\": 4\n" +
+                        "            },\n" +
+                        "            \"id\": 80450,\n" +
+                        "            \"publishedDate\": \"2020-03-10T17:40:09.603Z\",\n" +
+                        "            \"lastUpdatedDate\": \"2020-03-10T18:05:06.99Z\",\n" +
+                        "            \"comments\": [\n" +
+                        "                {\n" +
+                        "                    \"id\": 1,\n" +
+                        "                    \"parentCommentId\": 0,\n" +
+                        "                    \"author\": {\n" +
+                        "                        \"displayName\": \"More text\",\n" +
+                        "                        \"url\": \"https://dev.azure.com/fabrikam/_apis/Identities/c27db56f-07a0-43ac-9725-d6666e8b66b5\",\n" +
+                        "                        \"_links\": {\n" +
+                        "                            \"avatar\": {\n" +
+                        "                                \"href\": \"https://dev.azure.com/fabrikam/_apis/GraphProfile/MemberAvatars/win.Uy0xLTUtMjEtMzkwNzU4MjE0NC0yNDM3MzcyODg4LTE5Njg5NDAzMjgtMjIxNQ\"\n" +
+                        "                            }\n" +
+                        "                        },\n" +
+                        "                        \"id\": \"c27db56f-07a0-43ac-9725-d6666e8b66b5\",\n" +
+                        "                        \"uniqueName\": \"user@mail.ru\",\n" +
+                        "                        \"imageUrl\": \"https://dev.azure.com/fabrikam/_api/_common/identityImage?id=c27db56f-07a0-43ac-9725-d6666e8b66b5\",\n" +
+                        "                        \"descriptor\": \"win.Uy0xLTUtMjEtMzkwNzU4MjE0NC0yNDM3MzcyODg4LTE5Njg5NDAzMjgtMjIxNQ\"\n" +
+                        "                    },\n" +
+                        "                    \"publishedDate\": \"2020-03-10T17:40:09.603Z\",\n" +
+                        "                    \"lastUpdatedDate\": \"2020-03-10T18:05:06.99Z\",\n" +
+                        "                    \"lastContentUpdatedDate\": \"2020-03-10T18:05:06.99Z\",\n" +
+                        "                    \"isDeleted\": false,\n" +
+                        "                    \"commentType\": \"text\",\n" +
+                        "                    \"usersLiked\": [],\n" +
+                        "                    \"_links\": {\n" +
+                        "                        \"self\": {\n" +
+                        "                            \"href\": \"https://dev.azure.com/fabrikam/_apis/git/repositories/28afee9d-4e53-46b8-8deb-99ea20202b2b/pullRequests/8513/threads/80450/comments/1\"\n" +
+                        "                        }\n" +
+                        "                    }\n" +
+                        "                }\n" +
+                        "            ],\n" +
+                        "            \"status\": \"active\",\n" +
+                        "            \"threadContext\": {\n" +
+                        "                \"filePath\": \"/azureProject/myReposytory/Helpers/file.cs\",\n" +
+                        "                \"rightFileStart\": {\n" +
+                        "                    \"line\": 18,\n" +
+                        "                    \"offset\": 11\n" +
+                        "                },\n" +
+                        "                \"rightFileEnd\": {\n" +
+                        "                    \"line\": 18,\n" +
+                        "                    \"offset\": 15\n" +
+                        "                }\n" +
+                        "            },\n" +
+                        "            \"properties\": {},\n" +
+                        "            \"identities\": null,\n" +
+                        "            \"isDeleted\": false,\n" +
+                        "            \"_links\": {\n" +
+                        "                \"self\": {\n" +
+                        "                    \"href\": \"https://dev.azure.com/fabrikam/_apis/git/repositories/28afee9d-4e53-46b8-8deb-99ea20202b2b/pullRequests/8513/threads/80450\"\n" +
+                        "                }\n" +
+                        "            }\n" +
+                        "        },\n" +
+                        "        {\n" +
+                        "            \"pullRequestThreadContext\": {\n" +
+                        "                \"iterationContext\": {\n" +
+                        "                    \"firstComparingIteration\": 1,\n" +
+                        "                    \"secondComparingIteration\": 1\n" +
+                        "                },\n" +
+                        "                \"changeTrackingId\": 13\n" +
+                        "            },\n" +
+                        "            \"id\": 80452,\n" +
+                        "            \"publishedDate\": \"2020-03-10T19:06:11.37Z\",\n" +
+                        "            \"lastUpdatedDate\": \"2020-03-10T19:06:11.37Z\",\n" +
+                        "            \"comments\": [\n" +
+                        "                {\n" +
+                        "                    \"id\": 1,\n" +
+                        "                    \"parentCommentId\": 0,\n" +
+                        "                    \"author\": {\n" +
+                        "                        \"displayName\": \"text\",\n" +
+                        "                        \"url\": \"https://dev.azure.com/fabrikam/_apis/Identities/c27db56f-07a0-43ac-9725-d6666e8b66b5\",\n" +
+                        "                        \"_links\": {\n" +
+                        "                            \"avatar\": {\n" +
+                        "                                \"href\": \"https://dev.azure.com/fabrikam/_apis/GraphProfile/MemberAvatars/win.Uy0xLTUtMjEtMzkwNzU4MjE0NC0yNDM3MzcyODg4LTE5Njg5NDAzMjgtMjIxNQ\"\n" +
+                        "                            }\n" +
+                        "                        },\n" +
+                        "                        \"id\": \"c27db56f-07a0-43ac-9725-d6666e8b66b5\",\n" +
+                        "                        \"uniqueName\": \"user@mail.ru\",\n" +
+                        "                        \"imageUrl\": \"https://dev.azure.com/fabrikam/_api/_common/identityImage?id=c27db56f-07a0-43ac-9725-d6666e8b66b5\",\n" +
+                        "                        \"descriptor\": \"win.Uy0xLTUtMjEtMzkwNzU4MjE0NC0yNDM3MzcyODg4LTE5Njg5NDAzMjgtMjIxNQ\"\n" +
+                        "                    },\n" +
+                        "                    \"content\": \"Comment\",\n" +
+                        "                    \"publishedDate\": \"2020-03-10T19:06:11.37Z\",\n" +
+                        "                    \"lastUpdatedDate\": \"2020-03-10T19:06:11.37Z\",\n" +
+                        "                    \"lastContentUpdatedDate\": \"2020-03-10T19:06:11.37Z\",\n" +
+                        "                    \"commentType\": \"text\",\n" +
+                        "                    \"usersLiked\": [],\n" +
+                        "                    \"_links\": {\n" +
+                        "                        \"self\": {\n" +
+                        "                            \"href\": \"https://dev.azure.com/fabrikam/_apis/git/repositories/28afee9d-4e53-46b8-8deb-99ea20202b2b/pullRequests/8513/threads/80452/comments/1\"\n" +
+                        "                        }\n" +
+                        "                    }\n" +
+                        "                }\n" +
+                        "            ],\n" +
+                        "            \"status\": \"active\",\n" +
+                        "            \"threadContext\": {\n" +
+                        "                \"filePath\": \"/azureProject/myReposytory/Helpers/file2.cs\",\n" +
+                        "                \"rightFileStart\": {\n" +
+                        "                    \"line\": 30,\n" +
+                        "                    \"offset\": 57\n" +
+                        "                },\n" +
+                        "                \"rightFileEnd\": {\n" +
+                        "                    \"line\": 30,\n" +
+                        "                    \"offset\": 65\n" +
+                        "                }\n" +
+                        "            },\n" +
+                        "            \"properties\": {},\n" +
+                        "            \"identities\": null,\n" +
+                        "            \"isDeleted\": false,\n" +
+                        "            \"_links\": {\n" +
+                        "                \"self\": {\n" +
+                        "                    \"href\": \"https://dev.azure.com/fabrikam/_apis/git/repositories/28afee9d-4e53-46b8-8deb-99ea20202b2b/pullRequests/8513/threads/80452\"\n" +
+                        "                }\n" +
+                        "            }\n" +
+                        "        }\n" +
+                        "    ],\n" +
+                        "    \"count\": 2\n" +
+                        "}")));
+
+        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads?api-version=5.0-preview.1"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .withHeader("Authorization", equalTo(authorizationHeader))
+                .withRequestBody(equalTo("{" +
+                        "\"status\":\"ACTIVE\"," +
+                        "\"comments\":[{" +
+                        "\"content\":\"CODE_SMELL: issueMessage ([rule](" + sonarRootUrl + "/coding_rules?open=" + ruleKeyVal + "&rule_key=" + ruleKeyVal + "))\\r\\n\\r\\n[See in SonarQube](" + sonarRootUrl + "/project/issues?id=" + sonarProject + "&issues=" + issueKeyVal + "&open=" + issueKeyVal + "&pullRequest="+ pullRequestId +")\"," +
+                        "\"commentType\":\"TEXT\"," +
+                        "\"parentCommentId\":0," +
+                        "\"id\":0," +
+                        "\"threadId\":0," +
+                        "\"author\":null," +
+                        "\"publishedDate\":null," +
+                        "\"lastUpdatedDate\":null," +
+                        "\"lastContentUpdatedDate\":null," +
+                        "\"usersLiked\":null," +
+                        "\"isDeleted\":null," +
+                        "\"_links\":null}]," +
+                        "\"threadContext\":{" +
+                        "\"filePath\":\"/" + filePath + "\"," +
+                        "\"leftFileStart\":null," +
+                        "\"leftFileEnd\":null," +
+                        "\"rightFileStart\":{\"line\":0," +
+                        "\"offset\":1}," +
+                        "\"rightFileEnd\":{\"line\":0," +
+                        "\"offset\":1}}," +
+                        "\"id\":0," +
+                        "\"publishedDate\":null," +
+                        "\"lastUpdatedDate\":null," +
+                        "\"identities\":null," +
+                        "\"isDeleted\":null," +
+                        "\"_links\":null" +
+                        "}")
+                )
+                .willReturn(ok()));
+
+
+        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/statuses?api-version=5.0-preview.1"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .withHeader("Authorization", equalTo(authorizationHeader))
+                .withRequestBody(equalTo("{" +
+                        "\"state\":\"SUCCEEDED\"," +
+                        "\"description\":\"SonarQube Gate\"," +
+                        "\"context\":{\"genre\":\"SonarQube\",\"name\":\"QualityGate\"}," +
+                        "\"targetUrl\":\"" + sonarRootUrl + "/dashboard?id=" + sonarProject + "&pullRequest=" + pullRequestId + "\"" +
+                        "}")
+                )
+                .willReturn(ok()));
+
+        Server server = mock(Server.class);
+        when(server.getPublicRootUrl()).thenReturn(sonarRootUrl);
+        AzureDevOpsServerPullRequestDecorator pullRequestDecorator =
+                new AzureDevOpsServerPullRequestDecorator(server, scmInfoRepository);
+
+        pullRequestDecorator.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
@@ -104,7 +104,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
         when(ruleKey.toString()).thenReturn(ruleKeyVal);
 
         ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
-        wireMockRule.stubFor(get(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads?api-version=5.0-preview.1"))
+        wireMockRule.stubFor(get(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.AZURE_API_VERSION))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authorizationHeader))
@@ -241,7 +241,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                         "    \"count\": 2\n" +
                         "}")));
 
-        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads?api-version=5.0-preview.1"))
+        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.AZURE_API_VERSION))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authorizationHeader))
@@ -279,7 +279,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                 .willReturn(ok()));
 
 
-        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/statuses?api-version=5.0-preview.1"))
+        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/statuses"+ AzureDevOpsServerPullRequestDecorator.AZURE_API_VERSION))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authorizationHeader))

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
@@ -248,7 +248,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                 .withRequestBody(equalTo("{" +
                         "\"status\":\"ACTIVE\"," +
                         "\"comments\":[{" +
-                        "\"content\":\"CODE_SMELL: issueMessage ([rule](" + sonarRootUrl + "/coding_rules?open=" + ruleKeyVal + "&rule_key=" + ruleKeyVal + "))\\r\\n\\r\\n[See in SonarQube](" + sonarRootUrl + "/project/issues?id=" + sonarProject + "&issues=" + issueKeyVal + "&open=" + issueKeyVal + "&pullRequest="+ pullRequestId +")\"," +
+                        "\"content\":\"CODE_SMELL: issueMessage ([rule](" + sonarRootUrl + "/coding_rules?open=" + ruleKeyVal + "&rule_key=" + ruleKeyVal + "))\\n\\n[See in SonarQube](" + sonarRootUrl + "/project/issues?id=" + sonarProject + "&issues=" + issueKeyVal + "&open=" + issueKeyVal + "&pullRequest="+ pullRequestId +")\"," +
                         "\"commentType\":\"TEXT\"," +
                         "\"parentCommentId\":0," +
                         "\"id\":0," +

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
@@ -46,12 +46,12 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
     @Test
     public void decorateQualityGateStatus() {
         String apiVersion = "5.1-preview.1";
-        String azureProject = "azureProject";
+        String azureProject = "azure Project";
         String sonarProject = "sonarProject";
         String pullRequestId = "8513";
         String baseBranchName = "master";
         String branchName = "feature/some-feature";
-        String azureRepository = "myRepository";
+        String azureRepository = "my Repository";
         String sonarRootUrl = "http://sonar:9000/sonar";
         String filePath = "path/to/file";
         String issueMessage = "issueMessage";
@@ -107,7 +107,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
         when(ruleKey.toString()).thenReturn(ruleKeyVal);
 
         ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
-        wireMockRule.stubFor(get(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.API_VERSION_PREFIX + apiVersion))
+        wireMockRule.stubFor(get(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.API_VERSION_PREFIX + apiVersion))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authorizationHeader))
@@ -159,7 +159,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                         "            ],\n" +
                         "            \"status\": \"active\",\n" +
                         "            \"threadContext\": {\n" +
-                        "                \"filePath\": \"/azureProject/myReposytory/Helpers/file.cs\",\n" +
+                        "                \"filePath\": \"/" + azureProject + "/" + azureRepository + "/Helpers/file.cs\",\n" +
                         "                \"rightFileStart\": {\n" +
                         "                    \"line\": 18,\n" +
                         "                    \"offset\": 11\n" +
@@ -221,7 +221,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                         "            ],\n" +
                         "            \"status\": \"active\",\n" +
                         "            \"threadContext\": {\n" +
-                        "                \"filePath\": \"/azureProject/myReposytory/Helpers/file2.cs\",\n" +
+                        "                \"filePath\": \"/" + azureProject + "/" + azureRepository + "/Helpers/file2.cs\",\n" +
                         "                \"rightFileStart\": {\n" +
                         "                    \"line\": 30,\n" +
                         "                    \"offset\": 57\n" +
@@ -244,7 +244,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                         "    \"count\": 2\n" +
                         "}")));
 
-        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.API_VERSION_PREFIX + apiVersion))
+        wireMockRule.stubFor(post(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.API_VERSION_PREFIX + apiVersion))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authorizationHeader))
@@ -282,7 +282,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                 .willReturn(ok()));
 
 
-        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/statuses"+ AzureDevOpsServerPullRequestDecorator.API_VERSION_PREFIX + apiVersion))
+        wireMockRule.stubFor(post(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/"+ pullRequestId +"/statuses"+ AzureDevOpsServerPullRequestDecorator.API_VERSION_PREFIX + apiVersion))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authorizationHeader))

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
@@ -45,6 +45,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
 
     @Test
     public void decorateQualityGateStatus() {
+        String apiVersion = "5.1-preview.1";
         String azureProject = "azureProject";
         String sonarProject = "sonarProject";
         String pullRequestId = "8513";
@@ -82,6 +83,8 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                 .thenReturn(Optional.of(baseBranchName));
         when(analysisDetails.getScannerProperty(eq(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_BRANCH)))
                 .thenReturn(Optional.of(branchName));
+        when(analysisDetails.getScannerProperty(eq(AzureDevOpsServerPullRequestDecorator.PULLREQUEST_AZUREDEVOPS_API_VERSION)))
+                .thenReturn(Optional.of(apiVersion));
         when(analysisDetails.getAnalysisProjectKey()).thenReturn(sonarProject);
         when(analysisDetails.getQualityGateStatus()).thenReturn(QualityGate.Status.OK);
         when(analysisDetails.getBranchName()).thenReturn(pullRequestId);
@@ -104,7 +107,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
         when(ruleKey.toString()).thenReturn(ruleKeyVal);
 
         ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
-        wireMockRule.stubFor(get(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.AZURE_API_VERSION))
+        wireMockRule.stubFor(get(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.API_VERSION_PREFIX + apiVersion))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authorizationHeader))
@@ -241,7 +244,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                         "    \"count\": 2\n" +
                         "}")));
 
-        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.AZURE_API_VERSION))
+        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/threads"+ AzureDevOpsServerPullRequestDecorator.API_VERSION_PREFIX + apiVersion))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authorizationHeader))
@@ -279,7 +282,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
                 .willReturn(ok()));
 
 
-        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/statuses"+ AzureDevOpsServerPullRequestDecorator.AZURE_API_VERSION))
+        wireMockRule.stubFor(post(urlEqualTo("/_apis/git/repositories/"+ azureRepository +"/pullRequests/"+ pullRequestId +"/statuses"+ AzureDevOpsServerPullRequestDecorator.API_VERSION_PREFIX + apiVersion))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authorizationHeader))

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/DeleteBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/DeleteBindingActionTest.java
@@ -14,7 +14,7 @@ import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.alm.setting.AlmSettingDao;
 import org.sonar.db.alm.setting.ProjectAlmSettingDao;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -58,9 +58,9 @@ public class DeleteBindingActionTest {
 
         UserSession userSession = mock(UserSession.class);
 
-        ComponentDto componentDto = mock(ComponentDto.class);
+        ProjectDto componentDto = mock(ProjectDto.class);
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        when(componentFinder.getByKey(eq(dbSession), eq("projectKey"))).thenReturn(componentDto);
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("projectKey"))).thenReturn(componentDto);
 
         DeleteBindingAction testCase = new DeleteBindingAction(dbClient, userSession, componentFinder);
 
@@ -73,7 +73,7 @@ public class DeleteBindingActionTest {
         verify(dbSession).commit();
         verify(projectAlmSettingDao).deleteByProject(eq(dbSession), eq(componentDto));
         verify(response).noContent();
-        verify(userSession).checkComponentPermission("admin", componentDto);
+        verify(userSession).checkProjectPermission("admin", componentDto);
 
     }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/GetBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/GetBindingActionTest.java
@@ -25,7 +25,7 @@ import org.sonar.db.alm.setting.AlmSettingDao;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDao;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
-import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.exceptions.NotFoundException;
 import org.sonar.server.user.UserSession;
@@ -73,18 +73,18 @@ public class GetBindingActionTest {
         when(almSettingDto.getKey()).thenReturn("key");
         when(almSettingDto.getUrl()).thenReturn("url");
         when(dbClient.almSettingDao()).thenReturn(almSettingDao);
-        ComponentDto componentDto = mock(ComponentDto.class);
+        ProjectDto projectDto = mock(ProjectDto.class);
         ProjectAlmSettingDao projectAlmSettingDao = mock(ProjectAlmSettingDao.class);
         when(dbClient.projectAlmSettingDao()).thenReturn(projectAlmSettingDao);
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        when(componentDto.uuid()).thenReturn("projectUuid");
-        when(componentFinder.getByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
+        when(projectDto.getKey()).thenReturn("projectUuid");
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("project"))).thenReturn(projectDto);
         UserSession userSession = mock(UserSession.class);
         ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
         when(projectAlmSettingDto.getAlmSettingUuid()).thenReturn("almSettingUuid");
         when(projectAlmSettingDto.getAlmRepo()).thenReturn("repository");
         when(projectAlmSettingDto.getAlmSlug()).thenReturn("slug");
-        when(projectAlmSettingDao.selectByProject(eq(dbSession), eq(componentDto))).thenReturn(Optional.of(projectAlmSettingDto));
+        when(projectAlmSettingDao.selectByProject(eq(dbSession), eq(projectDto))).thenReturn(Optional.of(projectAlmSettingDto));
         ProtoBufWriter protoBufWriter = mock(ProtoBufWriter.class);
 
         GetBindingAction testCase = new GetBindingAction(dbClient, componentFinder, userSession, protoBufWriter);
@@ -122,12 +122,12 @@ public class GetBindingActionTest {
         when(projectAlmSettingDao.selectByProject(eq(dbSession), eq("projectUuid"))).thenReturn(Optional.empty());
         when(dbClient.projectAlmSettingDao()).thenReturn(projectAlmSettingDao);
 
-        ComponentDto componentDto = mock(ComponentDto.class);
-        when(componentDto.getKey()).thenReturn("projectKey");
+        ProjectDto projectDto = mock(ProjectDto.class);
+        when(projectDto.getKey()).thenReturn("project");
 
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        when(componentDto.uuid()).thenReturn("projectUuid");
-        when(componentFinder.getByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
+        when(projectDto.getKey()).thenReturn("project");
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("project"))).thenReturn(projectDto);
         UserSession userSession = mock(UserSession.class);
 
         GetBindingAction testCase = new GetBindingAction(dbClient, componentFinder, userSession);
@@ -139,7 +139,7 @@ public class GetBindingActionTest {
         when(request.mandatoryParam("project")).thenReturn("project");
         when(request.getMediaType()).thenReturn("dummy");
 
-        assertThatThrownBy(() -> testCase.handle(request, response)).isInstanceOf(NotFoundException.class).hasMessage("Project 'projectKey' is not bound to any ALM");
+        assertThatThrownBy(() -> testCase.handle(request, response)).isInstanceOf(NotFoundException.class).hasMessage("Project 'project' is not bound to any ALM");
     }
 
     @Test
@@ -151,10 +151,10 @@ public class GetBindingActionTest {
         ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
         when(projectAlmSettingDto.getAlmSettingUuid()).thenReturn("settingUuid");
 
-        ComponentDto componentDto = mock(ComponentDto.class);
-        when(componentDto.getKey()).thenReturn("projectKey");
+        ProjectDto projectDto = mock(ProjectDto.class);
+        when(projectDto.getKey()).thenReturn("project");
 
-        when(projectAlmSettingDao.selectByProject(eq(dbSession), eq(componentDto))).thenReturn(Optional.of(projectAlmSettingDto));
+        when(projectAlmSettingDao.selectByProject(eq(dbSession), eq(projectDto))).thenReturn(Optional.of(projectAlmSettingDto));
         when(dbClient.projectAlmSettingDao()).thenReturn(projectAlmSettingDao);
 
         AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
@@ -162,8 +162,8 @@ public class GetBindingActionTest {
         when(almSettingDao.selectByKey(eq(dbSession), eq("settingUuid"))).thenReturn(Optional.empty());
 
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        when(componentDto.uuid()).thenReturn("projectUuid");
-        when(componentFinder.getByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
+        when(projectDto.getKey()).thenReturn("projectUuid");
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("project"))).thenReturn(projectDto);
         UserSession userSession = mock(UserSession.class);
 
         GetBindingAction testCase = new GetBindingAction(dbClient, componentFinder, userSession);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsActionTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -110,6 +111,49 @@ public class ListDefinitionsActionTest {
                 .build())
             .addGitlab(AlmSettings.AlmSettingGitlab.newBuilder()
                 .setKey("gitlabKey")
+                .setPersonalAccessToken("gitlabPersonalAccessToken")
+                .build())
+            .build();
+
+        assertThat(message).isInstanceOf(AlmSettings.ListDefinitionsWsResponse.class).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    public void testHandleWithGitlabUrl() {
+        DbClient dbClient = mock(DbClient.class);
+        DbSession dbSession = mock(DbSession.class);
+        when(dbClient.openSession(eq(false))).thenReturn(dbSession);
+        AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
+
+        AlmSettingDto gitlabAlmSettingDto = mock(AlmSettingDto.class);
+        when(gitlabAlmSettingDto.getAlm()).thenReturn(ALM.GITLAB);
+        when(gitlabAlmSettingDto.getKey()).thenReturn("gitlabKey");
+        when(gitlabAlmSettingDto.getUrl()).thenReturn("url");
+        when(gitlabAlmSettingDto.getPersonalAccessToken()).thenReturn("gitlabPersonalAccessToken");
+        when(gitlabAlmSettingDto.getUrl()).thenReturn("url");
+
+        when(almSettingDao.selectAll(eq(dbSession))).thenReturn(Collections.singletonList(gitlabAlmSettingDto));
+        when(dbClient.almSettingDao()).thenReturn(almSettingDao);
+
+        UserSession userSession = mock(UserSession.class);
+
+        ProtoBufWriter protoBufWriter = mock(ProtoBufWriter.class);
+
+        ListDefinitionsAction testCase = new ListDefinitionsAction(dbClient, userSession, protoBufWriter);
+
+        Request request = mock(Request.class, Mockito.RETURNS_DEEP_STUBS);
+        Response response = mock(Response.class, Mockito.RETURNS_DEEP_STUBS);
+
+        testCase.handle(request, response);
+
+        ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(protoBufWriter).write(messageArgumentCaptor.capture(), eq(request), eq(response));
+        Message message = messageArgumentCaptor.getValue();
+
+        AlmSettings.ListDefinitionsWsResponse expectedResponse = AlmSettings.ListDefinitionsWsResponse.newBuilder()
+           .addGitlab(AlmSettings.AlmSettingGitlab.newBuilder()
+                .setKey("gitlabKey")
+                .setUrl("url")
                 .setPersonalAccessToken("gitlabPersonalAccessToken")
                 .build())
             .build();

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingActionTest.java
@@ -22,6 +22,7 @@ import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDao;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 import org.sonar.db.component.ComponentDto;
+import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
@@ -74,9 +75,9 @@ public class SetBindingActionTest {
         ProjectAlmSettingDao projectAlmSettingDao = mock(ProjectAlmSettingDao.class);
         when(dbClient.projectAlmSettingDao()).thenReturn(projectAlmSettingDao);
         ComponentFinder componentFinder = mock(ComponentFinder.class);
-        ComponentDto componentDto = mock(ComponentDto.class);
-        when(componentDto.uuid()).thenReturn("projectUuid");
-        when(componentFinder.getByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
+        ProjectDto componentDto = mock(ProjectDto.class);
+        when(componentDto.getUuid()).thenReturn("projectUuid");
+        when(componentFinder.getProjectByKey(eq(dbSession), eq("project"))).thenReturn(componentDto);
         UserSession userSession = mock(UserSession.class);
         ThreadLocal<WebService.NewAction> capturedAction = new ThreadLocal<>();
         ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/CreateGitlabActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/CreateGitlabActionTest.java
@@ -30,11 +30,17 @@ public class CreateGitlabActionTest {
         when(personalAccessTokenParameter.setRequired(anyBoolean())).thenReturn(personalAccessTokenParameter);
         when(newAction.createParam(eq("personalAccessToken"))).thenReturn(personalAccessTokenParameter);
 
+        WebService.NewParam urlParameter = mock(WebService.NewParam.class);
+        when(urlParameter.setMaximumLength(any(Integer.class))).thenReturn(urlParameter);
+        when(newAction.createParam(eq("url"))).thenReturn(urlParameter);
+
         CreateGitlabAction testCase = new CreateGitlabAction(dbClient, userSession);
         testCase.configureAction(newAction);
 
         verify(personalAccessTokenParameter).setRequired(eq(true));
         verify(personalAccessTokenParameter).setMaximumLength(2000);
+
+        verify(urlParameter).setMaximumLength(2000);
     }
 
     @Test
@@ -49,5 +55,24 @@ public class CreateGitlabActionTest {
         AlmSettingDto result = testCase.createAlmSettingDto("key", request);
 
         assertThat(result).isEqualToComparingFieldByField(new AlmSettingDto().setAlm(ALM.GITLAB).setKey("key").setPersonalAccessToken("personalAccessToken"));
+    }
+
+    @Test
+    public void testCreateAlmSettingDtoWithUrl() {
+        DbClient dbClient = mock(DbClient.class);
+        UserSession userSession = mock(UserSession.class);
+
+        Request request = mock(Request.class);
+        when(request.mandatoryParam(eq("personalAccessToken"))).thenReturn("personalAccessToken");
+        when(request.param(eq("url"))).thenReturn("url");
+
+        CreateGitlabAction testCase = new CreateGitlabAction(dbClient, userSession);
+        AlmSettingDto result = testCase.createAlmSettingDto("key", request);
+
+        assertThat(result).isEqualToComparingFieldByField(new AlmSettingDto()
+            .setAlm(ALM.GITLAB)
+            .setKey("key")
+            .setUrl("url")
+            .setPersonalAccessToken("personalAccessToken"));
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/UpdateGitlabActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/UpdateGitlabActionTest.java
@@ -29,11 +29,17 @@ public class UpdateGitlabActionTest {
         when(personalAccessTokenParameter.setRequired(anyBoolean())).thenReturn(personalAccessTokenParameter);
         when(newAction.createParam(eq("personalAccessToken"))).thenReturn(personalAccessTokenParameter);
 
+        WebService.NewParam urlParameter = mock(WebService.NewParam.class);
+        when(urlParameter.setMaximumLength(any(Integer.class))).thenReturn(urlParameter);
+        when(newAction.createParam(eq("url"))).thenReturn(urlParameter);
+
         UpdateGitlabAction testCase = new UpdateGitlabAction(dbClient, userSession);
         testCase.configureAction(newAction);
 
         verify(personalAccessTokenParameter).setRequired(eq(true));
         verify(personalAccessTokenParameter).setMaximumLength(2000);
+
+        verify(urlParameter).setMaximumLength(2000);
     }
 
     @Test
@@ -48,5 +54,23 @@ public class UpdateGitlabActionTest {
         AlmSettingDto result = testCase.updateAlmSettingsDto(new AlmSettingDto().setKey("originalKey"), request);
 
         assertThat(result).isEqualToComparingFieldByField(new AlmSettingDto().setKey("originalKey").setPersonalAccessToken("personalAccessToken"));
+    }
+
+    @Test
+    public void testUpdateAlmSettingsDtoWithUrl() {
+        DbClient dbClient = mock(DbClient.class);
+        UserSession userSession = mock(UserSession.class);
+
+        Request request = mock(Request.class);
+        when(request.mandatoryParam(eq("personalAccessToken"))).thenReturn("personalAccessToken");
+        when(request.param(eq("url"))).thenReturn("url");
+
+        UpdateGitlabAction testCase = new UpdateGitlabAction(dbClient, userSession);
+        AlmSettingDto result = testCase.updateAlmSettingsDto(new AlmSettingDto().setKey("originalKey").setUrl("url"), request);
+
+        assertThat(result).isEqualToComparingFieldByField(new AlmSettingDto()
+            .setKey("originalKey")
+            .setUrl("url")
+            .setPersonalAccessToken("personalAccessToken"));
     }
 }


### PR DESCRIPTION
Manual merge of @Iloer's Azure DevOps PR into @mc1arke's sq-8_2-support branch (with some additions to get it all working).

- Add support for Azure DevOps PR Decoration

Notes: 

1. The following should be set in the scanner properties:
sonar.pullrequest.vsts.instanceUrl=https://[organization].visualstudio.com/
sonar.pullrequest.vsts.project=[Project]
sonar.pullrequest.vsts.repository=[Repository]

2. Ensure that the following option is **unchecked** in the Azure DevOps Branch Policy configuration, otherwise an exception will be thrown:
**"Reset status whenever there are new changes"**