### PR TITLE
#295 [SQ86] missing /api/alm_settings/validate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '8.5.0.37579'
+def sonarqubeVersion = '8.6.0.39681'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -34,6 +34,7 @@ import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.DeleteBi
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.GetBindingAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ListAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ListDefinitionsAction;
+import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ValidateAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.azure.CreateAzureAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.azure.SetAzureBindingAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.azure.UpdateAzureAction;
@@ -77,6 +78,7 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                                   AlmSettingsWs.class, CountBindingAction.class, DeleteAction.class,
                                   DeleteBindingAction.class, ListAction.class, ListDefinitionsAction.class,
                                   GetBindingAction.class,
+                                  ValidateAction.class,
 
                                   CreateGithubAction.class, SetGithubBindingAction.class, UpdateGithubAction.class,
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsAction.java
@@ -69,22 +69,19 @@ public class ListDefinitionsAction extends AlmSettingsWsAction {
 
         try (DbSession dbSession = dbClient.openSession(false)) {
             List<AlmSettingDto> settings = dbClient.almSettingDao().selectAll(dbSession);
-            Map<ALM, List<AlmSettingDto>> settingsByAlm =
-                    settings.stream().collect(Collectors.groupingBy(AlmSettingDto::getAlm));
-            List<AlmSettingGithub> githubSettings =
-                    settingsByAlm.getOrDefault(ALM.GITHUB, emptyList()).stream().map(ListDefinitionsAction::toGitHub)
-                            .collect(Collectors.toList());
+            Map<ALM, List<AlmSettingDto>> settingsByAlm = settings.stream()
+                    .collect(Collectors.groupingBy(AlmSettingDto::getAlm));
+            List<AlmSettingGithub> githubSettings = settingsByAlm.getOrDefault(ALM.GITHUB, emptyList()).stream()
+                    .map(ListDefinitionsAction::toGitHub).collect(Collectors.toList());
             List<AlmSettingAzure> azureSettings = settingsByAlm.getOrDefault(ALM.AZURE_DEVOPS, emptyList()).stream()
                     .map(ListDefinitionsAction::toAzure).collect(Collectors.toList());
-            List<AlmSettingBitbucket> bitbucketSettings =
-                    settingsByAlm.getOrDefault(ALM.BITBUCKET, emptyList()).stream()
-                            .map(ListDefinitionsAction::toBitbucket).collect(Collectors.toList());
-            List<AlmSettings.AlmSettingGitlab> gitlabSettings =
-                    settingsByAlm.getOrDefault(ALM.GITLAB, emptyList()).stream().map(ListDefinitionsAction::toGitlab)
-                            .collect(Collectors.toList());
-            ListDefinitionsWsResponse.Builder builder =
-                    ListDefinitionsWsResponse.newBuilder().addAllGithub(githubSettings).addAllAzure(azureSettings)
-                            .addAllBitbucket(bitbucketSettings).addAllGitlab(gitlabSettings);
+            List<AlmSettingBitbucket> bitbucketSettings = settingsByAlm.getOrDefault(ALM.BITBUCKET, emptyList())
+                    .stream().map(ListDefinitionsAction::toBitbucket).collect(Collectors.toList());
+            List<AlmSettings.AlmSettingGitlab> gitlabSettings = settingsByAlm.getOrDefault(ALM.GITLAB, emptyList())
+                    .stream().map(ListDefinitionsAction::toGitlab).collect(Collectors.toList());
+            ListDefinitionsWsResponse.Builder builder = ListDefinitionsWsResponse.newBuilder()
+                    .addAllGithub(githubSettings).addAllAzure(azureSettings).addAllBitbucket(bitbucketSettings)
+                    .addAllGitlab(gitlabSettings);
 
             protoBufWriter.write(builder.build(), request, response);
         }
@@ -92,35 +89,35 @@ public class ListDefinitionsAction extends AlmSettingsWsAction {
     }
 
     private static AlmSettingGithub toGitHub(AlmSettingDto settingDto) {
-        return AlmSettingGithub.newBuilder()
-            .setKey(settingDto.getKey())
-            .setUrl(requireNonNull(settingDto.getUrl(), "URL cannot be null for GitHub ALM setting"))
-            .setAppId(requireNonNull(settingDto.getAppId(), "App ID cannot be null for GitHub ALM setting"))
-            .setPrivateKey(requireNonNull(settingDto.getPrivateKey(), "Private Key cannot be null for GitHub ALM setting"))
-            .setClientId(Optional.ofNullable(settingDto.getClientId()).orElse(""))
-            .setClientSecret(Optional.ofNullable(settingDto.getClientSecret()).orElse(""))
-            .build();
+        return AlmSettingGithub.newBuilder().setKey(settingDto.getKey())
+                .setUrl(requireNonNull(settingDto.getUrl(), "URL cannot be null for GitHub ALM setting"))
+                .setAppId(requireNonNull(settingDto.getAppId(), "App ID cannot be null for GitHub ALM setting"))
+                .setPrivateKey(
+                        requireNonNull(settingDto.getPrivateKey(), "Private Key cannot be null for GitHub ALM setting"))
+                .setClientId(Optional.ofNullable(settingDto.getClientId()).orElse(""))
+                .setClientSecret(Optional.ofNullable(settingDto.getClientSecret()).orElse("")).build();
     }
 
     private static AlmSettingAzure toAzure(AlmSettingDto settingDto) {
-        return AlmSettingAzure.newBuilder()
-            .setKey(settingDto.getKey())
-            .setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(), "Personal Access Token cannot be null for Azure ALM setting"))
-            .build();
+        return AlmSettingAzure.newBuilder().setKey(settingDto.getKey())
+                .setUrl(requireNonNull(settingDto.getUrl(), "URL cannot be null for Azure ALM setting"))
+                .setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(),
+                        "Personal Access Token cannot be null for Azure ALM setting"))
+                .build();
     }
 
     private static AlmSettingBitbucket toBitbucket(AlmSettingDto settingDto) {
-        return AlmSettingBitbucket.newBuilder()
-            .setKey(settingDto.getKey())
-            .setUrl(requireNonNull(settingDto.getUrl(), "URL cannot be null for Bitbucket ALM setting"))
-            .setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(), "Personal Access Token cannot be null for Bitbucket ALM setting"))
-            .build();
+        return AlmSettingBitbucket.newBuilder().setKey(settingDto.getKey())
+                .setUrl(requireNonNull(settingDto.getUrl(), "URL cannot be null for Bitbucket ALM setting"))
+                .setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(),
+                        "Personal Access Token cannot be null for Bitbucket ALM setting"))
+                .build();
     }
 
     private static AlmSettings.AlmSettingGitlab toGitlab(AlmSettingDto settingDto) {
-        AlmSettings.AlmSettingGitlab.Builder almSettingBuilder =  AlmSettings.AlmSettingGitlab.newBuilder()
-            .setKey(settingDto.getKey())
-            .setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(), "Personal Access Token cannot be null for Gitlab ALM setting"));
+        AlmSettings.AlmSettingGitlab.Builder almSettingBuilder = AlmSettings.AlmSettingGitlab.newBuilder()
+                .setKey(settingDto.getKey()).setPersonalAccessToken(requireNonNull(settingDto.getPersonalAccessToken(),
+                        "Personal Access Token cannot be null for Gitlab ALM setting"));
 
         Optional.ofNullable(settingDto.getUrl()).ifPresent(almSettingBuilder::setUrl);
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ValidateAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ValidateAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action;
+
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.db.DbClient;
+import org.sonar.server.user.UserSession;
+
+public class ValidateAction extends AlmSettingsWsAction {
+
+    private static final String KEY_PARAMETER = "key";
+
+    private final UserSession userSession;
+    private final String actionName;
+
+    public ValidateAction(DbClient dbClient, UserSession userSession) {
+        super(dbClient);
+        this.userSession = userSession;
+        this.actionName = "validate";
+    }
+
+    @Override
+    public void define(WebService.NewController newController) {
+        WebService.NewAction action = newController.createAction(actionName).setHandler(this);
+        action.createParam(KEY_PARAMETER).setMaximumLength(200).setRequired(true);
+    }
+
+    @Override
+    public void handle(Request request, Response response) {
+        userSession.checkIsSystemAdministrator();
+
+        response.noContent();
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/azure/CreateAzureAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/azure/CreateAzureAction.java
@@ -29,6 +29,7 @@ import static org.sonar.db.alm.setting.ALM.AZURE_DEVOPS;
 
 public class CreateAzureAction extends CreateAction {
 
+    private static final String URL_PARAMETER = "url";
     private static final String PERSONAL_ACCESS_TOKEN_PARAMETER = "personalAccessToken";
 
 
@@ -39,6 +40,7 @@ public class CreateAzureAction extends CreateAction {
     @Override
     public void configureAction(WebService.NewAction action) {
         action.createParam(PERSONAL_ACCESS_TOKEN_PARAMETER).setRequired(true).setMaximumLength(2000);
+        action.createParam(URL_PARAMETER).setRequired(true).setMaximumLength(2000);
     }
 
     @Override
@@ -46,6 +48,7 @@ public class CreateAzureAction extends CreateAction {
         return new AlmSettingDto()
             .setAlm(AZURE_DEVOPS)
             .setKey(key)
+            .setUrl(request.mandatoryParam(URL_PARAMETER))
             .setPersonalAccessToken(request.mandatoryParam(PERSONAL_ACCESS_TOKEN_PARAMETER));
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/azure/UpdateAzureAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/azure/UpdateAzureAction.java
@@ -27,6 +27,7 @@ import org.sonar.server.user.UserSession;
 
 public class UpdateAzureAction extends UpdateAction {
 
+    private static final String URL_PARAMETER = "url";
     private static final String PERSONAL_ACCESS_TOKEN_PARAMETER = "personalAccessToken";
 
     public UpdateAzureAction(DbClient dbClient, UserSession userSession) {
@@ -36,10 +37,14 @@ public class UpdateAzureAction extends UpdateAction {
     @Override
     protected void configureAction(WebService.NewAction action) {
         action.createParam(PERSONAL_ACCESS_TOKEN_PARAMETER).setRequired(true).setMaximumLength(2000);
+        action.createParam(URL_PARAMETER).setRequired(true).setMaximumLength(2000);
     }
+
     @Override
     protected AlmSettingDto updateAlmSettingsDto(AlmSettingDto almSettingDto, Request request) {
-        return almSettingDto.setPersonalAccessToken(request.mandatoryParam(PERSONAL_ACCESS_TOKEN_PARAMETER));
+        return almSettingDto
+            .setUrl(request.mandatoryParam(URL_PARAMETER))
+            .setPersonalAccessToken(request.mandatoryParam(PERSONAL_ACCESS_TOKEN_PARAMETER));
     }
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -119,7 +119,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(23, argumentCaptor.getAllValues().size());
+        assertEquals(24, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/ListDefinitionsActionTest.java
@@ -72,6 +72,7 @@ public class ListDefinitionsActionTest {
         AlmSettingDto azureDevOpsAlmSettingDto = mock(AlmSettingDto.class);
         when(azureDevOpsAlmSettingDto.getAlm()).thenReturn(ALM.AZURE_DEVOPS);
         when(azureDevOpsAlmSettingDto.getKey()).thenReturn("azureDevopsKey");
+        when(azureDevOpsAlmSettingDto.getUrl()).thenReturn("azureDevopsUrl");
         when(azureDevOpsAlmSettingDto.getPersonalAccessToken()).thenReturn("azureDevOpsPersonalAccessToken");
 
         when(almSettingDao.selectAll(eq(dbSession))).thenReturn(Arrays.asList(
@@ -106,6 +107,7 @@ public class ListDefinitionsActionTest {
             .addAzure(AlmSettings.AlmSettingAzure.newBuilder()
                 .setKey("azureDevopsKey")
                 .setPersonalAccessToken("azureDevOpsPersonalAccessToken")
+                .setUrl("azureDevopsUrl")
                 .build())
             .addBitbucket(AlmSettings.AlmSettingBitbucket.newBuilder()
                 .setKey("bitbucketKey")

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/azure/CreateAzureActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/azure/CreateAzureActionTest.java
@@ -30,11 +30,19 @@ public class CreateAzureActionTest {
         when(personalAccessTokenParameter.setRequired(anyBoolean())).thenReturn(personalAccessTokenParameter);
         when(newAction.createParam(eq("personalAccessToken"))).thenReturn(personalAccessTokenParameter);
 
+        WebService.NewParam urlParameter = mock(WebService.NewParam.class);
+        when(urlParameter.setMaximumLength(any(Integer.class))).thenReturn(urlParameter);
+        when(urlParameter.setRequired(anyBoolean())).thenReturn(urlParameter);
+        when(newAction.createParam(eq("url"))).thenReturn(urlParameter);
+
         CreateAzureAction testCase = new CreateAzureAction(dbClient, userSession);
         testCase.configureAction(newAction);
 
         verify(personalAccessTokenParameter).setRequired(eq(true));
         verify(personalAccessTokenParameter).setMaximumLength(2000);
+
+        verify(urlParameter).setRequired(eq(true));
+        verify(urlParameter).setMaximumLength(2000);
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/azure/UpdateAzureActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/azure/UpdateAzureActionTest.java
@@ -29,11 +29,19 @@ public class UpdateAzureActionTest {
         when(personalAccessTokenParameter.setRequired(anyBoolean())).thenReturn(personalAccessTokenParameter);
         when(newAction.createParam(eq("personalAccessToken"))).thenReturn(personalAccessTokenParameter);
 
+        WebService.NewParam urlParameter = mock(WebService.NewParam.class);
+        when(urlParameter.setMaximumLength(any(Integer.class))).thenReturn(urlParameter);
+        when(urlParameter.setRequired(anyBoolean())).thenReturn(urlParameter);
+        when(newAction.createParam(eq("url"))).thenReturn(urlParameter);
+
         UpdateAzureAction testCase = new UpdateAzureAction(dbClient, userSession);
         testCase.configureAction(newAction);
 
         verify(personalAccessTokenParameter).setRequired(eq(true));
         verify(personalAccessTokenParameter).setMaximumLength(2000);
+
+        verify(urlParameter).setRequired(eq(true));
+        verify(urlParameter).setMaximumLength(2000);
     }
 
     @Test


### PR DESCRIPTION
Added dummy /api/alm_settings/validate to SonarQube v8.6.0.39681 and up.

ALM | Pull Request Decoration | Project Import
------------ | ------------- | -------------
Azure DevOps | :heavy_check_mark: | :heavy_check_mark:
BitBucket | :heavy_check_mark: | :heavy_check_mark:
GitHub | :heavy_check_mark: | :heavy_check_mark:
GitLab | :heavy_check_mark: | :heavy_check_mark:

Download the pre-compiled jar [here](https://github.com/mc1arke/sonarqube-community-branch-plugin/files/5928334/sonarqube-community-branch-plugin-1.7.0-SNAPSHOT.bug295.SQ86.zip)

