### PR TITLE
Send total coverage back to GitLab instead of new coverage

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -128,9 +128,7 @@ public class AnalysisDetails {
     public String createAnalysisSummary(FormatterFactory formatterFactory) {
 
         BigDecimal newCoverage = getNewCoverage().orElse(null);
-
-
-        double coverage = findMeasure(CoreMetrics.COVERAGE_KEY).map(Measure::getDoubleValue).orElse(0D);
+        BigDecimal coverage = getCoverage().orElse(null);
 
         BigDecimal newDuplications = findQualityGateCondition(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY)
                 .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
@@ -352,6 +350,10 @@ public class AnalysisDetails {
                 .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
                 .map(QualityGate.Condition::getValue)
                 .map(BigDecimal::new);
+    }
+
+    public Optional<BigDecimal> getCoverage(){
+        return findMeasure(CoreMetrics.COVERAGE_KEY).map(Measure::getDoubleValue).map(BigDecimal::new);
     }
 
     public static class BranchDetails {

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -86,7 +86,7 @@ public class GitlabServerPullRequestDecoratorTest {
         when(analysisDetails.getAnalysisProjectKey()).thenReturn(projectKey);
         when(analysisDetails.getBranchName()).thenReturn(branchName);
         when(analysisDetails.getCommitSha()).thenReturn(commitSHA);
-        when(analysisDetails.getNewCoverage()).thenReturn(Optional.of(BigDecimal.TEN));
+        when(analysisDetails.getCoverage()).thenReturn(Optional.of(BigDecimal.TEN));
         PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         DefaultIssue defaultIssue = mock(DefaultIssue.class);


### PR DESCRIPTION
Reworked version of #157 (and #145). Third time's the charm, right? 🤞

The coverage send back via the GitLab API should be the total coverage
of the project, not the coverage of the new code in the PR. The GitLab
docs explicitly mention this: 
https://docs.gitlab.com/ee/api/commits.html#post-the-build-status-to-a-commit

The coverage reported by decorating the PR via a comment is not affected;
this still shows both the total and new coverage.

Note that there is an open GitLab issue for natively displaying new coverage
for just the diff of a PR (https://gitlab.com/gitlab-org/gitlab/-/issues/20895),
but this is not yet implemented.

In addition, reporting coverage back is optional. So if there is no coverage
information, we do not report it back.