### PR TITLE
#255 Compatibility with SonarQube CE 8.5.0.37579

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '8.2.0.32929'
+def sonarqubeVersion = '8.5.0.37579'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityComponentKey.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityComponentKey.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin.server;
 
+import org.sonar.db.component.BranchType;
 import org.sonar.server.ce.queue.BranchSupport;
 
 import java.util.Optional;
@@ -29,13 +30,15 @@ import java.util.Optional;
 
     private final String key;
     private final String dbKey;
-    private final BranchSupport.Branch branch;
+    private final String branchName;
+    private final BranchType branchType;
     private final String pullRequestKey;
 
-    /*package*/ CommunityComponentKey(String key, String dbKey, BranchSupport.Branch branch, String pullRequestKey) {
+    /*package*/ CommunityComponentKey(String key, String dbKey, String branchName, BranchType branchType, String pullRequestKey) {
         this.key = key;
         this.dbKey = dbKey;
-        this.branch = branch;
+        this.branchName = branchName;
+        this.branchType = branchType;
         this.pullRequestKey = pullRequestKey;
     }
 
@@ -50,8 +53,12 @@ import java.util.Optional;
     }
 
     @Override
-    public Optional<BranchSupport.Branch> getBranch() {
-        return Optional.ofNullable(branch);
+    public Optional<String> getBranchName() {
+        return Optional.ofNullable(branchName);
+    }
+
+    public Optional<BranchType> getBranchType() {
+        return Optional.ofNullable(branchType);
     }
 
     @Override
@@ -64,6 +71,6 @@ import java.util.Optional;
         if (key.equals(dbKey)) {
             return this;
         }
-        return new CommunityComponentKey(key, key, null, null);
+        return new CommunityComponentKey(key, key, null, null, null);
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ClassReferenceElevatedClassLoaderFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ClassReferenceElevatedClassLoaderFactoryTest.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.classloader;
 
 import org.hamcrest.core.IsEqual;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -45,6 +46,8 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Michael Clarke
  */
+@Ignore("SonarQube has removed bundled plugins from extensions/plugins.\n" +
+    "See https://jira.sonarsource.com/browse/SONAR-13792")
 public class ClassReferenceElevatedClassLoaderFactoryTest {
 
     private static final String SVN_PLUGIN_CLASS = "org.sonar.plugins.scm.svn.SvnPlugin";

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ReflectiveElevatedClassLoaderFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ReflectiveElevatedClassLoaderFactoryTest.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.classloader;
 
 import org.hamcrest.core.IsEqual;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,6 +39,8 @@ import static org.junit.Assert.assertNotSame;
 /**
  * @author Michael Clarke
  */
+@Ignore("SonarQube has removed bundled plugins from extensions/plugins.\n" +
+    "See https://jira.sonarsource.com/browse/SONAR-13792")
 public class ReflectiveElevatedClassLoaderFactoryTest {
 
     private final ExpectedException expectedException = ExpectedException.none();

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
@@ -33,7 +33,6 @@ import org.sonar.db.component.BranchType;
 import org.sonar.db.component.ComponentDao;
 import org.sonar.db.component.ComponentDto;
 import org.sonar.db.organization.OrganizationDto;
-import org.sonar.server.ce.queue.BranchSupport;
 
 import java.time.Clock;
 import java.util.Date;
@@ -68,7 +67,7 @@ public class CommunityBranchSupportDelegateTest {
         params.put("branch", "release-1.1");
         params.put("branchType", "BRANCH");
 
-        BranchSupport.ComponentKey componentKey =
+        CommunityComponentKey componentKey =
                 new CommunityBranchSupportDelegate(new SequenceUuidFactory(), mock(DbClient.class), mock(Clock.class))
                         .createComponentKey("yyy", params);
 
@@ -76,10 +75,11 @@ public class CommunityBranchSupportDelegateTest {
         assertEquals("yyy", componentKey.getKey());
         assertFalse(componentKey.getPullRequestKey().isPresent());
         assertFalse(componentKey.isMainBranch());
-        assertTrue(componentKey.getBranch().isPresent());
-        assertEquals("release-1.1", componentKey.getBranch().get().getName());
+        assertTrue(componentKey.getBranchName().isPresent());
+        assertTrue(componentKey.getBranchType().isPresent());
+        assertEquals("release-1.1", componentKey.getBranchName().get());
+        assertEquals(BranchType.BRANCH, componentKey.getBranchType().get());
         assertTrue(componentKey.getMainBranchComponentKey().isMainBranch());
-        assertEquals(BranchType.BRANCH, componentKey.getBranch().get().getType());
     }
 
     @Test
@@ -95,7 +95,8 @@ public class CommunityBranchSupportDelegateTest {
         assertTrue(componentKey.getPullRequestKey().isPresent());
         assertEquals("pullrequestkey", componentKey.getPullRequestKey().get());
         assertFalse(componentKey.isMainBranch());
-        assertFalse(componentKey.getBranch().isPresent());
+        assertFalse(componentKey.getBranchName().isPresent());
+        assertFalse(componentKey.getBranchType().isPresent());
         assertTrue(componentKey.getMainBranchComponentKey().isMainBranch());
         CommunityComponentKey mainBranchComponentKey = componentKey.getMainBranchComponentKey();
         assertSame(mainBranchComponentKey, mainBranchComponentKey.getMainBranchComponentKey());
@@ -145,10 +146,11 @@ public class CommunityBranchSupportDelegateTest {
         Clock clock = mock(Clock.class);
         when(clock.millis()).thenReturn(12345678901234L);
 
-        BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
+        CommunityComponentKey componentKey = mock(CommunityComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
         when(componentKey.getDbKey()).thenReturn("dbKey");
-        when(componentKey.getBranch()).thenReturn(Optional.of(new BranchSupport.Branch("dummy", BranchType.BRANCH)));
+        when(componentKey.getBranchName()).thenReturn(Optional.of("dummy"));
+        when(componentKey.getBranchType()).thenReturn(Optional.of(BranchType.BRANCH));
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
         ComponentDao componentDao = spy(mock(ComponentDao.class));
@@ -185,10 +187,11 @@ public class CommunityBranchSupportDelegateTest {
         Clock clock = mock(Clock.class);
         when(clock.millis()).thenReturn(12345678901234L);
 
-        BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
+        CommunityComponentKey componentKey = mock(CommunityComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
         when(componentKey.getDbKey()).thenReturn("dbKey");
-        when(componentKey.getBranch()).thenReturn(Optional.of(new BranchSupport.Branch("dummy", BranchType.BRANCH)));
+        when(componentKey.getBranchName()).thenReturn(Optional.of("dummy"));
+        when(componentKey.getBranchType()).thenReturn(Optional.of(BranchType.BRANCH));
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
         ComponentDao componentDao = mock(ComponentDao.class);
@@ -244,10 +247,11 @@ public class CommunityBranchSupportDelegateTest {
         Clock clock = mock(Clock.class);
         when(clock.millis()).thenReturn(1234567890123L);
 
-        BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
+        CommunityComponentKey componentKey = mock(CommunityComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
         when(componentKey.getDbKey()).thenReturn("dbKey");
-        when(componentKey.getBranch()).thenReturn(Optional.of(new BranchSupport.Branch("dummy", BranchType.BRANCH)));
+        when(componentKey.getBranchName()).thenReturn(Optional.of("dummy"));
+        when(componentKey.getBranchType()).thenReturn(Optional.of(BranchType.BRANCH));
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
         ComponentDao componentDao = spy(mock(ComponentDao.class));
@@ -284,10 +288,11 @@ public class CommunityBranchSupportDelegateTest {
         Clock clock = mock(Clock.class);
         when(clock.millis()).thenReturn(1234567890123L);
 
-        BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
+        CommunityComponentKey componentKey = mock(CommunityComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
         when(componentKey.getDbKey()).thenReturn("dbKey");
-        when(componentKey.getBranch()).thenReturn(Optional.empty());
+        when(componentKey.getBranchName()).thenReturn(Optional.empty());
+        when(componentKey.getBranchType()).thenReturn(Optional.empty());
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
         ComponentDao componentDao = mock(ComponentDao.class);


### PR DESCRIPTION
SonarQube introduced breaking changes in `org.sonar.server.ce.queue.BranchSupport`, so the plugin had to be adapted.

This change breaks backward compatibility, meaning that the plugin will now only support SonarQube 8.5.