### PR TITLE
#295 [SQ85] missing /api/alm_settings/validate

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -34,6 +34,7 @@ import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.DeleteBi
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.GetBindingAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ListAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ListDefinitionsAction;
+import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ValidateAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.azure.CreateAzureAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.azure.SetAzureBindingAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.azure.UpdateAzureAction;
@@ -77,6 +78,7 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                                   AlmSettingsWs.class, CountBindingAction.class, DeleteAction.class,
                                   DeleteBindingAction.class, ListAction.class, ListDefinitionsAction.class,
                                   GetBindingAction.class,
+                                  ValidateAction.class,
 
                                   CreateGithubAction.class, SetGithubBindingAction.class, UpdateGithubAction.class,
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ValidateAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ValidateAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action;
+
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.db.DbClient;
+import org.sonar.server.user.UserSession;
+
+public class ValidateAction extends AlmSettingsWsAction {
+
+    private static final String KEY_PARAMETER = "key";
+
+    private final UserSession userSession;
+    private final String actionName;
+
+    public ValidateAction(DbClient dbClient, UserSession userSession) {
+        super(dbClient);
+        this.userSession = userSession;
+        this.actionName = "validate";
+    }
+
+    @Override
+    public void define(WebService.NewController newController) {
+        WebService.NewAction action = newController.createAction(actionName).setHandler(this);
+        action.createParam(KEY_PARAMETER).setMaximumLength(200).setRequired(true);
+    }
+
+    @Override
+    public void handle(Request request, Response response) {
+        userSession.checkIsSystemAdministrator();
+
+        response.noContent();
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -119,7 +119,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(23, argumentCaptor.getAllValues().size());
+        assertEquals(24, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));


### PR DESCRIPTION
Added dummy /api/alm_settings/validate to SonarQube 8.5.0.37579 and up.

ALM | Pull Request Decoration | Project Import
------------ | ------------- | -------------
Azure DevOps | :heavy_check_mark: | :x:
BitBucket | :heavy_check_mark: | :heavy_check_mark:
GitHub | :heavy_check_mark: | :heavy_check_mark:
GitLab | :heavy_check_mark: | :heavy_check_mark:

Download the pre-compiled jar [here](https://github.com/mc1arke/sonarqube-community-branch-plugin/files/5928318/sonarqube-community-branch-plugin-1.7.0-SNAPSHOT.bug295.SQ85.zip)

