### PR TITLE
fix code smell image path in the analysis summary

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -175,7 +175,7 @@ public class AnalysisDetails {
                                                          issueCounts.get(RuleType.SECURITY_HOTSPOT), "Vulnerability",
                                                          "Vulnerabilities"))), new ListItem(new Image("Code Smell",
                                                                                                       baseImageUrl +
-                                                                                                      "/common/vulnerability.svg?sanitize=true"),
+                                                                                                      "/common/code_smell.svg?sanitize=true"),
                                                                                             new Text(" "), new Text(
                                                  pluralOf(issueCounts.get(RuleType.CODE_SMELL), "Code Smell",
                                                           "Code Smells")))),

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
@@ -339,7 +339,7 @@ public class AnalysisDetailsTest {
                                                                                                                      "2 Vulnerabilities")),
                                                                                                 new ListItem(new Image(
                                                                                                         "Code Smell",
-                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/vulnerability.svg?sanitize=true"),
+                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/code_smell.svg?sanitize=true"),
                                                                                                              new Text(
                                                                                                                      " "),
                                                                                                              new Text(
@@ -439,7 +439,7 @@ public class AnalysisDetailsTest {
                                                                                                                      "0 Vulnerabilities")),
                                                                                                 new ListItem(new Image(
                                                                                                         "Code Smell",
-                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/vulnerability.svg?sanitize=true"),
+                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/code_smell.svg?sanitize=true"),
                                                                                                              new Text(
                                                                                                                      " "),
                                                                                                              new Text(
@@ -546,7 +546,7 @@ public class AnalysisDetailsTest {
                                                                                                                     "0 Vulnerabilities")),
                                                                                                new ListItem(new Image(
                                                                                                        "Code Smell",
-                                                                                                       "http://host.name/path/common/vulnerability.svg?sanitize=true"),
+                                                                                                       "http://host.name/path/common/code_smell.svg?sanitize=true"),
                                                                                                             new Text(
                                                                                                                     " "),
                                                                                                             new Text(
@@ -644,7 +644,7 @@ public class AnalysisDetailsTest {
                                                                                                                      "0 Vulnerabilities")),
                                                                                                 new ListItem(new Image(
                                                                                                         "Code Smell",
-                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/vulnerability.svg?sanitize=true"),
+                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/code_smell.svg?sanitize=true"),
                                                                                                              new Text(
                                                                                                                      " "),
                                                                                                              new Text(


### PR DESCRIPTION
I have noticed that the Code Smell group in the PR decoration uses the same icon as the Vulnerabilities group.
This PR fixes this minor bug. It also includes the updated tests.