### PR TITLE
Add ability to generate Docker Image containing plugin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/build/
+/.idea/
+/.gradle/
+/out/

--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
+SONARQUBE_VERSION=latest
+
+# The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
+DOCKERFILE=Dockerfile
+
+# The version of the plugin to include in the image; only relevant if 'release.Dockerfile' is being used
+PLUGIN_VERSION=1.6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:11-jdk-slim as builder
+
+COPY . /home/build/project
+WORKDIR /home/build/project
+RUN ./gradlew build -x test
+
+FROM sonarqube:community
+COPY --from=builder --chown=sonarqube:sonarqube /home/build/project/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/lib/common/
+COPY --from=builder --chown=sonarqube:sonarqube /home/build/project/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/extensions/plugins/

--- a/README.md
+++ b/README.md
@@ -26,46 +26,6 @@ The plugin is intended to support the [features and parameters specified in the 
 # Installation
 Either build the project or [download a compatible release version of the plugin JAR](https://github.com/mc1arke/sonarqube-community-branch-plugin/releases). Copy the plugin JAR file to the `extensions/plugins/` **and** the `lib/common/` directories of your SonarQube instance and restart SonarQube.
 
-## Installation Docker
-Add download the plugin and mount it to the container see the last two volumes in the yaml below.
-```
-version: 2
-
-services:
-  sonarqube:
-    image: sonarqube:lts
-    container_name: sonarqube
-    ports:
-      - 9000:9000
-    networks:
-      - sonarnet
-    environment:
-      - SONARQUBE_JDBC_URL=jdbc:postgresql://db:5432/sonar
-      - SONARQUBE_JDBC_USERNAME=sonar
-      - SONARQUBE_JDBC_PASSWORD=sonar
-    volumes:
-      - sonarqube_conf:/opt/sonarqube/conf
-      - sonarqube_data:/opt/sonarqube/data
-      - sonarqube_extensions:/opt/sonarqube/extensions
-      - sonarqube_bundled-plugins:/opt/sonarqube/lib/bundled-plugins
-      - /home/user/sonarqube-community-branch-plugin-X.X.X.jar:/opt/sonarqube/extensions/plugins/sonarqube-community
--branch-plugin.jar
-      - /home/user/sonarqube-community-branch-plugin-X.X.X.jar:/opt/sonarqube/lib/common/sonarqube-community-branch
--plugin.jar
-
-  db:
-    image: postgres
-    container_name: postgres
-    networks:
-      - sonarnet
-    environment:
-      - POSTGRES_USER=sonar
-      - POSTGRES_PASSWORD=sonar
-    volumes:
-      - postgresql:/var/lib/postgresql
-      - postgresql_data:/var/lib/postgresql/data
-``` 
-
 # Configuration
 ## Global configuration
 Make sure `sonar.core.serverBaseURL` in SonarQube [/admin/settings](http://localhost:9000/admin/settings) is properly

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.8"
+
+services:
+  sonarqube:
+    depends_on:
+      - db
+    image: mc1arke/sonarqube-with-community-branch-plugin:${SONARQUBE_VERSION}
+    build:
+      context: .
+      dockerfile: ${DOCKERFILE}
+      args:
+        SONARQUBE_VERSION: ${SONARQUBE_VERSION}
+        PLUGIN_VERSION: ${PLUGIN_VERSION}
+    container_name: sonarqube
+    ports:
+      - 9000:9000
+    networks:
+      - sonarnet
+    environment:
+      - SONARQUBE_JDBC_URL=jdbc:postgresql://db:5432/sonar
+      - SONARQUBE_JDBC_USERNAME=sonar
+      - SONARQUBE_JDBC_PASSWORD=sonar
+    volumes:
+      - sonarqube_conf:/opt/sonarqube/conf
+      - sonarqube_data:/opt/sonarqube/data
+  db:
+    image: postgres:11
+    container_name: postgres
+    networks:
+      - sonarnet
+    environment:
+      - POSTGRES_USER=sonar
+      - POSTGRES_PASSWORD=sonar
+    volumes:
+      - postgresql:/var/lib/postgresql
+      - postgresql_data:/var/lib/postgresql/data
+
+volumes:
+  sonarqube_conf:
+  sonarqube_data:
+  postgresql:
+  postgresql_data:
+
+networks:
+  sonarnet:

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,0 +1,9 @@
+ARG SONARQUBE_VERSION
+
+FROM sonarqube:${SONARQUBE_VERSION}
+
+ARG PLUGIN_VERSION
+ENV PLUGIN_VERSION=${PLUGIN_VERSION}
+
+ADD --chown=sonarqube:sonarqube https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/${PLUGIN_VERSION}/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar /opt/sonarqube/lib/common/
+ADD --chown=sonarqube:sonarqube https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/${PLUGIN_VERSION}/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar /opt/sonarqube/extensions/plugins/


### PR DESCRIPTION
This change adds the relevant docker files to allow building a development docker image containing the code in this repository, or generating an image using a released version of the plugin, with either of these being backed by a particular base Docker image of Sonarqube's community releases. The `.env` file contains the variables required to configure what builds is performed with docker-compose.yml then driving the relevant creation from there.