### PR TITLE
Add support of summaryComment on GitHub

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/AddComment.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/AddComment.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Julien Roy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.aexp.nodes.graphql.annotations.GraphQLArgument;
+import io.aexp.nodes.graphql.annotations.GraphQLProperty;
+
+@GraphQLProperty(name = "addComment", arguments = {@GraphQLArgument(name = "input")})
+public class AddComment {
+
+    private final String clientMutationId;
+
+    @JsonCreator
+    public AddComment(@JsonProperty("clientMutationId") String clientMutationId) {
+        this.clientMutationId = clientMutationId;
+    }
+
+    public String getClientMutationId() {
+        return clientMutationId;
+    }
+
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GetPullRequest.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GetPullRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 Julien Roy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.v4;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.aexp.nodes.graphql.annotations.GraphQLArgument;
+import io.aexp.nodes.graphql.annotations.GraphQLProperty;
+
+@GraphQLProperty(name = "repository", arguments = {@GraphQLArgument(name = "owner"), @GraphQLArgument(name = "name")})
+public class GetPullRequest {
+
+    private final String url;
+
+    @GraphQLProperty(name = "pullRequest", arguments = {@GraphQLArgument(name = "number")})
+    private final PullRequest pullRequest;
+
+    @JsonCreator
+    public GetPullRequest(@JsonProperty("url") String url, @JsonProperty("pullRequest") PullRequest pullRequest) {
+        this.url = url;
+        this.pullRequest = pullRequest;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public PullRequest getPullRequest() {
+        return pullRequest;
+    }
+
+    public static class PullRequest {
+
+        private final String id;
+
+        @JsonCreator
+        public PullRequest(@JsonProperty("id") String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetGithubBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetGithubBindingAction.java
@@ -28,6 +28,7 @@ import org.sonar.server.user.UserSession;
 public class SetGithubBindingAction extends SetBindingAction {
 
     private static final String REPOSITORY_PARAMETER = "repository";
+    private static final String SUMMARY_COMMENT_PARAMETER = "summaryCommentEnabled";
 
     public SetGithubBindingAction(DbClient dbClient, ComponentFinder componentFinder, UserSession userSession) {
         super(dbClient, componentFinder, userSession, "set_github_binding");
@@ -37,6 +38,7 @@ public class SetGithubBindingAction extends SetBindingAction {
     protected void configureAction(WebService.NewAction action) {
         super.configureAction(action);
         action.createParam(REPOSITORY_PARAMETER).setRequired(true).setMaximumLength(256);
+        action.createParam(SUMMARY_COMMENT_PARAMETER).setRequired(false).setBooleanPossibleValues();
     }
 
     @Override
@@ -45,6 +47,7 @@ public class SetGithubBindingAction extends SetBindingAction {
                 .setProjectUuid(projectUuid)
                 .setAlmSettingUuid(settingsUuid)
                 .setAlmRepo(request.mandatoryParam(REPOSITORY_PARAMETER))
+                .setSummaryCommentEnabled(request.paramAsBoolean(SUMMARY_COMMENT_PARAMETER))
                 .setMonorepo(false);
     }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetGithubBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetGithubBindingActionTest.java
@@ -48,6 +48,11 @@ public class SetGithubBindingActionTest {
         when(repositoryParameter.setRequired(anyBoolean())).thenReturn(repositoryParameter);
         when(newAction.createParam("repository")).thenReturn(repositoryParameter);
 
+        WebService.NewParam commentEnabledParameter = mock(WebService.NewParam.class);
+        when(commentEnabledParameter.setBooleanPossibleValues()).thenReturn(commentEnabledParameter);
+        when(commentEnabledParameter.setRequired(anyBoolean())).thenReturn(commentEnabledParameter);
+        when(newAction.createParam("summaryCommentEnabled")).thenReturn(commentEnabledParameter);
+
         WebService.NewParam almSettingParameter = mock(WebService.NewParam.class);
         when(almSettingParameter.setMaximumLength(any(Integer.class))).thenReturn(almSettingParameter);
         when(almSettingParameter.setRequired(anyBoolean())).thenReturn(almSettingParameter);
@@ -68,11 +73,12 @@ public class SetGithubBindingActionTest {
 
         Request request = mock(Request.class);
         when(request.mandatoryParam("repository")).thenReturn("repository");
+        when(request.paramAsBoolean("summaryCommentEnabled")).thenReturn(true);
 
         SetGithubBindingAction testCase = new SetGithubBindingAction(dbClient, componentFinder, userSession);
         ProjectAlmSettingDto result = testCase.createProjectAlmSettingDto("projectUuid", "settingsUuid", request);
 
-        assertThat(result).isEqualToComparingFieldByField(new ProjectAlmSettingDto().setProjectUuid("projectUuid").setAlmSettingUuid("settingsUuid").setAlmRepo("repository").setMonorepo(false));
+        assertThat(result).isEqualToComparingFieldByField(new ProjectAlmSettingDto().setProjectUuid("projectUuid").setAlmSettingUuid("settingsUuid").setAlmRepo("repository").setSummaryCommentEnabled(true).setMonorepo(false));
 
     }
 }


### PR DESCRIPTION
This pull request implement the support of the "Enable analysis summary under the GitHub Conversation tab" parameter for GitHub PullRequest analysis.


Screenshot of pull request comment submitted by SonarQube : 

![github-sonarqube-comment](https://user-images.githubusercontent.com/1958756/110914917-4f214900-8317-11eb-8839-9733393d30dd.png)
