### PR TITLE
Fix Bitbucket Server PR decoration

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/CodeInsightsAnnotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/CodeInsightsAnnotation.java
@@ -24,13 +24,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Class for reusing models between the cloud and the server version
  */
 public class CodeInsightsAnnotation {
-    @JsonProperty("line")
     private final int line;
-    @JsonProperty("summary")
     private final String message;
-    @JsonProperty("path")
     private final String path;
-    @JsonProperty("severity")
     private final String severity;
 
     public CodeInsightsAnnotation(int line, String message, String path, String severity) {
@@ -40,18 +36,22 @@ public class CodeInsightsAnnotation {
         this.severity = severity;
     }
 
+    @JsonProperty("line")
     public int getLine() {
         return line;
     }
 
+    @JsonProperty("message")
     public String getMessage() {
         return message;
     }
 
+    @JsonProperty("path")
     public String getPath() {
         return path;
     }
 
+    @JsonProperty("severity")
     public String getSeverity() {
         return severity;
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudAnnotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/model/cloud/CloudAnnotation.java
@@ -23,11 +23,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.CodeInsightsAnnotation;
 
 public class CloudAnnotation extends CodeInsightsAnnotation {
-    @JsonProperty("external_id")
     private final String externalId;
-    @JsonProperty("link")
     private final String link;
-    @JsonProperty("annotation_type")
     private final String annotationType;
 
     @JsonCreator
@@ -44,14 +41,23 @@ public class CloudAnnotation extends CodeInsightsAnnotation {
         this.annotationType = annotationType;
     }
 
+    @Override
+    @JsonProperty("summary")
+    public String getMessage() {
+        return super.getMessage();
+    }
+
+    @JsonProperty("external_id")
     public String getExternalId() {
         return externalId;
     }
 
+    @JsonProperty("link")
     public String getLink() {
         return link;
     }
 
+    @JsonProperty("annotation_type")
     public String getAnnotationType() {
         return annotationType;
     }


### PR DESCRIPTION
In #237 the property names of the annotation model were changed to fix a bug with how code annotations are reported to Bitbucket Cloud. This PR however did not take into consideration that the previous naming was actually correct and required for Bitbucket Server. With this change Bitbucket Cloud will continue to receive the message as `summary` ([API docs](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/commit/%7Bcommit%7D/reports/%7BreportId%7D/annotations)), while Bitbucket Server receives the message as `message` again ([API docs](https://docs.atlassian.com/bitbucket-server/rest/7.7.0/bitbucket-code-insights-rest.html#idp12)). This closes #265.

I moved the `@JsonProperty` annotations to the getters so that they support overrides, as mixing property-level and method-level annotations does not work for this use case. Technically this is only needed for the `message` property, but for consistency reasons I did it for all. I verified that this is mapped correctly for both cloud and server now.

For the impatient I also published a [snapshot release](https://github.com/idealo/sonarqube-community-branch-plugin/releases/tag/1.6.1-SNAPSHOT) that you may use until the fix is merged here.