### PR TITLE
#243: Handle no messages in error response from Bitbucket

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/ErrorResponse.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/server/ErrorResponse.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 public class ErrorResponse implements Serializable {
@@ -32,7 +33,7 @@ public class ErrorResponse implements Serializable {
     }
 
     public Set<Error> getErrors() {
-        return Collections.unmodifiableSet(errors);
+        return Optional.ofNullable(errors).map(Collections::unmodifiableSet).orElse(null);
     }
 
     public static class Error implements Serializable {

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketExceptionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketExceptionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.server.ErrorResponse;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BitbucketExceptionTest {
+
+    @Test
+    public void verifyMessageReturnedWhenErrorResponseContainsNoErrors() {
+        BitbucketException testCase = new BitbucketException(401, new ErrorResponse(null));
+        assertThat(testCase.getMessage()).isEqualTo("Bitbucket responded with an error status (401)");
+    }
+}


### PR DESCRIPTION
There are situations where Bitbucket server is returning an error during API calls, but has no messages specified in the response body, so is causing a `NullPointerException` to be thrown by the plugin whilst attempting to provide details on the error. Specifically checking for the messages not being present allows for the underlying HTTP status code to be returned in the exception details so the user can get a better understanding of what the issue is.