### PR TITLE
Fix bad usages of Mockito classes

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginBootstrapTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginBootstrapTest.java
@@ -40,10 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -64,7 +61,7 @@ public class CommunityBranchPluginBootstrapTest {
     }
 
     @Test
-    public void testDefineInvokedOnSuccessLoad() throws ClassNotFoundException {
+    public void testDefineInvokedOnSuccessLoad() {
         Plugin.Context context = mock(Plugin.Context.class);
         Configuration configuration = mock(Configuration.class);
         when(context.getBootConfiguration()).thenReturn(configuration);
@@ -73,8 +70,12 @@ public class CommunityBranchPluginBootstrapTest {
         when(context.getRuntime()).thenReturn(sonarRuntime);
         when(sonarRuntime.getSonarQubeSide()).thenReturn(SonarQubeSide.SCANNER);
 
-        ClassLoader classLoader = mock(ClassLoader.class);
-        when(classLoader.loadClass(any())).thenReturn((Class) MockPlugin.class);
+        ClassLoader classLoader = new ClassLoader() {
+            @Override
+            public Class<?> loadClass(String name) {
+                return MockPlugin.class;
+            }
+        };
 
         ElevatedClassLoaderFactory elevatedClassLoaderFactory = mock(ElevatedClassLoaderFactory.class);
         when(elevatedClassLoaderFactory.createClassLoader(any())).thenReturn(classLoader);
@@ -91,7 +92,7 @@ public class CommunityBranchPluginBootstrapTest {
     }
 
     @Test
-    public void testDefineNotInvokedForNonScanner() throws ClassNotFoundException {
+    public void testDefineNotInvokedForNonScanner() {
         Plugin.Context context = mock(Plugin.Context.class);
         Configuration configuration = mock(Configuration.class);
         when(context.getBootConfiguration()).thenReturn(configuration);
@@ -100,8 +101,12 @@ public class CommunityBranchPluginBootstrapTest {
         when(context.getRuntime()).thenReturn(sonarRuntime);
         when(sonarRuntime.getSonarQubeSide()).thenReturn(SonarQubeSide.SERVER);
 
-        ClassLoader classLoader = mock(ClassLoader.class);
-        when(classLoader.loadClass(any())).thenReturn((Class) MockPlugin.class);
+        ClassLoader classLoader = new ClassLoader() {
+            @Override
+            public Class<?> loadClass(String name) {
+                return MockPlugin.class;
+            }
+        };
 
         ElevatedClassLoaderFactory elevatedClassLoaderFactory = mock(ElevatedClassLoaderFactory.class);
         when(elevatedClassLoaderFactory.createClassLoader(any())).thenReturn(classLoader);
@@ -117,10 +122,15 @@ public class CommunityBranchPluginBootstrapTest {
         assertNull(MockPlugin.invokedContext);
     }
 
+
     @Test
-    public void testFailureOnIncorrectClassTypeReturned() throws ReflectiveOperationException {
-        ClassLoader classLoader = mock(ClassLoader.class);
-        doReturn(this.getClass()).when(classLoader).loadClass(any());
+    public void testFailureOnIncorrectClassTypeReturned() {
+        ClassLoader classLoader = new ClassLoader() {
+            @Override
+            public Class<?> loadClass(String name) {
+                return CommunityBranchPluginBootstrapTest.class;
+            }
+        };
 
         ElevatedClassLoaderFactory classLoaderFactory = mock(ElevatedClassLoaderFactory.class);
         when(classLoaderFactory.createClassLoader(any())).thenReturn(classLoader);
@@ -149,10 +159,13 @@ public class CommunityBranchPluginBootstrapTest {
     }
 
     @Test
-    public void testFailureOnReflectiveOperationException() throws ReflectiveOperationException {
-        ClassLoader classLoader = mock(ClassLoader.class);
-        doThrow(new ClassNotFoundException("Whoops")).when(classLoader).loadClass(any());
-
+    public void testFailureOnReflectiveOperationException() {
+        ClassLoader classLoader = new ClassLoader() {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                throw new ClassNotFoundException("Whoops");
+            }
+        };
         Plugin.Context context = mock(Plugin.Context.class, Mockito.RETURNS_DEEP_STUBS);
         SonarRuntime sonarRuntime = mock(SonarRuntime.class);
         when(context.getRuntime()).thenReturn(sonarRuntime);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -41,7 +41,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -111,7 +110,7 @@ public class CommunityBranchPluginTest {
     public void testServerSideLoad() {
         final CommunityBranchPlugin testCase = new CommunityBranchPlugin();
 
-        final CoreExtension.Context context = spy(mock(CoreExtension.Context.class, Mockito.RETURNS_DEEP_STUBS));
+        final CoreExtension.Context context = mock(CoreExtension.Context.class, Mockito.RETURNS_DEEP_STUBS);
         when(context.getRuntime().getSonarQubeSide()).thenReturn(SonarQubeSide.SERVER);
 
         testCase.load(context);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ReflectiveElevatedClassLoaderFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ReflectiveElevatedClassLoaderFactoryTest.java
@@ -22,7 +22,6 @@ import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.internal.configuration.plugins.Plugins;
 import org.sonar.api.Plugin;
 import org.sonar.classloader.ClassloaderBuilder;
 import org.sonar.classloader.Mask;
@@ -154,15 +153,15 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
         Map<String, ClassLoader> loaders = builder.build();
         ClassLoader classLoader = loaders.get("_customPlugin");
 
-        Class<? extends Plugins> loadedClass =
-                (Class<? extends Plugins>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
+        Class<? extends Plugin> loadedClass =
+                (Class<? extends Plugin>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(IsEqual.equalTo(
                 "Expected classloader of type 'org.sonar.classloader.ClassRealm' but got 'java.net.URLClassLoader'"));
 
         ReflectiveElevatedClassLoaderFactory testCase = new ReflectiveElevatedClassLoaderFactory();
-        testCase.createClassLoader((Class<? extends Plugin>) loadedClass);
+        testCase.createClassLoader(loadedClass);
 
     }
 
@@ -180,15 +179,15 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
 
         ClassLoader classLoader = new URLClassLoader(urls);
 
-        Class<? extends Plugins> loadedClass =
-                (Class<? extends Plugins>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
+        Class<? extends Plugin> loadedClass =
+                (Class<? extends Plugin>) classLoader.loadClass(TARGET_PLUGIN_CLASS);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(IsEqual.equalTo(
                 "Expected classloader of type 'org.sonar.classloader.ClassRealm' but got 'java.net.URLClassLoader'"));
 
         ReflectiveElevatedClassLoaderFactory testCase = new ReflectiveElevatedClassLoaderFactory();
-        testCase.createClassLoader((Class<? extends Plugin>) loadedClass);
+        testCase.createClassLoader(loadedClass);
 
     }
 


### PR DESCRIPTION
Some tests currently use Mockito to create mock classloaders, which do not then call `super` properly so cause classes to be defined with no module and cause subsequent JVM crashes when these classes are used later in the testsuite on newer Mockito versions.

An internal Mockito class has also been incorrectly referenced in a test in place of a Sonarqube class with a similar name, and a spy setup incorrectly around a mock, both of which fail in the latest Mockito version. These have both been updated to work correctly regardless by referencing the correct Sonarqube class and using the mock directly, rather than attempting to spy an already mocked instance.