### PR TITLE
Add direct dependency on JUnit 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'
     testImplementation(platform('org.junit:junit-bom:5.7.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')
+    testImplementation("junit:junit:4.13.2")
     testRuntime("org.junit.vintage:junit-vintage-engine")
 }
 


### PR DESCRIPTION
Junit 4 is used directly in tests but is only transitively inherited from other dependencies, which causes an issue if any of those dependencies require updating and drop their JUnit 4 dependency. To overcome this, JUnit 4 is being added as a direct dependency to the project's test scope.