### PR TITLE
#276: Use correct link on Pull Request annotations for Hostspots

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -116,8 +116,12 @@ public class AnalysisDetails {
         return publicRootURL + "/dashboard?id=" + encode(project.getKey()) + "&pullRequest=" + branchDetails.getBranchName();
     }
 
-    public String getIssueUrl(String issueKey) {
-        return publicRootURL + "/project/issues?id=" + encode(project.getKey()) + "&pullRequest=" + branchDetails.getBranchName() + "&issues=" + issueKey + "&open=" + issueKey;
+    public String getIssueUrl(PostAnalysisIssueVisitor.LightIssue issue) {
+        if (issue.type() == RuleType.SECURITY_HOTSPOT) {
+            return String.format("%s/security_hotspots?id=%s&pullRequest=%s&hotspots=%s", publicRootURL, encode(project.getKey()), branchDetails.getBranchName(), issue.key());
+        } else {
+            return String.format("%s/project/issues?id=%s&pullRequest=%s&issues=%s&open=%s", publicRootURL, encode(project.getKey()), branchDetails.getBranchName(), issue.key(), issue.key());
+        }
     }
 
     public Optional<String> getPullRequestBase() {
@@ -234,7 +238,7 @@ public class AnalysisDetails {
                 new Paragraph(new Text(String.format("**Message:** %s", issue.getMessage()))),
                 effortNode,
                 resolutionNode,
-                new Link(getIssueUrl(issue.key()), new Text("View in SonarQube"))
+                new Link(getIssueUrl(issue), new Text("View in SonarQube"))
         );
         return formatterFactory.documentFormatter().format(document, formatterFactory);
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecorator.java
@@ -190,7 +190,7 @@ public class AzureDevOpsServerPullRequestDecorator implements PullRequestBuildSt
                         issue.getIssue().type().name(),
                         issue.getIssue().getMessage(),
                         analysisDetails.getRuleUrlWithRuleKey(issue.getIssue().getRuleKey().toString()),
-                        analysisDetails.getIssueUrl(issue.getIssue().key())
+                        analysisDetails.getIssueUrl(issue.getIssue())
                 );
 
                 CommentThread thread = new CommentThread(filePath, locate, message);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
@@ -147,7 +147,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                     String path = componentIssue.getComponent().getReportAttributes().getScmPath().get();
                     return client.createCodeInsightsAnnotation(componentIssue.getIssue().key(),
                             Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0),
-                            analysisDetails.getIssueUrl(componentIssue.getIssue().key()),
+                            analysisDetails.getIssueUrl(componentIssue.getIssue()),
                             componentIssue.getIssue().getMessage(),
                             path,
                             toBitbucketSeverity(componentIssue.getIssue().severity()),

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsServerPullRequestDecoratorTest.java
@@ -97,7 +97,7 @@ public class AzureDevOpsServerPullRequestDecoratorTest {
         when(analysisDetails.getBranchName()).thenReturn(pullRequestId);
         when(analysisDetails.getPostAnalysisIssueVisitor()).thenReturn(issueVisitor);
         when(analysisDetails.getRuleUrlWithRuleKey(ruleKeyVal)).thenReturn(ruleUrl);
-        when(analysisDetails.getIssueUrl(issueKeyVal)).thenReturn(issueUrl);
+        when(analysisDetails.getIssueUrl(defaultIssue)).thenReturn(issueUrl);
         when(analysisDetails.getSCMPathForIssue(componentIssue)).thenReturn(Optional.of(filePath));
         when(issueVisitor.getIssues()).thenReturn(Collections.singletonList(componentIssue));
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -148,7 +148,7 @@ public class BitbucketPullRequestDecoratorTest {
         when(defaultIssue.key()).thenReturn(ISSUE_KEY);
         when(defaultIssue.type()).thenReturn(RuleType.BUG);
         when(defaultIssue.getMessage()).thenReturn(ISSUE_MESSAGE);
-        when(analysisDetails.getIssueUrl(ISSUE_KEY)).thenReturn(ISSUE_LINK);
+        when(analysisDetails.getIssueUrl(defaultIssue)).thenReturn(ISSUE_LINK);
         when(analysisDetails.getBaseImageUrl()).thenReturn(IMAGE_URL);
 
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);


### PR DESCRIPTION
Sonarqube uses a different URL format for issues compared to Security Hotspots, but the plugin was using the same format for both during Pull Request decoration, so linking to invalid URLS for hotspots. The URL generation has therefore been altered to take the issue type into account when generating a link to each issue.