### PR TITLE
Bitbucket Cloud PR Decoration - Annotation summary is displaying a URL instead of the user message

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/CodeInsightsAnnotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/CodeInsightsAnnotation.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class CodeInsightsAnnotation {
     @JsonProperty("line")
     private final int line;
-    @JsonProperty("message")
+    @JsonProperty("summary")
     private final String message;
     @JsonProperty("path")
     private final String path;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudAnnotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudAnnotation.java
@@ -25,7 +25,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model
 public class CloudAnnotation extends CodeInsightsAnnotation {
     @JsonProperty("external_id")
     private final String externalId;
-    @JsonProperty("summary")
+    @JsonProperty("link")
     private final String link;
     @JsonProperty("annotation_type")
     private final String annotationType;


### PR DESCRIPTION
The message displayed in the annotation on the pull request is a URL which points to the issue in SonarQube. 

This is because the `summary` field of the annotation body is serialising `link`. See screenshot.

```
public class CloudAnnotation extends CodeInsightsAnnotation {
    @JsonProperty("external_id")
    private final String externalId;
    @JsonProperty("summary")
    private final String link;
    @JsonProperty("annotation_type")
    private final String annotationType;
```

Is this intentional? Would it not be better to serialise the message instead? Then the analysis message is visible directly in the PR.  

Furthermore, I can't see anywhere in the Bitbucket API where `message` is specified in annotation body.

```
public class CodeInsightsAnnotation {
    @JsonProperty("line")
    private final int line;
    @JsonProperty("message")
    private final String message;
```

**Software Versions**
 - SonarQube Version: 8.1
 - Plugin Version: [1.4.0]
![Screenshot 2020-08-23 at 11 23 38](https://user-images.githubusercontent.com/8506869/92323055-7415c600-f02d-11ea-82de-e5383cf55ad0.png)
