### PR TITLE
#377 Allow decorating Gitlab Mono Repository Merge Requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compileOnly fileTree(dir: sonarLibraries, include: '**/*.jar', exclude: 'extensions/*.jar')
     testCompile fileTree(dir: sonarLibraries, include: '**/*.jar', exclude: 'extensions/*.jar')
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.1.0'
-    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.13.2'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.20.2'
     testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.24.1'
     zip "sonarqube:sonarqube:${sonarqubeVersion}@zip"
     compile 'org.bouncycastle:bcpkix-jdk15on:1.62'

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
@@ -354,7 +354,8 @@ public class AnalysisDetailsTest {
                                                                                  "http://localhost:9000/static/communityBranchPlugin/checks/Duplications/NoDuplicationInfo.svg?sanitize=true"),
                                                                        new Text(" "), new Text(
                                                                   "No duplication information (12.30% Estimated after merge)"))),
-                                                 new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube")));
+                                                 new Paragraph(new Text("**Project ID:** Project Key")),
+                                                 new Paragraph(new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube"))));
 
         assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
 
@@ -454,7 +455,8 @@ public class AnalysisDetailsTest {
                                                                                  "http://localhost:9000/static/communityBranchPlugin/checks/Duplications/20.svg?sanitize=true"),
                                                                        new Text(" "), new Text(
                                                                   "18.00% Duplicated Code (21.78% Estimated after merge)"))),
-                                                 new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube")));
+                                                 new Paragraph(new Text("**Project ID:** Project Key")),
+                                                 new Paragraph(new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube"))));
 
         assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
 
@@ -561,7 +563,8 @@ public class AnalysisDetailsTest {
                                                                                  "http://host.name/path/checks/Duplications/10.svg?sanitize=true"),
                                                                        new Text(" "), new Text(
                                                                   "10.00% Duplicated Code (21.78% Estimated after merge)"))),
-                                                 new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube")));
+                                                 new Paragraph(new Text("**Project ID:** Project Key")),
+                                                 new Paragraph(new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube"))));
 
         assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
 
@@ -659,7 +662,8 @@ public class AnalysisDetailsTest {
                                                                                  "http://localhost:9000/static/communityBranchPlugin/checks/Duplications/20plus.svg?sanitize=true"),
                                                                        new Text(" "), new Text(
                                                                   "30.00% Duplicated Code (21.78% Estimated after merge)"))),
-                                                 new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube")));
+                                                 new Paragraph(new Text("**Project ID:** Project Key")),
+                                                 new Paragraph(new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube"))));
 
         assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
 
@@ -851,7 +855,8 @@ public class AnalysisDetailsTest {
                         new Paragraph(new Text("**Message:** message")),
                         new Paragraph(new Text("**Duration (min):** 123")),
                         new Text(""),
-                        new Link("http://localhost:9000/project/issues?id=projectKey&pullRequest=branchName&issues=issueKey&open=issueKey", new Text("View in SonarQube"))
+                        new Paragraph(new Text("**Project ID:** projectKey **Issue ID:** issueKey")),
+                        new Paragraph(new Link("http://localhost:9000/project/issues?id=projectKey&pullRequest=branchName&issues=issueKey&open=issueKey", new Text("View in SonarQube")))
                 )
         );
     }
@@ -861,8 +866,10 @@ public class AnalysisDetailsTest {
         AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
                 mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
                 mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("https://sonarqube.dummy/path/dashboard?pullRequest=123"))
-                .isEqualTo(Optional.of("decorator-summary-comment"));
+        assertThat(analysisDetails.parseIssueIdFromUrl("https://sonarqube.dummy/path/dashboard?id=project&pullRequest=123"))
+                .get()
+                .usingRecursiveComparison()
+                .isEqualTo(new AnalysisDetails.ProjectIssueIdentifier("project", "decorator-summary-comment"));
     }
 
     @Test
@@ -870,8 +877,10 @@ public class AnalysisDetailsTest {
         AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
                 mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
                 mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/security_hotspots?hotspots=A1B2-Z9Y8X7"))
-                .isEqualTo(Optional.of("A1B2-Z9Y8X7"));
+        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/security_hotspots?id=projectIdentifier&hotspots=A1B2-Z9Y8X7"))
+                .get()
+                .usingRecursiveComparison()
+                .isEqualTo(new AnalysisDetails.ProjectIssueIdentifier("projectIdentifier", "A1B2-Z9Y8X7"));
     }
 
     @Test
@@ -879,7 +888,7 @@ public class AnalysisDetailsTest {
         AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
                 mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
                 mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/security_hotspots?other_parameter=ABC"))
+        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/security_hotspots?id=projectId&other_parameter=ABC"))
                 .isEmpty();
     }
 
@@ -888,8 +897,10 @@ public class AnalysisDetailsTest {
         AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
                 mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
                 mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/issue?issues=XXX-YYY-ZZZ"))
-                .isEqualTo(Optional.of("XXX-YYY-ZZZ"));
+        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/issue?id=projectId&issues=XXX-YYY-ZZZ"))
+                .get()
+                .usingRecursiveComparison()
+                .isEqualTo(new AnalysisDetails.ProjectIssueIdentifier("projectId", "XXX-YYY-ZZZ"));
     }
 
     @Test
@@ -897,6 +908,6 @@ public class AnalysisDetailsTest {
         AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
                 mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
                 mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/issue?other_parameter=123")).isEmpty();
+        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/issue?id=projectId&other_parameter=123")).isEmpty();
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
@@ -178,6 +178,9 @@ public class GitlabMergeRequestDecoratorIntegrationTest {
                         discussionPostResponseBody(discussionId + 6,
                                 discussionNote(noteId + 9, user, "Resolved Sonarqube issue with response comment from other user so discussion can't be closed\\n[View in SonarQube](https://sonarqube.dummy/project/issues?id=" + projectKey + "&pullRequest=1234&issues=oldid&open=oldid)", true, false),
                                 discussionNote(noteId + 10, "other", "Comment from other user", true, false)) +
+                        "," +
+                        discussionPostResponseBody(discussionId + 7,
+                                discussionNote(noteId + 11, user, "Sonarqube issue for anther project\\n[View in SonarQube](https://sonarqube.dummy/project/issues?id=abcd-" + projectKey + "&pullRequest=1234&issues=oldid&open=oldid)", true, false)) +
                         "]")));
 
         wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + sourceProjectId + "/merge_requests/" + mergeRequestIid + "/discussions/" + discussionId + "/notes"))


### PR DESCRIPTION
The Gitlab decorator treated any comment posted by the current Gitlab user as having been submitted for the current Sonarqube project, and therefore resolved any threads that no active issue could be found for in the current analysis. This prevented the decorator being used for a mono-repo as issues from decorations for other projects based in the repo would be resolved as subsequent projects completed their analysis.

The decorator has been changed to include the project ID in the details extracted from the existing comments, and to filter out any comments with project keys that do not match the project key the analysis is being performed for, before closing any remaining discussions, so that comments from other Sonarqube projects are not prematurely closed.