### PR TITLE
Bugfix: #93 html tags not escaped on gitlab pull request decoration

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactory.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup;
 
 import java.util.stream.IntStream;
+import static com.google.common.html.HtmlEscapers.htmlEscaper;
 
 public final class MarkdownFormatterFactory implements FormatterFactory {
 
@@ -110,7 +111,7 @@ public final class MarkdownFormatterFactory implements FormatterFactory {
         return new BaseFormatter<Text>() {
             @Override
             public String format(Text node, FormatterFactory formatterFactory) {
-                return node.getContent();
+                return htmlEscaper().escape(node.getContent()).trim();
             }
         };
     }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactoryTest.java
@@ -84,4 +84,18 @@ public class MarkdownFormatterFactoryTest {
         MarkdownFormatterFactory testCase = new MarkdownFormatterFactory();
         assertEquals("Text", testCase.textFormatter().format(new Text("Text"), testCase));
     }
+
+    @Test
+    public void testContentTextFormatterEscapedHtml(){
+        MarkdownFormatterFactory testCase = new MarkdownFormatterFactory();
+        assertEquals("&lt;p&gt; no html allowed", testCase.textFormatter().format(new Text("<p> no html allowed"), testCase));
+        assertEquals("no html &lt;p&gt; allowed", testCase.textFormatter().format(new Text("no html <p> allowed"), testCase));
+        assertEquals("&lt;/i&gt;no html &lt;p&gt; allowed&lt;i&gt;", testCase.textFormatter().format(new Text("</i>no html <p> allowed<i>"), testCase));
+    }
+
+    @Test
+    public void testContentTextFormatterTrimWhitespaceAtBeginAndEnd(){
+        MarkdownFormatterFactory testCase = new MarkdownFormatterFactory();
+        assertEquals("", testCase.textFormatter().format(new Text("             "), testCase));
+    }
 }


### PR DESCRIPTION
Escapes HTML tags in GitLab Merge Request decorations. This PR fixes issue #93. This PR depends on PR #214.