### PR TITLE
Prevent BitBucket unit tests initiating real HTTP calls

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -3,6 +3,7 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketClient;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.BitbucketClientFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client.model.AnnotationUploadLimit;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,22 +49,17 @@ public class BitbucketPullRequestDecoratorTest {
     private static final String DASHBOARD_URL = "https://dashboard-url";
     private static final String IMAGE_URL = "https://image-url";
 
-    private AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
-
-    private BitbucketClient client = mock(BitbucketClient.class);
-
-    private BitbucketPullRequestDecorator underTest = new BitbucketPullRequestDecorator() {
-        @Override
-        BitbucketClient createClient(AlmSettingDto almSettingDto, ProjectAlmSettingDto projectAlmSettingDto) {
-            return client;
-        }
-    };
+    private final AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
+    private final BitbucketClient client = mock(BitbucketClient.class);
+    private final BitbucketClientFactory bitbucketClientFactory = mock(BitbucketClientFactory.class);
+    private final BitbucketPullRequestDecorator underTest = new BitbucketPullRequestDecorator(bitbucketClientFactory);
 
     private final AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
     private final ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
 
     @Before
     public void setUp() {
+        when(bitbucketClientFactory.createClient(any(), any())).thenReturn(client);
         when(client.resolveProject(any(), any())).thenReturn(PROJECT);
         when(client.resolveRepository(any(), any())).thenReturn(REPO);
     }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClientFactoryUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/client/BitbucketClientFactoryUnitTest.java
@@ -1,35 +1,49 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.client;
 
+import okhttp3.OkHttpClient;
+import okhttp3.ResponseBody;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
+import java.io.IOException;
+
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BitbucketClientFactoryUnitTest {
 
     @Test
-    public void testCreateClientIsCloudIfCloudConfig() {
+    public void testCreateClientIsCloudIfCloudConfig() throws IOException {
         // given
         AlmSettingDto almSettingDto = new AlmSettingDto().setAlm(ALM.BITBUCKET_CLOUD);
         ProjectAlmSettingDto projectAlmSettingDto = new ProjectAlmSettingDto();
+        OkHttpClient.Builder builder = mock(OkHttpClient.Builder.class, Mockito.RETURNS_DEEP_STUBS);
+        when(builder.addInterceptor(any())).thenReturn(builder);
+
+        ResponseBody responseBody = mock(ResponseBody.class);
+        when(responseBody.string()).thenReturn("{}");
+        when(builder.build().newCall(any()).execute().body()).thenReturn(responseBody);
 
         // when
-        BitbucketClient client = BitbucketClientFactory.createClient(almSettingDto, projectAlmSettingDto);
+        BitbucketClient client = new BitbucketClientFactory(() -> builder).createClient(almSettingDto, projectAlmSettingDto);
 
         // then
         assertTrue(client instanceof BitbucketCloudClient);
     }
 
     @Test
-    public void testCreateClientIfNotCLoudConfig() {
+    public void testCreateClientIfNotCloudConfig() {
         // given
         AlmSettingDto almSettingDto = new AlmSettingDto().setAlm(ALM.BITBUCKET);
         ProjectAlmSettingDto projectAlmSettingDto = new ProjectAlmSettingDto();
 
         // when
-        BitbucketClient client = BitbucketClientFactory.createClient(almSettingDto, projectAlmSettingDto);
+        BitbucketClient client = new BitbucketClientFactory(() -> mock(OkHttpClient.Builder.class, Mockito.RETURNS_DEEP_STUBS)).createClient(almSettingDto, projectAlmSettingDto);
 
         // then
         assertTrue(client instanceof BitbucketServerClient);


### PR DESCRIPTION
The BitBucket cloud decorator was attempting to perform an OAuth negotiation during construction in unit tests, so was dependent on the availability of BitBucket for the tests to pass. The `BitbucketClientFactory` has been altered to take an OkHttp Client Builder Supplier as an argument, with the tests injecting a mock client builder so no Http calls are performed during the BitBucket decorator tests.