### PR TITLE
Added encoding for entity sending to gitlab.

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClient.java
@@ -111,7 +111,7 @@ class GitlabRestClient implements GitlabClient {
 
         HttpPost httpPost = new HttpPost(targetUrl);
         httpPost.addHeader("Content-type", ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
-        httpPost.setEntity(new UrlEncodedFormEntity(requestContent));
+        httpPost.setEntity(new UrlEncodedFormEntity(requestContent, StandardCharsets.UTF_8));
         return entity(httpPost, Discussion.class, httpResponse -> validateResponse(httpResponse, 201, "Discussion successfully created"));
     }
 


### PR DESCRIPTION
fixed: #445 

Currently the Gitlab decorator does not set an encoding when sending the merge request decoration details to Gitlab, which results in some characters - such as the Cyrillic alphabet - being rendered incorrectly on Gitlab, or if that character found on old \ new path position occurs error in API. Explicitly specifying UTF-8 as the encoding overcome this.

p.s restored fix from: https://github.com/mc1arke/sonarqube-community-branch-plugin/commit/4a9918dfa34376346ae98fc7ada4a7b4babfa0eb