### PR TITLE
#209: Allow the Bitbucket clients to have different upload limits

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClient.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.DataValue;
@@ -88,5 +89,16 @@ public interface BitbucketClient {
      * @return boolean
      */
     boolean supportsCodeInsights();
+
+    /**
+     * <p>
+     *     Returns the annotation upload limit consisting of two different objects:
+     *     1. the batch size for each incremental annotation upload
+     *     2. the total allowed annotations for the given provider
+     * </p>
+     *
+     * @return the configured limit
+     */
+    AnnotationUploadLimit getAnnotationUploadLimit();
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClient.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
@@ -142,6 +143,11 @@ public class BitbucketCloudClient implements BitbucketClient {
     @Override
     public boolean supportsCodeInsights() {
         return true;
+    }
+
+    @Override
+    public AnnotationUploadLimit getAnnotationUploadLimit() {
+        return new AnnotationUploadLimit(100, 1000);
     }
 
     void deleteExistingReport(String project, String repository, String commit) throws IOException {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketServerClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketServerClient.java
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
@@ -149,6 +150,11 @@ public class BitbucketServerClient implements BitbucketClient {
             return false;
         }
         return false;
+    }
+
+    @Override
+    public AnnotationUploadLimit getAnnotationUploadLimit() {
+        return new AnnotationUploadLimit(1000, 1000);
     }
 
     public ServerProperties getServerProperties() throws IOException {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/AnnotationUploadLimit.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/AnnotationUploadLimit.java
@@ -1,0 +1,22 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model;
+
+/**
+ * Determines the different upload limits for both bitbucket cloud and bitbucket server.
+ */
+public class AnnotationUploadLimit {
+    private final int annotationBatchSize;
+    private final int totalAllowedAnnotations;
+
+    public AnnotationUploadLimit(int annotationBatchSize, int totalAllowedAnnotations) {
+        this.annotationBatchSize = annotationBatchSize;
+        this.totalAllowedAnnotations = totalAllowedAnnotations;
+    }
+
+    public int getAnnotationBatchSize() {
+        return annotationBatchSize;
+    }
+
+    public int getTotalAllowedAnnotations() {
+        return totalAllowedAnnotations;
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -3,6 +3,7 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketClient;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -70,6 +73,8 @@ public class BitbucketPullRequestDecoratorTest {
     @Test
     public void testValidAnalysis() throws IOException {
         when(client.supportsCodeInsights()).thenReturn(true);
+        AnnotationUploadLimit uploadLimit = new AnnotationUploadLimit(1000, 1000);
+        when(client.getAnnotationUploadLimit()).thenReturn(uploadLimit);
 
         mockValidAnalysis();
         underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
@@ -78,6 +83,45 @@ public class BitbucketPullRequestDecoratorTest {
         verify(client).createLinkDataValue(DASHBOARD_URL);
         verify(client).createCodeInsightsReport(any(), eq("Quality Gate passed" + System.lineSeparator()), any(), eq(DASHBOARD_URL), eq(String.format("%s/common/icon.png", IMAGE_URL)), eq(QualityGate.Status.OK));
         verify(client).deleteAnnotations(PROJECT, REPO, COMMIT);
+    }
+
+    @Test
+    public void testExceedsMaximumNumberOfAnnotations() {
+        // given
+        AnnotationUploadLimit uploadLimit = new AnnotationUploadLimit(100, 1000);
+        int counter = 2;
+
+        // when
+        boolean result = BitbucketPullRequestDecorator.exceedsMaximumNumberOfAnnotations(counter, uploadLimit);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void testExceedsMaximumNumberOfAnnotationsEdgeCase() {
+        // given
+        AnnotationUploadLimit uploadLimit = new AnnotationUploadLimit(1000, 1000);
+        int counter = 1;
+
+        // when
+        boolean result = BitbucketPullRequestDecorator.exceedsMaximumNumberOfAnnotations(counter, uploadLimit);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void testExceedsMaximumNumberOfAnnotationsEdgeBatchCase() {
+        // given
+        AnnotationUploadLimit uploadLimit = new AnnotationUploadLimit(100, 1000);
+        int counter = 10;
+
+        // when
+        boolean result = BitbucketPullRequestDecorator.exceedsMaximumNumberOfAnnotations(counter, uploadLimit);
+
+        // then
+        assertFalse(result);
     }
 
     private void mockValidAnalysis() {

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketCloudClientUnitTest.java
@@ -1,7 +1,7 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
@@ -125,6 +125,17 @@ public class BitbucketCloudClientUnitTest {
         Request request = captor.getValue();
         assertEquals("POST", request.method());
         assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+    }
+
+    @Test
+    public void testUploadLimit() {
+        // given
+        // when
+        AnnotationUploadLimit annotationUploadLimit = underTest.getAnnotationUploadLimit();
+
+        // then
+        assertEquals(100, annotationUploadLimit.getAnnotationBatchSize());
+        assertEquals(1000, annotationUploadLimit.getTotalAllowedAnnotations());
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketServerClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketServerClientUnitTest.java
@@ -2,6 +2,7 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsReport;
@@ -368,6 +369,17 @@ public class BitbucketServerClientUnitTest {
         // then
         assertTrue(data instanceof DataValue.Link);
         assertEquals("https://localhost:9000/any/project", ((DataValue.Link) data).getHref());
+    }
+
+    @Test
+    public void testUploadLimit() {
+        // given
+        // when
+        AnnotationUploadLimit annotationUploadLimit = underTest.getAnnotationUploadLimit();
+
+        // then
+        assertEquals(1000, annotationUploadLimit.getAnnotationBatchSize());
+        assertEquals(1000, annotationUploadLimit.getTotalAllowedAnnotations());
     }
 
     @Test


### PR DESCRIPTION
This commit fixes an issue with Bitbucket Cloud if more than 100 annotations
are present. Annotations will be chunked from now on on batches of 100 until
the total allowed of 1000 is reached.

For Bitbucket Server nothing changed.

Closes #209