### PR TITLE
Reduce memory usage of the PostAnalysisIssueVisitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,11 @@
 /.idea/
 *.iml
 
+# Eclipse
+/.classpath
+/.project
+/.settings/
+/bin/
+
 #Project libs
 /sonarqube-lib/

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     compile('io.aexp.nodes.graphql:nodes:0.5.0') {
         exclude group: 'com.fasterxml.jackson.core'
     }
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -20,7 +20,6 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
 
 
 import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Document;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Heading;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -20,6 +20,7 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
 
 
 import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Document;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Heading;
@@ -45,7 +46,6 @@ import org.sonar.ce.task.projectanalysis.component.TreeRootHolder;
 import org.sonar.ce.task.projectanalysis.measure.Measure;
 import org.sonar.ce.task.projectanalysis.measure.MeasureRepository;
 import org.sonar.ce.task.projectanalysis.metric.MetricRepository;
-import org.sonar.core.issue.DefaultIssue;
 import org.sonar.server.measure.Rating;
 
 import java.io.UnsupportedEncodingException;
@@ -201,7 +201,7 @@ public class AnalysisDetails {
     }
 
     public String createAnalysisIssueSummary(PostAnalysisIssueVisitor.ComponentIssue componentIssue, FormatterFactory formatterFactory) {
-        final DefaultIssue issue = componentIssue.getIssue();
+        final PostAnalysisIssueVisitor.LightIssue issue = componentIssue.getIssue();
 
         String baseImageUrl = getBaseImageUrl();
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitor.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
 
+import org.sonar.api.rules.RuleType;
 import org.sonar.ce.task.projectanalysis.component.Component;
 import org.sonar.ce.task.projectanalysis.issue.IssueVisitor;
 import org.sonar.core.issue.DefaultIssue;
@@ -25,6 +26,9 @@ import org.sonar.core.issue.DefaultIssue;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.CheckForNull;
 
 public class PostAnalysisIssueVisitor extends IssueVisitor {
 
@@ -42,20 +46,115 @@ public class PostAnalysisIssueVisitor extends IssueVisitor {
     public static class ComponentIssue {
 
         private final Component component;
-        private final DefaultIssue issue;
+        private final LightIssue issue;
 
         ComponentIssue(Component component, DefaultIssue issue) {
             super();
             this.component = component;
-            this.issue = issue;
+            this.issue = (issue != null) ? new LightIssue(issue) : null;
+            // the null test is to please PostAnalysisIssueVisitorTest.checkAllIssuesCollected()
         }
 
         public Component getComponent() {
             return component;
         }
 
-        public DefaultIssue getIssue() {
+        public LightIssue getIssue() {
             return issue;
         }
+    }
+
+    /**
+     * A simple bean for holding the useful bits of a #{@link DefaultIssue}.
+     * <br>
+     * It presents a subset of the #{@link DefaultIssue} interface, hence the inconsistent getters names,
+     * and CheckForNull annotations.
+     */
+    public static class LightIssue {
+
+        private final Long effortInMinutes;
+        private final String key;
+        private final Integer line;
+        private final String message;
+        private final String resolution;
+        private final String severity;
+        private final String status;
+        private final RuleType type;
+
+        private LightIssue(DefaultIssue issue) {
+            this.effortInMinutes = issue.effortInMinutes();
+            this.key = issue.key();
+            this.line = issue.getLine();
+            this.message = issue.getMessage();
+            this.resolution = issue.resolution();
+            this.severity = issue.severity();
+            this.status = issue.status();
+            this.type = issue.type();
+        }
+
+        @CheckForNull
+        public Long effortInMinutes() {
+            return effortInMinutes;
+        }
+
+        public String key() {
+            return key;
+        }
+
+        @CheckForNull
+        public Integer getLine() {
+            return line;
+        }
+
+        @CheckForNull
+        public String getMessage() {
+            return message;
+        }
+
+        @CheckForNull
+        public String resolution() {
+            return resolution;
+        }
+
+        public String severity() {
+            return severity;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public String status() {
+            return status;
+        }
+
+        public RuleType type() {
+            return type;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(effortInMinutes, key, line, message, resolution, severity, status, type);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            LightIssue other = (LightIssue) obj;
+            return Objects.equals(effortInMinutes, other.effortInMinutes)
+                    && Objects.equals(key, other.key)
+                    && Objects.equals(line, other.line)
+                    && Objects.equals(message, other.message)
+                    && Objects.equals(resolution, other.resolution)
+                    && Objects.equals(severity, other.severity)
+                    && Objects.equals(status, other.status)
+                    && type == other.type;
+        }
+
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
@@ -45,7 +45,6 @@ import org.sonar.ce.task.projectanalysis.measure.Measure;
 import org.sonar.ce.task.projectanalysis.measure.MeasureRepository;
 import org.sonar.ce.task.projectanalysis.metric.Metric;
 import org.sonar.ce.task.projectanalysis.metric.MetricRepository;
-import org.sonar.core.issue.DefaultIssue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -193,26 +192,26 @@ public class AnalysisDetailsTest {
         doReturn(treeRootHolder).when(measuresHolder).getTreeRootHolder();
 
         PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
-        DefaultIssue issue1 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue1 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         doReturn(Issue.STATUS_CLOSED).when(issue1).status();
 
-        DefaultIssue issue2 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue2 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         doReturn(Issue.STATUS_OPEN).when(issue2).status();
         doReturn(RuleType.BUG).when(issue2).type();
 
-        DefaultIssue issue3 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue3 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         doReturn(Issue.STATUS_OPEN).when(issue3).status();
         doReturn(RuleType.SECURITY_HOTSPOT).when(issue3).type();
 
-        DefaultIssue issue4 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue4 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         doReturn(Issue.STATUS_OPEN).when(issue4).status();
         doReturn(RuleType.CODE_SMELL).when(issue4).type();
 
-        DefaultIssue issue5 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue5 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         doReturn(Issue.STATUS_OPEN).when(issue5).status();
         doReturn(RuleType.VULNERABILITY).when(issue5).type();
 
-        DefaultIssue issue6 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue6 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         doReturn(Issue.STATUS_OPEN).when(issue6).status();
         doReturn(RuleType.BUG).when(issue6).type();
 
@@ -469,7 +468,7 @@ public class AnalysisDetailsTest {
         AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
         doReturn(treeRootHolder).when(measuresHolder).getTreeRootHolder();
 
-        DefaultIssue issue = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue = mock(PostAnalysisIssueVisitor.LightIssue.class);
         doReturn(Issue.STATUS_OPEN).when(issue).status();
         doReturn(RuleType.BUG).when(issue).type();
         PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -15,7 +15,6 @@ import org.sonar.api.rule.Severity;
 import org.sonar.api.rules.RuleType;
 import org.sonar.ce.task.projectanalysis.component.Component;
 import org.sonar.ce.task.projectanalysis.component.ReportAttributes;
-import org.sonar.core.issue.DefaultIssue;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
@@ -104,7 +103,7 @@ public class BitbucketPullRequestDecoratorTest {
         when(component.getType()).thenReturn(Component.Type.FILE);
         when(component.getReportAttributes()).thenReturn(reportAttributes);
 
-        DefaultIssue defaultIssue = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue defaultIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(defaultIssue.status()).thenReturn(Issue.STATUS_OPEN);
         when(defaultIssue.severity()).thenReturn(Severity.CRITICAL);
         when(defaultIssue.getLine()).thenReturn(ISSUE_LINE);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProviderTest.java
@@ -39,7 +39,6 @@ import org.sonar.api.platform.Server;
 import org.sonar.api.rule.Severity;
 import org.sonar.ce.task.projectanalysis.component.Component;
 import org.sonar.ce.task.projectanalysis.component.ReportAttributes;
-import org.sonar.core.issue.DefaultIssue;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
@@ -146,7 +145,7 @@ public class GraphqlCheckRunProviderTest {
         when(component.getType()).thenReturn(Component.Type.FILE);
         when(component.getReportAttributes()).thenReturn(reportAttributes);
 
-        DefaultIssue defaultIssue = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue defaultIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(defaultIssue.severity()).thenReturn("dummy");
         when(defaultIssue.status()).thenReturn(Issue.STATUS_OPEN);
         when(defaultIssue.resolution()).thenReturn(null);
@@ -239,7 +238,7 @@ public class GraphqlCheckRunProviderTest {
 
         when(server.getPublicRootUrl()).thenReturn("http://sonar.server/root");
 
-        DefaultIssue issue1 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue1 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(issue1.getLine()).thenReturn(2);
         when(issue1.getMessage()).thenReturn(messageInput[0]);
         when(issue1.severity()).thenReturn(Severity.INFO);
@@ -256,7 +255,7 @@ public class GraphqlCheckRunProviderTest {
         when(componentIssue1.getComponent()).thenReturn(component1);
         when(componentIssue1.getIssue()).thenReturn(issue1);
 
-        DefaultIssue issue2 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue2 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(issue2.getLine()).thenReturn(null);
         when(issue2.getMessage()).thenReturn(messageInput[1]);
         when(issue2.status()).thenReturn(Issue.STATUS_OPEN);
@@ -273,7 +272,7 @@ public class GraphqlCheckRunProviderTest {
         when(component2.getReportAttributes()).thenReturn(reportAttributes);
         when(component2.getType()).thenReturn(Component.Type.FILE);
 
-        DefaultIssue issue3 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue3 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(issue3.getLine()).thenReturn(9);
         when(issue3.severity()).thenReturn(Severity.CRITICAL);
         when(issue3.getMessage()).thenReturn(messageInput[2]);
@@ -290,7 +289,7 @@ public class GraphqlCheckRunProviderTest {
         when(component3.getReportAttributes()).thenReturn(reportAttributes);
         when(component3.getType()).thenReturn(Component.Type.PROJECT);
 
-        DefaultIssue issue4 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue4 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(issue4.getLine()).thenReturn(2);
         when(issue4.severity()).thenReturn(Severity.CRITICAL);
         when(issue4.getMessage()).thenReturn(messageInput[3]);
@@ -301,7 +300,7 @@ public class GraphqlCheckRunProviderTest {
         when(componentIssue4.getComponent()).thenReturn(component3);
         when(componentIssue4.getIssue()).thenReturn(issue4);
 
-        DefaultIssue issue5 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue5 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(issue5.getLine()).thenReturn(1999);
         when(issue5.severity()).thenReturn(Severity.MAJOR);
         when(issue5.getMessage()).thenReturn(messageInput[4]);
@@ -312,7 +311,7 @@ public class GraphqlCheckRunProviderTest {
         when(componentIssue5.getComponent()).thenReturn(component2);
         when(componentIssue5.getIssue()).thenReturn(issue5);
 
-        DefaultIssue issue6 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue6 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(issue6.getLine()).thenReturn(42);
         when(issue6.severity()).thenReturn(Severity.MINOR);
         when(issue6.getMessage()).thenReturn(messageInput[5]);
@@ -323,7 +322,7 @@ public class GraphqlCheckRunProviderTest {
         when(componentIssue6.getComponent()).thenReturn(component2);
         when(componentIssue6.getIssue()).thenReturn(issue6);
 
-        DefaultIssue issue7 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue7 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(issue7.getLine()).thenReturn(42);
         when(issue7.severity()).thenReturn(Severity.MINOR);
         when(issue7.getMessage()).thenReturn(messageInput[6]);
@@ -334,7 +333,7 @@ public class GraphqlCheckRunProviderTest {
         when(componentIssue7.getComponent()).thenReturn(component2);
         when(componentIssue7.getIssue()).thenReturn(issue7);
 
-        DefaultIssue issue8 = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue issue8 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(issue8.getLine()).thenReturn(42);
         when(issue8.severity()).thenReturn(Severity.MINOR);
         when(issue8.status()).thenReturn(Issue.STATUS_RESOLVED);
@@ -511,7 +510,7 @@ public class GraphqlCheckRunProviderTest {
         when(component.getReportAttributes()).thenReturn(reportAttributes);
         List<PostAnalysisIssueVisitor.ComponentIssue> issues = IntStream.range(0, 120)
                 .mapToObj(i -> {
-                    DefaultIssue defaultIssue = mock(DefaultIssue.class);
+                    PostAnalysisIssueVisitor.LightIssue defaultIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
                     when(defaultIssue.severity()).thenReturn(Severity.INFO);
                     when(defaultIssue.getMessage()).thenReturn("message");
                     when(defaultIssue.status()).thenReturn(Issue.STATUS_OPEN);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabServerPullRequestDecoratorTest.java
@@ -30,7 +30,6 @@ import org.sonar.ce.task.projectanalysis.component.Component;
 import org.sonar.ce.task.projectanalysis.scm.Changeset;
 import org.sonar.ce.task.projectanalysis.scm.ScmInfo;
 import org.sonar.ce.task.projectanalysis.scm.ScmInfoRepository;
-import org.sonar.core.issue.DefaultIssue;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
@@ -89,7 +88,7 @@ public class GitlabServerPullRequestDecoratorTest {
         when(analysisDetails.getNewCoverage()).thenReturn(Optional.of(BigDecimal.TEN));
         PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
-        DefaultIssue defaultIssue = mock(DefaultIssue.class);
+        PostAnalysisIssueVisitor.LightIssue defaultIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(defaultIssue.getStatus()).thenReturn(Issue.STATUS_OPEN);
         when(defaultIssue.getLine()).thenReturn(lineNumber);
         when(componentIssue.getIssue()).thenReturn(defaultIssue);


### PR DESCRIPTION
The collection of `DefaultIssue` objects hold by the `PostAnalysisIssueVisitor` can take a significant amount of memory in the CE process heap, when there are numerous issues (a `DefaultIssue` alone can weigh several 10th of kilobytes). 

A small example in Eclipse MAT (and I've seen much worse):
![heap](https://user-images.githubusercontent.com/6212720/96252376-2d16db00-0fb2-11eb-8850-c332f4077631.png)

This PR mostly fixes that. The logic is unchanged: there is still a list of issues to be processed at the end. But it contains lighter objects, with only the few members which would actually be used later to decorate pullrequests. On our production instances (1.3.2 plugin / SQ 7.9 LTS), a similar patch made a major difference on the CE processes memory footprint.

I've tried to write this patch to minimize impact/changes on the code. The `PostAnalysisIssueVisitor.LightIssue` class exposes a subset of the `DefaultIssue` public interface, thus the changes are mostly limited to the actual return type of `PostAnalysisIssueVisitor.ComponentIssue#getIssue()`.