### PR TITLE
Hide outdated summary comments on GitHub

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/Actor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/Actor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 Julien Roy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.aexp.nodes.graphql.annotations.GraphQLProperty;
+
+public class Actor {
+    @GraphQLProperty(name = "__typename")
+    private final String type;
+    private final String login;
+
+    @JsonCreator
+    public Actor(@JsonProperty("__typename") String type, @JsonProperty("login") String login) {
+        this.type = type;
+        this.login = login;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/Comments.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/Comments.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 Julien Roy, Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.aexp.nodes.graphql.annotations.GraphQLProperty;
+
+import java.util.List;
+
+public class Comments {
+    private final List<CommentNode> nodes;
+    private final PageInfo pageInfo;
+
+    @JsonCreator
+    public Comments(@JsonProperty("nodes") List<CommentNode> nodes, @JsonProperty("pageInfo") PageInfo pageInfo) {
+        this.nodes = nodes;
+        this.pageInfo = pageInfo;
+    }
+
+    public List<CommentNode> getNodes() {
+        return nodes;
+    }
+
+    public PageInfo getPageInfo() {
+        return pageInfo;
+    }
+
+
+    public static class CommentNode {
+
+        private final String id;
+        private final Actor author;
+        @GraphQLProperty(name = "isMinimized")
+        private final boolean minimized;
+
+        @JsonCreator
+        public CommentNode(@JsonProperty("id") String id, @JsonProperty("author") Actor author, @JsonProperty("isMinimized") boolean minimized) {
+            this.id = id;
+            this.author = author;
+            this.minimized = minimized;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Actor getAuthor() {
+            return author;
+        }
+
+        public boolean isMinimized() {
+            return minimized;
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GetPullRequest.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GetPullRequest.java
@@ -49,13 +49,22 @@ public class GetPullRequest {
 
         private final String id;
 
+        @GraphQLProperty(name = "comments", arguments = {@GraphQLArgument(name = "first", optional = true, type = "Integer"), @GraphQLArgument(name = "after", optional = true, type = "String")})
+        private final Comments comments;
+
         @JsonCreator
-        public PullRequest(@JsonProperty("id") String id) {
+        public PullRequest(@JsonProperty("id") String id, @JsonProperty("comments") Comments comments) {
             this.id = id;
+            this.comments = comments;
         }
 
         public String getId() {
             return id;
         }
+
+        public Comments getComments() {
+            return comments;
+        }
     }
+
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/MinimizeComment.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/MinimizeComment.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Julien Roy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.aexp.nodes.graphql.annotations.GraphQLArgument;
+import io.aexp.nodes.graphql.annotations.GraphQLProperty;
+
+@GraphQLProperty(name = "minimizeComment", arguments = {@GraphQLArgument(name = "input")})
+public class MinimizeComment {
+
+    private final String clientMutationId;
+
+    @JsonCreator
+    public MinimizeComment(@JsonProperty("clientMutationId") String clientMutationId) {
+        this.clientMutationId = clientMutationId;
+    }
+
+    public String getClientMutationId() {
+        return clientMutationId;
+    }
+
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/PageInfo.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/PageInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PageInfo {
+    private final boolean hasNextPage;
+    private final String endCursor;
+
+    @JsonCreator
+    public PageInfo(@JsonProperty("hasNextPage") boolean hasNextPage, @JsonProperty("endCursor") String endCursor) {
+        this.hasNextPage = hasNextPage;
+        this.endCursor = endCursor;
+    }
+
+    public boolean hasNextPage() {
+        return hasNextPage;
+    }
+
+    public String getEndCursor() {
+        return endCursor;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/Viewer.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/Viewer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 Julien Roy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.aexp.nodes.graphql.annotations.GraphQLProperty;
+
+@GraphQLProperty(name = "viewer")
+public class Viewer {
+
+    private final String login;
+
+    @JsonCreator
+    public Viewer(@JsonProperty("login") String login) {
+        this.login = login;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/model/CommentClassifiers.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/model/CommentClassifiers.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2021 Julien Roy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model;
+
+public enum CommentClassifiers {
+    OUTDATED
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
@@ -384,18 +384,48 @@ public class GraphqlGithubClientTest {
         GraphQLTemplate graphQLTemplate = mock(GraphQLTemplate.class);
         when(graphQLTemplate.mutate(requestEntityArgumentCaptor.capture(), eq(CreateCheckRun.class))).thenReturn(graphQLResponseEntity);
 
+        GraphQLResponseEntity<Viewer> viewerResponseEntity = objectMapper.readValue("{" +
+                "  \"response\": {" +
+                "      \"login\": \"test-sonar[bot]\"" +
+                "  }" +
+                "}",
+            objectMapper.getTypeFactory().constructParametricType(GraphQLResponseEntity.class, Viewer.class));
+        ArgumentCaptor<GraphQLRequestEntity> getViewer = ArgumentCaptor.forClass(GraphQLRequestEntity.class);
+        when(graphQLTemplate.query(getViewer.capture(), eq(Viewer.class))).thenReturn(viewerResponseEntity);
+
         GraphQLResponseEntity<GetPullRequest> getPullRequestResponseEntity =
             objectMapper.readValue("{" +
                 "\"response\": " +
-                "  {\n" +
-                "    \"pullRequest\": {\n" +
-                "      \"id\": \"MDExOlB1bGxSZXF1ZXN0MzUzNDc=\"\n" +
-                "    }\n" +
-                "  }\n" +
+                "  {" +
+                "    \"pullRequest\": {" +
+                "      \"id\": \"MDExOlB1bGxSZXF1ZXN0MzUzNDc=\"," +
+                "      \"comments\": {" +
+                "        \"nodes\": [" +
+                "          {" +
+                "            \"id\": \"MDEyOklzc3VlQ29tbWVudDE1MDE3\"," +
+                "            \"isMinimized\": false," +
+                "            \"author\": {" +
+                "              \"__typename\": \"Bot\"," +
+                "              \"login\": \"test-sonar\"" +
+                "            }" +
+                "          }"+
+                "        ],"+
+                "        \"pageInfo\": {" +
+                "          \"hasNextPage\": false" +
+                "        } " +
+                "      }"+
+                "    }" +
+                "  }" +
                 "}", objectMapper.getTypeFactory().constructParametricType(GraphQLResponseEntity.class, GetPullRequest.class));
 
         ArgumentCaptor<GraphQLRequestEntity> getPullRequestRequestEntityArgumentCaptor = ArgumentCaptor.forClass(GraphQLRequestEntity.class);
-        when(graphQLTemplate.execute(getPullRequestRequestEntityArgumentCaptor.capture(), eq(GetPullRequest.class))).thenReturn(getPullRequestResponseEntity);
+        when(graphQLTemplate.query(getPullRequestRequestEntityArgumentCaptor.capture(), eq(GetPullRequest.class))).thenReturn(getPullRequestResponseEntity);
+
+        GraphQLResponseEntity<MinimizeComment> minimizeCommentResponseEntity =
+            objectMapper.readValue("{\"response\":{}}", objectMapper.getTypeFactory().constructParametricType(GraphQLResponseEntity.class, MinimizeComment.class));
+
+        ArgumentCaptor<GraphQLRequestEntity> minimizeCommentRequestEntityArgumentCaptor = ArgumentCaptor.forClass(GraphQLRequestEntity.class);
+        when(graphQLTemplate.mutate(minimizeCommentRequestEntityArgumentCaptor.capture(), eq(MinimizeComment.class))).thenReturn(minimizeCommentResponseEntity);
 
         GraphQLResponseEntity<AddComment> addCommentResponseEntity =
             objectMapper.readValue("{\"response\":{}}", objectMapper.getTypeFactory().constructParametricType(GraphQLResponseEntity.class, AddComment.class));
@@ -417,7 +447,7 @@ public class GraphqlGithubClientTest {
                 new GraphqlGithubClient(graphqlProvider, clock, repositoryAuthenticationToken, server);
         testCase.createCheckRun(analysisDetails, almSettingDto, projectAlmSettingDto);
 
-        assertEquals(3, requestBuilders.size());
+        assertEquals(5, requestBuilders.size());
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Authorization", "Bearer dummyAuthToken");
@@ -468,7 +498,7 @@ public class GraphqlGithubClientTest {
             position++;
         }
 
-        assertEquals(3 + position, inputObjectBuilders.size());
+        assertEquals(4 + position, inputObjectBuilders.size());
 
         ArgumentCaptor<List<InputObject<Object>>> annotationArgumentCaptor = ArgumentCaptor.forClass(List.class);
 
@@ -495,19 +525,42 @@ public class GraphqlGithubClientTest {
         verify(inputObjectBuilders.get(position + 1)).put("output", inputObjects.get(position));
         verify(inputObjectBuilders.get(position + 1)).build();
 
-        // Verify getPullRequest requestEntity
+        // Verify GetViewer
+        verify(requestBuilders.get(1)).url(fullPath);
+        verify(requestBuilders.get(1)).headers(headers);
+        verify(requestBuilders.get(1)).build();
+        assertEquals(requestEntities.get(1), getViewer.getValue());
         assertEquals(
-            "query { repository (owner:\"dummy\",name:\"repo\") { url pullRequest : pullRequest (number:13579) { id } } } ",
+            "query { viewer { login } } ",
+            getViewer.getValue().getRequest()
+        );
+
+        // Verify GetPullRequest
+        verify(requestBuilders.get(2)).url(fullPath);
+        verify(requestBuilders.get(2)).headers(headers);
+        verify(requestBuilders.get(2)).build();
+        assertEquals(requestEntities.get(2), getPullRequestRequestEntityArgumentCaptor.getValue());
+        assertEquals(
+            "query { repository (owner:\"dummy\",name:\"repo\") { url pullRequest : pullRequest (number:13579) { comments : comments (first:100) { nodes" +
+                " { author { type : __typename login } id minimized : isMinimized } pageInfo { hasNextPage endCursor } } id } } } ",
             getPullRequestRequestEntityArgumentCaptor.getValue().getRequest()
         );
 
-        // Validate AddComment
-        verify(requestBuilders.get(2)).url(fullPath);
-        verify(requestBuilders.get(2)).headers(headers);
-        verify(requestBuilders.get(2)).requestMethod(GraphQLTemplate.GraphQLMethod.MUTATE);
-        verify(requestBuilders.get(2)).build();
-        assertEquals(requestEntities.get(2), addCommentRequestEntityArgumentCaptor.getValue());
+        // Validate Minimize Comment
+        verify(requestBuilders.get(3)).url(fullPath);
+        verify(requestBuilders.get(3)).headers(headers);
+        verify(requestBuilders.get(3)).build();
+        assertEquals(requestEntities.get(3), minimizeCommentRequestEntityArgumentCaptor.getValue());
+        assertEquals(
+            "mutation { minimizeComment (input:{classifier:OUTDATED,subjectId:\"MDEyOklzc3VlQ29tbWVudDE1MDE3\"}) { clientMutationId } } ",
+            minimizeCommentRequestEntityArgumentCaptor.getValue().getRequest()
+        );
 
+        // Validate AddComment
+        verify(requestBuilders.get(4)).url(fullPath);
+        verify(requestBuilders.get(4)).headers(headers);
+        verify(requestBuilders.get(4)).build();
+        assertEquals(requestEntities.get(4), addCommentRequestEntityArgumentCaptor.getValue());
         assertEquals(
           "mutation { addComment (input:{body:\"dummy summary\",subjectId:\"MDExOlB1bGxSZXF1ZXN0MzUzNDc=\"}) { clientMutationId } } ",
             addCommentRequestEntityArgumentCaptor.getValue().getRequest()


### PR DESCRIPTION
When multiple Sonarqube analyses are performed against a Github Pull Request, each analysis generates a summary comment but none of the previous comments are cleaned-up on any subsequent analysis. To prevent a Pull Request becoming cluttered with summary comments, a search is being performed for all comments made by the current user, and all those comments are being minimized to prevent them being shown in-full on the Github user interface. As code level annotations are not treated as comments, this change has no impact on the individual findings within a Pull Request, only on the post-scan summary comment.