### PR TITLE
Allows the bitbucket clients to have different upload limits

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
@@ -25,6 +25,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.UnifyConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketClient;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketClientFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketException;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
@@ -65,8 +66,6 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
     public static final String PULL_REQUEST_BITBUCKET_REPOSITORY_SLUG = "sonar.pullrequest.bitbucket.repositorySlug";
 
     private static final Logger LOGGER = Loggers.get(BitbucketPullRequestDecorator.class);
-
-    private static final int DEFAULT_MAX_ANNOTATIONS = 1000;
 
     private static final DecorationResult DEFAULT_DECORATION_RESULT = DecorationResult.builder().build();
 
@@ -139,7 +138,9 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
 
         client.deleteAnnotations(project, repo, analysisDetails.getCommitSha());
 
-        Map<Object, Set<CodeInsightsAnnotation>> annotationChunks = analysisDetails.getPostAnalysisIssueVisitor().getIssues().stream()
+        AnnotationUploadLimit uploadLimit = client.getAnnotationUploadLimit();
+
+        Map<Integer, Set<CodeInsightsAnnotation>> annotationChunks = analysisDetails.getPostAnalysisIssueVisitor().getIssues().stream()
                 .filter(i -> i.getComponent().getReportAttributes().getScmPath().isPresent())
                 .filter(i -> i.getComponent().getType() == Component.Type.FILE)
                 .filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().status()))
@@ -153,10 +154,17 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                             path,
                             toBitbucketSeverity(componentIssue.getIssue().severity()),
                             toBitbucketType(componentIssue.getIssue().type()));
-                }).collect(Collectors.groupingBy(s -> chunkCounter.getAndIncrement() / DEFAULT_MAX_ANNOTATIONS, toSet()));
+                }).collect(Collectors.groupingBy(s -> chunkCounter.getAndIncrement() / uploadLimit.getAnnotationBatchSize(), toSet()));
 
+        int totalAnnotationsCounter = 1;
         for (Set<CodeInsightsAnnotation> annotations : annotationChunks.values()) {
             try {
+                if (exceedsMaximumNumberOfAnnotations(totalAnnotationsCounter++, uploadLimit)) {
+                    LOGGER.warn("This project has too many issues. The provider only supports {}." +
+                            " The remaining annotations will be truncated.", uploadLimit.getTotalAllowedAnnotations());
+                    break;
+                }
+
                 client.uploadAnnotations(project, repo, analysisDetails.getCommitSha(), annotations);
             } catch (BitbucketException e) {
                 if (e.isError(BitbucketException.PAYLOAD_TOO_LARGE)) {
@@ -164,9 +172,13 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                 } else {
                     throw e;
                 }
-
             }
         }
+    }
+
+    @VisibleForTesting
+    static boolean exceedsMaximumNumberOfAnnotations(int chunkCounter, AnnotationUploadLimit uploadLimit) {
+        return (chunkCounter * uploadLimit.getAnnotationBatchSize()) > uploadLimit.getTotalAllowedAnnotations();
     }
 
     private String toBitbucketSeverity(String severity) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClient.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.DataValue;
@@ -88,5 +89,16 @@ public interface BitbucketClient {
      * @return boolean
      */
     boolean supportsCodeInsights();
+
+    /**
+     * <p>
+     *     Returns the annotation upload limit consisting of two different objects:
+     *     1. the batch size for each incremental annotation upload
+     *     2. the total allowed annotations for the given provider
+     * </p>
+     *
+     * @return the configured limit
+     */
+    AnnotationUploadLimit getAnnotationUploadLimit();
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClient.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
@@ -142,6 +143,11 @@ public class BitbucketCloudClient implements BitbucketClient {
     @Override
     public boolean supportsCodeInsights() {
         return true;
+    }
+
+    @Override
+    public AnnotationUploadLimit getAnnotationUploadLimit() {
+        return new AnnotationUploadLimit(100, 1000);
     }
 
     void deleteExistingReport(String project, String repository, String commit) throws IOException {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketServerClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketServerClient.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
@@ -149,6 +150,11 @@ public class BitbucketServerClient implements BitbucketClient {
             return false;
         }
         return false;
+    }
+
+    @Override
+    public AnnotationUploadLimit getAnnotationUploadLimit() {
+        return new AnnotationUploadLimit(1000, 1000);
     }
 
     public ServerProperties getServerProperties() throws IOException {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/AnnotationUploadLimit.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/AnnotationUploadLimit.java
@@ -1,0 +1,22 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model;
+
+/**
+ * Determines the different upload limits for both bitbucket cloud and bitbucket server.
+ */
+public class AnnotationUploadLimit {
+    private final int annotationBatchSize;
+    private final int totalAllowedAnnotations;
+
+    public AnnotationUploadLimit(int annotationBatchSize, int totalAllowedAnnotations) {
+        this.annotationBatchSize = annotationBatchSize;
+        this.totalAllowedAnnotations = totalAllowedAnnotations;
+    }
+
+    public int getAnnotationBatchSize() {
+        return annotationBatchSize;
+    }
+
+    public int getTotalAllowedAnnotations() {
+        return totalAllowedAnnotations;
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClientUnitTest.java
@@ -1,7 +1,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
@@ -125,6 +125,17 @@ public class BitbucketCloudClientUnitTest {
         Request request = captor.getValue();
         assertEquals("POST", request.method());
         assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+    }
+
+    @Test
+    public void testUploadLimit() {
+        // given
+        // when
+        AnnotationUploadLimit annotationUploadLimit = underTest.getAnnotationUploadLimit();
+
+        // then
+        assertEquals(100, annotationUploadLimit.getAnnotationBatchSize());
+        assertEquals(1000, annotationUploadLimit.getTotalAllowedAnnotations());
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketServerClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketServerClientUnitTest.java
@@ -2,6 +2,7 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
@@ -368,6 +369,17 @@ public class BitbucketServerClientUnitTest {
         // then
         assertTrue(data instanceof DataValue.Link);
         assertEquals("https://localhost:9000/any/project", ((DataValue.Link) data).getHref());
+    }
+
+    @Test
+    public void testUploadLimit() {
+        // given
+        // when
+        AnnotationUploadLimit annotationUploadLimit = underTest.getAnnotationUploadLimit();
+
+        // then
+        assertEquals(1000, annotationUploadLimit.getAnnotationBatchSize());
+        assertEquals(1000, annotationUploadLimit.getTotalAllowedAnnotations());
     }
 
     @Test


### PR DESCRIPTION
This commit fixes an issue with Bitbucket Cloud if more than 100 annotations
are present. Annotations will be chunked from now on on batches of 100 until
the total allowed of 1000 is reached.

For Bitbucket Server nothing changed.

Closes #209

Example error message:

```
sonarqube    | 2020.07.17 19:52:19 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Create report on bitbucket cloud
sonarqube    | 2020.07.17 19:52:20 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:21 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:22 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:23 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:24 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:26 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:27 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:28 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:30 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:31 INFO  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.c.BitbucketCloudClient] Creating annotations on bitbucket cloud
sonarqube    | 2020.07.17 19:52:32 WARN  ce[AXNeVZecvjAJsjSGH1p9][c.g.m.s.p.c.p.b.BitbucketPullRequestDecorator] This project has too many issues. The provider only supports 1000. The remaining annotations will be truncated.
```

Successful report in Bitbucket Cloud:

![image](https://user-images.githubusercontent.com/708887/87825859-2d4eef80-c878-11ea-840d-818045e5b058.png)
