### PR TITLE
Bugfix: #201 could not decorate gitlab merge request

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecorator.java
@@ -104,15 +104,16 @@ public class GitlabServerPullRequestDecorator implements PullRequestBuildStatusD
 
         try {
             final String apiURL = Optional.ofNullable(StringUtils.stripToNull(almSettingDto.getUrl()))
-                .orElse(analysis.getScannerProperty(PULLREQUEST_GITLAB_INSTANCE_URL)
-                .orElseThrow(() -> new IllegalStateException(String.format(
-                            "Could not decorate Gitlab merge request. '%s' has not been set in scanner properties",
-                            PULLREQUEST_GITLAB_INSTANCE_URL))));
+                    .orElseGet(() -> analysis.getScannerProperty(PULLREQUEST_GITLAB_INSTANCE_URL)
+                            .orElseThrow(() -> new IllegalStateException(String.format(
+                                    "Could not decorate Gitlab merge request. '%s' has not been set in scanner properties",
+                                    PULLREQUEST_GITLAB_INSTANCE_URL))));
             final String apiToken = almSettingDto.getPersonalAccessToken();
-            final String projectId = analysis.getScannerProperty(PULLREQUEST_GITLAB_PROJECT_ID).orElseThrow(
-                    () -> new IllegalStateException(String.format(
-                            "Could not decorate Gitlab merge request. '%s' has not been set in scanner properties",
-                            PULLREQUEST_GITLAB_PROJECT_ID)));
+            final String projectId = Optional.ofNullable(StringUtils.stripToNull(projectAlmSettingDto.getAlmRepo()))
+                    .orElseGet(() -> analysis.getScannerProperty(PULLREQUEST_GITLAB_PROJECT_ID)
+                            .orElseThrow(() -> new IllegalStateException(String.format(
+                                    "Could not decorate Gitlab merge request. '%s' has not been set in scanner properties",
+                                    PULLREQUEST_GITLAB_PROJECT_ID))));
             final String pullRequestId = analysis.getBranchName();
 
             final String projectURL = apiURL + String.format("/projects/%s", URLEncoder

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/SetGitlabBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/SetGitlabBindingAction.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.gitlab;
 
 import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 import org.sonar.server.component.ComponentFinder;
@@ -27,15 +28,25 @@ import org.sonar.server.user.UserSession;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.SetBindingAction;
 
 public class SetGitlabBindingAction extends SetBindingAction {
+    private static final String REPOSITORY_PARAMETER = "repository";
 
     public SetGitlabBindingAction(DbClient dbClient, ComponentFinder componentFinder, UserSession userSession) {
         super(dbClient, componentFinder, userSession, "set_gitlab_binding");
     }
 
     @Override
+    protected void configureAction(WebService.NewAction action) {
+        super.configureAction(action);
+        action.createParam(REPOSITORY_PARAMETER);
+    }
+
+    @Override
     protected ProjectAlmSettingDto createProjectAlmSettingDto(String projectUuid, String settingsUuid,
                                                               Request request) {
-        return new ProjectAlmSettingDto().setProjectUuid(projectUuid).setAlmSettingUuid(settingsUuid);
+        return new ProjectAlmSettingDto()
+                .setProjectUuid(projectUuid)
+                .setAlmSettingUuid(settingsUuid)
+                .setAlmRepo(request.param(REPOSITORY_PARAMETER));
     }
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/SetGitlabBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/gitlab/SetGitlabBindingActionTest.java
@@ -1,17 +1,46 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.gitlab;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
 import org.junit.Test;
 import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 import org.sonar.server.component.ComponentFinder;
 import org.sonar.server.user.UserSession;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 public class SetGitlabBindingActionTest {
+
+    @Test
+    public void testConfigureAction() {
+        DbClient dbClient = mock(DbClient.class);
+        UserSession userSession = mock(UserSession.class);
+        ComponentFinder componentFinder = mock(ComponentFinder.class);
+
+        WebService.NewAction newAction = mock(WebService.NewAction.class);
+
+        WebService.NewParam repositoryParameter = mock(WebService.NewParam.class);
+        when(newAction.createParam(eq("repository"))).thenReturn(repositoryParameter);
+
+        WebService.NewParam almSettingParameter = mock(WebService.NewParam.class);
+        when(almSettingParameter.setRequired(anyBoolean())).thenReturn(almSettingParameter);
+        when(newAction.createParam(eq("almSetting"))).thenReturn(almSettingParameter);
+
+        SetGitlabBindingAction testCase = new SetGitlabBindingAction(dbClient, componentFinder, userSession);
+        testCase.configureAction(newAction);
+
+        verify(newAction).createParam(eq("repository"));
+
+        verify(almSettingParameter).setRequired(eq(true));
+    }
 
     @Test
     public void testCreateProjectAlmSettingDto() {
@@ -20,12 +49,13 @@ public class SetGitlabBindingActionTest {
         ComponentFinder componentFinder = mock(ComponentFinder.class);
 
         Request request = mock(Request.class);
+        when(request.param("repository")).thenReturn("repositoryId");
 
         SetGitlabBindingAction testCase = new SetGitlabBindingAction(dbClient, componentFinder, userSession);
         ProjectAlmSettingDto result = testCase.createProjectAlmSettingDto("projectUuid", "settingsUuid", request);
 
-        assertThat(result).isEqualToComparingFieldByField(new ProjectAlmSettingDto().setProjectUuid("projectUuid").setAlmSettingUuid("settingsUuid"));
+        assertThat(result).isEqualToComparingFieldByField(new ProjectAlmSettingDto().setProjectUuid("projectUuid").setAlmSettingUuid("settingsUuid").setAlmRepo("repositoryId"));
+        verify(request).param("repository");
         verifyNoMoreInteractions(request);
-
     }
 }


### PR DESCRIPTION
Enables GitLab merge request to be decorated. This PR fixes issue #201 for SonarQube 8.2+.