### PR TITLE
Back port #213 Add support for multiple pull request decoration in mono repo

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -287,6 +287,10 @@ public class AnalysisDetails {
         return project.getKey();
     }
 
+    public String getAnalysisProjectName() {
+        return project.getName();
+    }
+
     public List<QualityGate.Condition> findFailedConditions() {
         return qualityGate.getConditions().stream().filter(c -> c.getStatus() == QualityGate.EvaluationStatus.ERROR)
                 .collect(Collectors.toList());

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
@@ -132,7 +132,7 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
 
         Map<String, Object> inputObjectArguments = new HashMap<>();
         inputObjectArguments.put("repositoryId", repositoryAuthenticationToken.getRepositoryId());
-        inputObjectArguments.put("name", appName + " Results");
+        inputObjectArguments.put("name", String.format("%s Sonarqube Results", analysisDetails.getAnalysisProjectName()));
         inputObjectArguments.put("status", RequestableCheckStatusState.COMPLETED);
         inputObjectArguments.put("conclusion", QualityGate.Status.OK == analysisDetails.getQualityGateStatus() ?
                                    CheckConclusionState.SUCCESS : CheckConclusionState.FAILURE);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2020 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -363,6 +363,7 @@ public class GraphqlCheckRunProviderTest {
         when(analysisDetails.createAnalysisSummary(any())).thenReturn("dummy summary");
         when(analysisDetails.getCommitSha()).thenReturn("commit SHA");
         when(analysisDetails.getAnalysisProjectKey()).thenReturn("projectKey");
+        when(analysisDetails.getAnalysisProjectName()).thenReturn("projectName");
         when(analysisDetails.getBranchName()).thenReturn("branchName");
         when(analysisDetails.getAnalysisDate()).thenReturn(new Date(1234567890));
         when(analysisDetails.getAnalysisId()).thenReturn("analysis ID");
@@ -491,7 +492,7 @@ public class GraphqlCheckRunProviderTest {
         assertThat(annotationArgumentCaptor.getValue()).isEqualTo(expectedAnnotationObjects);
 
         verify(inputObjectBuilders.get(position + 1)).put(eq("repositoryId"), eq("repository ID"));
-        verify(inputObjectBuilders.get(position + 1)).put(eq("name"), eq("sonar.alm.github.app.name Results"));
+        verify(inputObjectBuilders.get(position + 1)).put(eq("name"), eq("projectName Sonarqube Results"));
         verify(inputObjectBuilders.get(position + 1)).put(eq("headSha"), eq("commit SHA"));
         verify(inputObjectBuilders.get(position + 1)).put(eq("status"), eq(RequestableCheckStatusState.COMPLETED));
         verify(inputObjectBuilders.get(position + 1)).put(eq("conclusion"), eq(status == QualityGate.Status.OK ?


### PR DESCRIPTION
If multiple micro-services are modified at once then only the final Sonarqube PR decoration appeared in the checks tab of Github. This change updates the name of the Status check to include the Sonarqube project name so that multiple checks can be attached to the one pull request.