### PR TITLE
Add support for Sonarqube 8.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '8.2.0.32929'
+def sonarqubeVersion = '8.5.0.37579'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 
@@ -57,8 +57,8 @@ compileJava {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    compileOnly fileTree(dir: sonarLibraries, include: '**/*.jar')
-    testCompile fileTree(dir: sonarLibraries, include: '**/*.jar')
+    compileOnly fileTree(dir: sonarLibraries, include: '**/*.jar', exclude: 'extensions/*.jar')
+    testCompile fileTree(dir: sonarLibraries, include: '**/*.jar', exclude: 'extensions/*.jar')
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.1.0'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.13.2'

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegate.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegate.java
@@ -71,9 +71,8 @@ public class CommunityBranchSupportDelegate implements BranchSupportDelegate {
         String branch = StringUtils.trimToNull(characteristics.get(CeTaskCharacteristicDto.BRANCH_KEY));
 
         try {
-            BranchType branchType = BranchType.valueOf(branchTypeParam);
-            return new CommunityComponentKey(projectKey, ComponentDto.generateBranchKey(projectKey, branch),
-                                             new BranchSupport.Branch(branch, branchType), null);
+            BranchType.valueOf(branchTypeParam);
+            return new CommunityComponentKey(projectKey, ComponentDto.generateBranchKey(projectKey, branch), branch, null);
         } catch (IllegalArgumentException ex) {
             throw new IllegalArgumentException(String.format("Unsupported branch type '%s'", branchTypeParam), ex);
         }
@@ -88,9 +87,8 @@ public class CommunityBranchSupportDelegate implements BranchSupportDelegate {
             throw new IllegalStateException("Component Key and Main Component Key do not match");
         }
 
-        Optional<BranchSupport.Branch> branchOptional = componentKey.getBranch();
-        if (branchOptional.isPresent() && branchOptional.get().getName().equals(mainComponentBranchDto.getKey()) &&
-            mainComponentBranchDto.getBranchType() == branchOptional.get().getType()) {
+        Optional<String> branchOptional = componentKey.getBranchName();
+        if (branchOptional.isPresent() && branchOptional.get().equals(mainComponentBranchDto.getKey())) {
             return mainComponentDto;
         }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityComponentKey.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityComponentKey.java
@@ -29,13 +29,13 @@ import java.util.Optional;
 
     private final String key;
     private final String dbKey;
-    private final BranchSupport.Branch branch;
+    private final String branchName;
     private final String pullRequestKey;
 
-    /*package*/ CommunityComponentKey(String key, String dbKey, BranchSupport.Branch branch, String pullRequestKey) {
+    /*package*/ CommunityComponentKey(String key, String dbKey, String branchName, String pullRequestKey) {
         this.key = key;
         this.dbKey = dbKey;
-        this.branch = branch;
+        this.branchName = branchName;
         this.pullRequestKey = pullRequestKey;
     }
 
@@ -50,10 +50,9 @@ import java.util.Optional;
     }
 
     @Override
-    public Optional<BranchSupport.Branch> getBranch() {
-        return Optional.ofNullable(branch);
+    public Optional<String> getBranchName() {
+        return Optional.ofNullable(branchName);
     }
-
     @Override
     public Optional<String> getPullRequestKey() {
         return Optional.ofNullable(pullRequestKey);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsAction.java
@@ -97,6 +97,8 @@ public class ListDefinitionsAction extends AlmSettingsWsAction {
             .setUrl(requireNonNull(settingDto.getUrl(), "URL cannot be null for GitHub ALM setting"))
             .setAppId(requireNonNull(settingDto.getAppId(), "App ID cannot be null for GitHub ALM setting"))
             .setPrivateKey(requireNonNull(settingDto.getPrivateKey(), "Private Key cannot be null for GitHub ALM setting"))
+            .setClientId(Optional.ofNullable(settingDto.getClientId()).orElse(""))
+            .setClientSecret(Optional.ofNullable(settingDto.getClientSecret()).orElse(""))
             .build();
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/CreateGithubAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/CreateGithubAction.java
@@ -29,19 +29,13 @@ import static org.sonar.db.alm.setting.ALM.GITHUB;
 
 public class CreateGithubAction extends CreateAction {
 
-    private static final String URL_PARAMETER = "url";
-    private static final String APP_ID_PARAMETER = "appId";
-    private static final String PRIVATE_KEY_PARAMETER = "privateKey";
-
     public CreateGithubAction(DbClient dbClient, UserSession userSession) {
         super(dbClient, userSession, "create_github");
     }
 
     @Override
     public void configureAction(WebService.NewAction action) {
-        action.createParam(URL_PARAMETER).setRequired(true).setMaximumLength(2000);
-        action.createParam(APP_ID_PARAMETER).setRequired(true).setMaximumLength(80);
-        action.createParam(PRIVATE_KEY_PARAMETER).setRequired(true).setMaximumLength(2000);
+        GithubRequestParameterManager.createRequestParameters(action);
     }
 
     @Override
@@ -49,9 +43,11 @@ public class CreateGithubAction extends CreateAction {
         return new AlmSettingDto()
                 .setAlm(GITHUB)
                 .setKey(key)
-                .setUrl(request.mandatoryParam(URL_PARAMETER))
-                .setAppId(request.mandatoryParam(APP_ID_PARAMETER))
-                .setPrivateKey(request.mandatoryParam(PRIVATE_KEY_PARAMETER));
+                .setUrl(request.mandatoryParam(GithubRequestParameterManager.URL_PARAMETER))
+                .setAppId(request.mandatoryParam(GithubRequestParameterManager.APP_ID_PARAMETER))
+                .setPrivateKey(request.mandatoryParam(GithubRequestParameterManager.PRIVATE_KEY_PARAMETER))
+                .setClientId(request.mandatoryParam(GithubRequestParameterManager.CLIENT_ID))
+                .setClientSecret(request.mandatoryParam(GithubRequestParameterManager.CLIENT_SECRET));
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/GithubRequestParameterManager.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/GithubRequestParameterManager.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.github;
+
+import org.sonar.api.server.ws.WebService;
+
+final class GithubRequestParameterManager {
+
+    static final String URL_PARAMETER = "url";
+    static final String APP_ID_PARAMETER = "appId";
+    static final String PRIVATE_KEY_PARAMETER = "privateKey";
+    static final String CLIENT_ID = "clientId";
+    static final String CLIENT_SECRET = "clientSecret";
+
+    private GithubRequestParameterManager() {
+        super();
+    }
+
+    static void createRequestParameters(WebService.NewAction action) {
+        action.createParam(URL_PARAMETER).setRequired(true).setMaximumLength(2000);
+        action.createParam(APP_ID_PARAMETER).setRequired(true).setMaximumLength(80);
+        action.createParam(PRIVATE_KEY_PARAMETER).setRequired(true).setMaximumLength(2000);
+        action.createParam(CLIENT_ID).setRequired(true).setMaximumLength(80);
+        action.createParam(CLIENT_SECRET).setRequired(true).setMaximumLength(80);
+    }
+
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/UpdateGithubAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/UpdateGithubAction.java
@@ -27,26 +27,22 @@ import org.sonar.server.user.UserSession;
 
 public class UpdateGithubAction extends UpdateAction {
 
-    private static final String URL_PARAMETER = "url";
-    private static final String APP_ID_PARAMETER = "appId";
-    private static final String PRIVATE_KEY_PARAMETER = "privateKey";
-
     public UpdateGithubAction(DbClient dbClient, UserSession userSession) {
         super(dbClient, userSession, "update_github");
     }
 
     @Override
     protected void configureAction(WebService.NewAction action) {
-        action.createParam(URL_PARAMETER).setRequired(true).setMaximumLength(2000);
-        action.createParam(APP_ID_PARAMETER).setRequired(true).setMaximumLength(80);
-        action.createParam(PRIVATE_KEY_PARAMETER).setRequired(true).setMaximumLength(2000);
+        GithubRequestParameterManager.createRequestParameters(action);
     }
 
     @Override
     protected AlmSettingDto updateAlmSettingsDto(AlmSettingDto almSettingDto, Request request) {
-        return almSettingDto.setUrl(request.mandatoryParam(URL_PARAMETER))
-                .setAppId(request.mandatoryParam(APP_ID_PARAMETER))
-                .setPrivateKey(request.mandatoryParam(PRIVATE_KEY_PARAMETER));
+        return almSettingDto.setUrl(request.mandatoryParam(GithubRequestParameterManager.URL_PARAMETER))
+                .setAppId(request.mandatoryParam(GithubRequestParameterManager.APP_ID_PARAMETER))
+                .setPrivateKey(request.mandatoryParam(GithubRequestParameterManager.PRIVATE_KEY_PARAMETER))
+                .setClientSecret(request.mandatoryParam(GithubRequestParameterManager.CLIENT_SECRET))
+                .setClientId(request.mandatoryParam(GithubRequestParameterManager.CLIENT_ID));
     }
 
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ClassReferenceElevatedClassLoaderFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ClassReferenceElevatedClassLoaderFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2020 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.verify;
  */
 public class ClassReferenceElevatedClassLoaderFactoryTest {
 
-    private static final String SVN_PLUGIN_CLASS = "org.sonar.plugins.scm.svn.SvnPlugin";
+    private static final String TARGET_PLUGIN_CLASS = "org.sonar.plugins.java.JavaPlugin";
     private final ExpectedException expectedException = ExpectedException.none();
 
     @Rule
@@ -70,7 +70,7 @@ public class ClassReferenceElevatedClassLoaderFactoryTest {
     public void testClassloaderReturnedOnHappyPath() throws ReflectiveOperationException, MalformedURLException {
         URLClassLoader mockClassLoader = new URLClassLoader(findSonarqubePluginJars());
         ElevatedClassLoaderFactory testCase = spy(new ClassReferenceElevatedClassLoaderFactory(getClass().getName()));
-        testCase.createClassLoader((Class<? extends Plugin>) mockClassLoader.loadClass(SVN_PLUGIN_CLASS));
+        testCase.createClassLoader((Class<? extends Plugin>) mockClassLoader.loadClass(TARGET_PLUGIN_CLASS));
 
         ArgumentCaptor<ClassLoader> argumentCaptor = ArgumentCaptor.forClass(ClassLoader.class);
         verify(testCase).createClassLoader(argumentCaptor.capture(), argumentCaptor.capture());
@@ -95,7 +95,7 @@ public class ClassReferenceElevatedClassLoaderFactoryTest {
         Map<String, ClassLoader> loaders = builder.build();
         ClassLoader classLoader = loaders.get("_customPlugin");
 
-        Class<? extends Plugin> loadedClass = (Class<? extends Plugin>) classLoader.loadClass(SVN_PLUGIN_CLASS);
+        Class<? extends Plugin> loadedClass = (Class<? extends Plugin>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
 
         ClassReferenceElevatedClassLoaderFactory testCase =
                 new ClassReferenceElevatedClassLoaderFactory(ActiveRule.class.getName());
@@ -109,7 +109,7 @@ public class ClassReferenceElevatedClassLoaderFactoryTest {
         List<URL> pluginUrls = new ArrayList<>();
         File[] sonarQubeDistributions = new File("sonarqube-lib/").listFiles();
 
-        for (File pluginJar : new File(sonarQubeDistributions[0], "extensions/plugins/").listFiles()) {
+        for (File pluginJar : new File(sonarQubeDistributions[0], "lib/extensions/").listFiles()) {
             pluginUrls.add(pluginJar.toURI().toURL());
         }
         return pluginUrls.toArray(new URL[0]);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ReflectiveElevatedClassLoaderFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ReflectiveElevatedClassLoaderFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2020 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -39,6 +39,10 @@ import static org.junit.Assert.assertNotSame;
  * @author Michael Clarke
  */
 public class ReflectiveElevatedClassLoaderFactoryTest {
+    
+    private static final String TARGET_PLUGIN_CLASS = "org.sonar.plugins.java.JavaPlugin";
+    private static final String BUNDLED_PLUGINS_DIRECTORY = "lib/extensions";
+    private static final String SONARQUBE_LIB_DIRECTORY = "sonarqube-lib/";
 
     private final ExpectedException expectedException = ExpectedException.none();
 
@@ -57,9 +61,9 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
         builder.setParent("_customPlugin", "_api_", new Mask());
         builder.setLoadingOrder("_customPlugin", ClassloaderBuilder.LoadingOrder.SELF_FIRST);
 
-        File[] sonarQubeDistributions = new File("sonarqube-lib/").listFiles();
+        File[] sonarQubeDistributions = new File(SONARQUBE_LIB_DIRECTORY).listFiles();
 
-        for (File pluginJar : new File(sonarQubeDistributions[0], "extensions/plugins/").listFiles()) {
+        for (File pluginJar : new File(sonarQubeDistributions[0], BUNDLED_PLUGINS_DIRECTORY).listFiles()) {
             builder.addURL("_customPlugin", pluginJar.toURI().toURL());
         }
 
@@ -67,7 +71,7 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
         ClassLoader classLoader = loaders.get("_customPlugin");
 
         Class<? extends Plugin> loadedClass =
-                (Class<? extends Plugin>) classLoader.loadClass("org.sonar.plugins.scm.svn.SvnPlugin");
+                (Class<? extends Plugin>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
 
         ReflectiveElevatedClassLoaderFactory testCase = new ReflectiveElevatedClassLoaderFactory();
         ClassLoader elevatedLoader = testCase.createClassLoader(loadedClass);
@@ -78,8 +82,7 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
 
 
     @Test
-    public void testLoadClassInvalidClassRealmKey()
-            throws ClassNotFoundException, IllegalAccessException, InstantiationException, MalformedURLException {
+    public void testLoadClassInvalidClassRealmKey() throws ClassNotFoundException, MalformedURLException {
         ClassloaderBuilder builder = new ClassloaderBuilder();
         builder.newClassloader("_xxx_", getClass().getClassLoader());
         builder.setMask("_xxx_", new Mask().addInclusion("java/").addInclusion("org/sonar/api/"));
@@ -88,9 +91,9 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
         builder.setParent("_customPlugin", "_xxx_", new Mask());
         builder.setLoadingOrder("_customPlugin", ClassloaderBuilder.LoadingOrder.SELF_FIRST);
 
-        File[] sonarQubeDistributions = new File("sonarqube-lib/").listFiles();
+        File[] sonarQubeDistributions = new File(SONARQUBE_LIB_DIRECTORY).listFiles();
 
-        for (File pluginJar : new File(sonarQubeDistributions[0], "extensions/plugins/").listFiles()) {
+        for (File pluginJar : new File(sonarQubeDistributions[0], BUNDLED_PLUGINS_DIRECTORY).listFiles()) {
             builder.addURL("_customPlugin", pluginJar.toURI().toURL());
         }
 
@@ -98,7 +101,7 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
         ClassLoader classLoader = loaders.get("_customPlugin");
 
         Class<? extends Plugin> loadedClass =
-                (Class<? extends Plugin>) classLoader.loadClass("org.sonar.plugins.scm.svn.SvnPlugin");
+                (Class<? extends Plugin>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(IsEqual.equalTo("Expected classloader with key '_api_' but found key '_xxx_'"));
@@ -110,15 +113,14 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
 
 
     @Test
-    public void testLoadClassNoParentRef()
-            throws ClassNotFoundException, IllegalAccessException, InstantiationException, MalformedURLException {
+    public void testLoadClassNoParentRef() throws ClassNotFoundException, MalformedURLException {
         ClassloaderBuilder builder = new ClassloaderBuilder();
         builder.newClassloader("_xxx_", getClass().getClassLoader());
         builder.setMask("_xxx_", new Mask());
 
-        File[] sonarQubeDistributions = new File("sonarqube-lib/").listFiles();
+        File[] sonarQubeDistributions = new File(SONARQUBE_LIB_DIRECTORY).listFiles();
 
-        for (File pluginJar : new File(sonarQubeDistributions[0], "extensions/plugins/").listFiles()) {
+        for (File pluginJar : new File(sonarQubeDistributions[0], BUNDLED_PLUGINS_DIRECTORY).listFiles()) {
             builder.addURL("_xxx_", pluginJar.toURI().toURL());
         }
 
@@ -126,7 +128,7 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
         ClassLoader classLoader = loaders.get("_xxx_");
 
         Class<? extends Plugin> loadedClass =
-                (Class<? extends Plugin>) classLoader.loadClass("org.sonar.plugins.scm.svn.SvnPlugin");
+                (Class<? extends Plugin>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(IsEqual.equalTo("Could not access ClassLoader chain using reflection"));
@@ -137,16 +139,15 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
     }
 
     @Test
-    public void testLoadClassInvalidApiClassloader()
-            throws ClassNotFoundException, IllegalAccessException, InstantiationException, MalformedURLException {
+    public void testLoadClassInvalidApiClassloader() throws ClassNotFoundException, MalformedURLException {
         ClassloaderBuilder builder = new ClassloaderBuilder();
         builder.newClassloader("_customPlugin");
         builder.setParent("_customPlugin", new URLClassLoader(new URL[0]), new Mask());
         builder.setLoadingOrder("_customPlugin", ClassloaderBuilder.LoadingOrder.SELF_FIRST);
 
-        File[] sonarQubeDistributions = new File("sonarqube-lib/").listFiles();
+        File[] sonarQubeDistributions = new File(SONARQUBE_LIB_DIRECTORY).listFiles();
 
-        for (File pluginJar : new File(sonarQubeDistributions[0], "extensions/plugins/").listFiles()) {
+        for (File pluginJar : new File(sonarQubeDistributions[0], BUNDLED_PLUGINS_DIRECTORY).listFiles()) {
             builder.addURL("_customPlugin", pluginJar.toURI().toURL());
         }
 
@@ -154,7 +155,7 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
         ClassLoader classLoader = loaders.get("_customPlugin");
 
         Class<? extends Plugins> loadedClass =
-                (Class<? extends Plugins>) classLoader.loadClass("org.sonar.plugins.scm.svn.SvnPlugin");
+                (Class<? extends Plugins>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(IsEqual.equalTo(
@@ -168,8 +169,8 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
     @Test
     public void testLoadClassInvalidClassloader() throws ClassNotFoundException, MalformedURLException {
 
-        File[] sonarQubeDistributions = new File("sonarqube-lib/").listFiles();
-        File[] plugins = new File(sonarQubeDistributions[0], "extensions/plugins/").listFiles();
+        File[] sonarQubeDistributions = new File(SONARQUBE_LIB_DIRECTORY).listFiles();
+        File[] plugins = new File(sonarQubeDistributions[0], BUNDLED_PLUGINS_DIRECTORY).listFiles();
 
         URL[] urls = new URL[plugins.length];
         int i = 0;
@@ -180,7 +181,7 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
         ClassLoader classLoader = new URLClassLoader(urls);
 
         Class<? extends Plugins> loadedClass =
-                (Class<? extends Plugins>) classLoader.loadClass("org.sonar.plugins.scm.svn.SvnPlugin");
+                (Class<? extends Plugins>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(IsEqual.equalTo(

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
@@ -76,10 +76,9 @@ public class CommunityBranchSupportDelegateTest {
         assertEquals("yyy", componentKey.getKey());
         assertFalse(componentKey.getPullRequestKey().isPresent());
         assertFalse(componentKey.isMainBranch());
-        assertTrue(componentKey.getBranch().isPresent());
-        assertEquals("release-1.1", componentKey.getBranch().get().getName());
+        assertTrue(componentKey.getBranchName().isPresent());
+        assertEquals("release-1.1", componentKey.getBranchName().get());
         assertTrue(componentKey.getMainBranchComponentKey().isMainBranch());
-        assertEquals(BranchType.BRANCH, componentKey.getBranch().get().getType());
     }
 
     @Test
@@ -95,7 +94,7 @@ public class CommunityBranchSupportDelegateTest {
         assertTrue(componentKey.getPullRequestKey().isPresent());
         assertEquals("pullrequestkey", componentKey.getPullRequestKey().get());
         assertFalse(componentKey.isMainBranch());
-        assertFalse(componentKey.getBranch().isPresent());
+        assertFalse(componentKey.getBranchName().isPresent());
         assertTrue(componentKey.getMainBranchComponentKey().isMainBranch());
         CommunityComponentKey mainBranchComponentKey = componentKey.getMainBranchComponentKey();
         assertSame(mainBranchComponentKey, mainBranchComponentKey.getMainBranchComponentKey());
@@ -148,7 +147,7 @@ public class CommunityBranchSupportDelegateTest {
         BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
         when(componentKey.getDbKey()).thenReturn("dbKey");
-        when(componentKey.getBranch()).thenReturn(Optional.of(new BranchSupport.Branch("dummy", BranchType.BRANCH)));
+        when(componentKey.getBranchName()).thenReturn(Optional.of("dummy"));
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
         ComponentDao componentDao = spy(mock(ComponentDao.class));
@@ -180,7 +179,7 @@ public class CommunityBranchSupportDelegateTest {
 
         BranchDto branchDto = mock(BranchDto.class);
         when(branchDto.getUuid()).thenReturn("componentUuid");
-        when(branchDto.getKey()).thenReturn("dummy");
+        when(branchDto.getKey()).thenReturn("nonDummy");
 
         Clock clock = mock(Clock.class);
         when(clock.millis()).thenReturn(12345678901234L);
@@ -188,7 +187,7 @@ public class CommunityBranchSupportDelegateTest {
         BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
         when(componentKey.getDbKey()).thenReturn("dbKey");
-        when(componentKey.getBranch()).thenReturn(Optional.of(new BranchSupport.Branch("dummy", BranchType.BRANCH)));
+        when(componentKey.getBranchName()).thenReturn(Optional.of("dummy"));
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
         ComponentDao componentDao = mock(ComponentDao.class);
@@ -247,7 +246,7 @@ public class CommunityBranchSupportDelegateTest {
         BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
         when(componentKey.getDbKey()).thenReturn("dbKey");
-        when(componentKey.getBranch()).thenReturn(Optional.of(new BranchSupport.Branch("dummy", BranchType.BRANCH)));
+        when(componentKey.getBranchName()).thenReturn(Optional.of("dummy"));
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
         ComponentDao componentDao = spy(mock(ComponentDao.class));
@@ -287,7 +286,7 @@ public class CommunityBranchSupportDelegateTest {
         BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
         when(componentKey.getDbKey()).thenReturn("dbKey");
-        when(componentKey.getBranch()).thenReturn(Optional.empty());
+        when(componentKey.getBranchName()).thenReturn(Optional.empty());
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
         ComponentDao componentDao = mock(ComponentDao.class);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsActionTest.java
@@ -1,14 +1,6 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-import java.util.Collections;
-
+import com.google.protobuf.Message;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -23,7 +15,14 @@ import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.server.user.UserSession;
 import org.sonarqube.ws.AlmSettings;
 
-import com.google.protobuf.Message;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ListDefinitionsActionTest {
 
@@ -55,6 +54,8 @@ public class ListDefinitionsActionTest {
         when(githubAlmSettingDto.getKey()).thenReturn("githubKey");
         when(githubAlmSettingDto.getUrl()).thenReturn("githubUrl");
         when(githubAlmSettingDto.getAppId()).thenReturn("githubAppId");
+        when(githubAlmSettingDto.getClientId()).thenReturn("githubClientId");
+        when(githubAlmSettingDto.getClientSecret()).thenReturn("githubClientSecret");
         when(githubAlmSettingDto.getPrivateKey()).thenReturn("githubPrivateKey");
 
         AlmSettingDto gitlabAlmSettingDto = mock(AlmSettingDto.class);
@@ -99,6 +100,8 @@ public class ListDefinitionsActionTest {
                 .setUrl("githubUrl")
                 .setAppId("githubAppId")
                 .setPrivateKey("githubPrivateKey")
+                .setClientId("githubClientId")
+                .setClientSecret("githubClientSecret")
                 .build())
             .addAzure(AlmSettings.AlmSettingAzure.newBuilder()
                 .setKey("azureDevopsKey")

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/CreateGithubActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/CreateGithubActionTest.java
@@ -1,13 +1,5 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.github;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.Test;
 import org.sonar.api.server.ws.Request;
 import org.sonar.api.server.ws.WebService;
@@ -15,6 +7,14 @@ import org.sonar.db.DbClient;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.server.user.UserSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CreateGithubActionTest {
 
@@ -40,6 +40,16 @@ public class CreateGithubActionTest {
         when(privateKeyParameter.setRequired(anyBoolean())).thenReturn(privateKeyParameter);
         when(newAction.createParam(eq("privateKey"))).thenReturn(privateKeyParameter);
 
+        WebService.NewParam clientIdParameter = mock(WebService.NewParam.class);
+        when(clientIdParameter.setMaximumLength(any(Integer.class))).thenReturn(clientIdParameter);
+        when(clientIdParameter.setRequired(anyBoolean())).thenReturn(clientIdParameter);
+        when(newAction.createParam(eq("clientId"))).thenReturn(clientIdParameter);
+
+        WebService.NewParam clientSecretParameter = mock(WebService.NewParam.class);
+        when(clientSecretParameter.setMaximumLength(any(Integer.class))).thenReturn(clientSecretParameter);
+        when(clientSecretParameter.setRequired(anyBoolean())).thenReturn(clientSecretParameter);
+        when(newAction.createParam(eq("clientSecret"))).thenReturn(clientSecretParameter);
+
         CreateGithubAction testCase = new CreateGithubAction(dbClient, userSession);
         testCase.configureAction(newAction);
 
@@ -51,6 +61,12 @@ public class CreateGithubActionTest {
 
         verify(privateKeyParameter).setRequired(eq(true));
         verify(privateKeyParameter).setMaximumLength(2000);
+
+        verify(clientIdParameter).setRequired(eq(true));
+        verify(clientIdParameter).setMaximumLength(80);
+
+        verify(clientSecretParameter).setRequired(eq(true));
+        verify(clientSecretParameter).setMaximumLength(80);
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/UpdateGithubActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/github/UpdateGithubActionTest.java
@@ -1,5 +1,12 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.github;
 
+import org.junit.Test;
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.db.DbClient;
+import org.sonar.db.alm.setting.AlmSettingDto;
+import org.sonar.server.user.UserSession;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -7,13 +14,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import org.junit.Test;
-import org.sonar.api.server.ws.Request;
-import org.sonar.api.server.ws.WebService;
-import org.sonar.db.DbClient;
-import org.sonar.db.alm.setting.AlmSettingDto;
-import org.sonar.server.user.UserSession;
 
 public class UpdateGithubActionTest {
 
@@ -39,6 +39,16 @@ public class UpdateGithubActionTest {
         when(privateKeyParameter.setRequired(anyBoolean())).thenReturn(privateKeyParameter);
         when(newAction.createParam(eq("privateKey"))).thenReturn(privateKeyParameter);
 
+        WebService.NewParam clientIdParameter = mock(WebService.NewParam.class);
+        when(clientIdParameter.setMaximumLength(any(Integer.class))).thenReturn(clientIdParameter);
+        when(clientIdParameter.setRequired(anyBoolean())).thenReturn(clientIdParameter);
+        when(newAction.createParam(eq("clientId"))).thenReturn(clientIdParameter);
+
+        WebService.NewParam clientSecretParameter = mock(WebService.NewParam.class);
+        when(clientSecretParameter.setMaximumLength(any(Integer.class))).thenReturn(clientSecretParameter);
+        when(clientSecretParameter.setRequired(anyBoolean())).thenReturn(clientSecretParameter);
+        when(newAction.createParam(eq("clientSecret"))).thenReturn(clientSecretParameter);
+
         UpdateGithubAction testCase = new UpdateGithubAction(dbClient, userSession);
         testCase.configureAction(newAction);
 
@@ -50,6 +60,12 @@ public class UpdateGithubActionTest {
 
         verify(privateKeyParameter).setRequired(eq(true));
         verify(privateKeyParameter).setMaximumLength(2000);
+
+        verify(clientIdParameter).setRequired(eq(true));
+        verify(clientIdParameter).setMaximumLength(80);
+
+        verify(clientSecretParameter).setRequired(eq(true));
+        verify(clientSecretParameter).setMaximumLength(80);
     }
 
     @Test


### PR DESCRIPTION
Sonarqube 8.5.0 removed the `BranchSupport.Branch` class which breaks backwards-compatibility with previous Sonarqube versions, and requires updating how the ComponentKey is checked and generated during the creation of the analysis report. This version of Sonarqube also moves the bundled plugins into their own directory, so the build classpath has been updated to exclude those plugins from being able to be part of the compilation path, and updates the class-loading unit tests to reference a plugin class and file path that is still available in the newer Sonarqube version.