### PR TITLE
Backport fix on annotation summary for Bitbucket Cloud PR decoration on branch 1.3

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/CodeInsightsAnnotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/CodeInsightsAnnotation.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class CodeInsightsAnnotation {
     @JsonProperty("line")
     private final int line;
-    @JsonProperty("message")
+    @JsonProperty("summary")
     private final String message;
     @JsonProperty("path")
     private final String path;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudAnnotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudAnnotation.java
@@ -25,7 +25,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model
 public class CloudAnnotation extends CodeInsightsAnnotation {
     @JsonProperty("external_id")
     private final String externalId;
-    @JsonProperty("summary")
+    @JsonProperty("link")
     private final String link;
     @JsonProperty("annotation_type")
     private final String annotationType;


### PR DESCRIPTION
This is a backport of #237 on branch 1.3 (for SonarQube 7.8 to 8.0)