### PR TITLE
Sonar 8.6 compability changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '8.5.0.37579'
+def sonarqubeVersion = '8.6.1.40680'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -31,6 +31,7 @@ import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.AlmSettingsWs;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.CountBindingAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.DeleteAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.DeleteBindingAction;
+import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ValidateAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.GetBindingAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ListAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ListDefinitionsAction;
@@ -74,7 +75,7 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
         } else if (SonarQubeSide.SERVER == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class,
 
-                                  AlmSettingsWs.class, CountBindingAction.class, DeleteAction.class,
+                                  AlmSettingsWs.class, CountBindingAction.class, DeleteAction.class, ValidateAction.class,
                                   DeleteBindingAction.class, ListAction.class, ListDefinitionsAction.class,
                                   GetBindingAction.class,
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ValidateAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ValidateAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action;
+
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.alm.setting.AlmSettingDto;
+import org.sonar.server.user.UserSession;
+
+public class ValidateAction extends AlmSettingsWsAction {
+
+    private static final String KEY_PARAMETER = "key";
+
+    private final DbClient dbClient;
+    private final UserSession userSession;
+
+    public ValidateAction(DbClient dbClient, UserSession userSession) {
+        super(dbClient);
+        this.dbClient = dbClient;
+        this.userSession = userSession;
+    }
+
+    @Override
+    public void define(WebService.NewController context) {
+        WebService.NewAction action = context.createAction("validate").setHandler(this).setDescription("Dummy Validate WS Action wihtout function.");
+
+        action.createParam(KEY_PARAMETER).setRequired(true);
+    }
+
+    @Override
+    public void handle(Request request, Response response) {
+        //Dummy method. Do absolutley nothing. Alway return status 204.
+        response.stream().setStatus(204);
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -119,7 +119,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(23, argumentCaptor.getAllValues().size());
+        assertEquals(24, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));


### PR DESCRIPTION
resolves https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/295 by adding a dummy validation method.

it simply always returns status 204 which equals a successful validation.
Of course a real implementation of the validation feature would be nice, but at least with this we have a basis to extend and it fixes the reported error 😃 

Here is the compiled version for anyone who wants to test it without compiling the code:
[sonarqube-community-branch-plugin-1.7.0-SNAPSHOT.zip](https://github.com/mc1arke/sonarqube-community-branch-plugin/files/5898131/sonarqube-community-branch-plugin-1.7.0-SNAPSHOT.zip)
