### PR TITLE
#454: Add support for Sonarqube 9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '9.0.0.45539'
+def sonarqubeVersion = '9.1.0.47736'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/DefaultGithubClientFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/DefaultGithubClientFactory.java
@@ -21,6 +21,7 @@ package com.github.mc1arke.sonarqube.plugin.almclient.github;
 import com.github.mc1arke.sonarqube.plugin.InvalidConfigurationException;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.GraphqlGithubClient;
 import org.sonar.api.ce.ComputeEngineSide;
+import org.sonar.api.config.internal.Settings;
 import org.sonar.api.platform.Server;
 import org.sonar.api.server.ServerSide;
 import org.sonar.db.alm.setting.AlmSettingDto;
@@ -35,16 +36,18 @@ public class DefaultGithubClientFactory implements GithubClientFactory {
 
     private final GithubApplicationAuthenticationProvider githubApplicationAuthenticationProvider;
     private final Server server;
+    private final Settings settings;
 
-    public DefaultGithubClientFactory(GithubApplicationAuthenticationProvider githubApplicationAuthenticationProvider, Server server) {
+    public DefaultGithubClientFactory(GithubApplicationAuthenticationProvider githubApplicationAuthenticationProvider, Server server, Settings settings) {
         this.githubApplicationAuthenticationProvider = githubApplicationAuthenticationProvider;
         this.server = server;
+        this.settings = settings;
     }
 
     @Override
     public GithubClient createClient(ProjectAlmSettingDto projectAlmSettingDto, AlmSettingDto almSettingDto) {
         String apiUrl = Optional.ofNullable(almSettingDto.getUrl()).orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "No URL has been set for Github connections"));
-        String apiPrivateKey = Optional.ofNullable(almSettingDto.getPrivateKey()).orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "No private key has been set for Github connections"));
+        String apiPrivateKey = Optional.ofNullable(almSettingDto.getDecryptedPrivateKey(settings.getEncryption())).orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "No private key has been set for Github connections"));
         String projectPath = Optional.ofNullable(projectAlmSettingDto.getAlmRepo()).orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.PROJECT, "No repository name has been set for Github connections"));
         String appId = Optional.ofNullable(almSettingDto.getAppId()).orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "No App ID has been set for Github connections"));
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingAction.java
@@ -51,7 +51,7 @@ public abstract class SetBindingAction extends ProjectWsAction {
 
         DbClient dbClient = getDbClient();
         AlmSettingDto almSettingDto = getAlmSetting(dbClient, dbSession, almSetting);
-        dbClient.projectAlmSettingDao().insertOrUpdate(dbSession, createProjectAlmSettingDto(project.getUuid(), almSettingDto.getUuid(), request));
+        dbClient.projectAlmSettingDao().insertOrUpdate(dbSession, createProjectAlmSettingDto(project.getUuid(), almSettingDto.getUuid(), request), almSettingDto.getUuid(), project.getName(), project.getKey());
         dbSession.commit();
 
         response.noContent();

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactoryUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactoryUnitTest.java
@@ -4,6 +4,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.sonar.api.config.internal.Encryption;
+import org.sonar.api.config.internal.Settings;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
@@ -33,8 +35,12 @@ public class DefaultBitbucketClientFactoryUnitTest {
         when(responseBody.string()).thenReturn("{}");
         when(builder.build().newCall(any()).execute().body()).thenReturn(responseBody);
 
+        Settings settings = mock(Settings.class);
+        Encryption encryption = mock(Encryption.class);
+
         // when
-        BitbucketClient client = new DefaultBitbucketClientFactory(() -> builder).createClient(projectAlmSettingDto, almSettingDto);
+        when(settings.getEncryption()).thenReturn(encryption);
+        BitbucketClient client = new DefaultBitbucketClientFactory(settings, () -> builder).createClient(projectAlmSettingDto, almSettingDto);
 
         // then
         assertTrue(client instanceof BitbucketCloudClient);
@@ -50,8 +56,12 @@ public class DefaultBitbucketClientFactoryUnitTest {
                 .setAlmRepo("almRepo")
                 .setAlmSlug("almSlug");
 
+        Settings settings = mock(Settings.class);
+        Encryption encryption = mock(Encryption.class);
+
         // when
-        BitbucketClient client = new DefaultBitbucketClientFactory(() -> mock(OkHttpClient.Builder.class, Mockito.RETURNS_DEEP_STUBS)).createClient(projectAlmSettingDto, almSettingDto);
+        when(settings.getEncryption()).thenReturn(encryption);
+        BitbucketClient client = new DefaultBitbucketClientFactory(settings, () -> mock(OkHttpClient.Builder.class, Mockito.RETURNS_DEEP_STUBS)).createClient(projectAlmSettingDto, almSettingDto);
 
         // then
         assertTrue(client instanceof BitbucketServerClient);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/DefaultGithubClientFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/DefaultGithubClientFactoryTest.java
@@ -24,6 +24,8 @@ import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.GraphqlGithubClie
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.sonar.api.config.internal.Encryption;
+import org.sonar.api.config.internal.Settings;
 import org.sonar.api.platform.Server;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
@@ -42,68 +44,70 @@ class DefaultGithubClientFactoryTest {
     private final ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
     private final RestApplicationAuthenticationProvider restApplicationAuthenticationProvider = mock(RestApplicationAuthenticationProvider.class);
     private final Server server = mock(Server.class);
+    private final Settings settings = mock(Settings.class);
 
     @BeforeEach
     public void setUp() {
         when(almSettingDto.getUrl()).thenReturn("url");
-        when(almSettingDto.getPrivateKey()).thenReturn("privateKey");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("privateKey");
         when(projectAlmSettingDto.getAlmRepo()).thenReturn("repo");
         when(almSettingDto.getAppId()).thenReturn("appId");
+        when(settings.getEncryption()).thenReturn(mock(Encryption.class));
     }
 
     @Test
     void testExceptionThrownIfUrlMissing() {
         when(almSettingDto.getUrl()).thenReturn(null);
-        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server);
+        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server, settings);
         assertThatThrownBy(() -> underTest.createClient(projectAlmSettingDto, almSettingDto))
                 .isInstanceOf(InvalidConfigurationException.class)
                 .hasMessage("No URL has been set for Github connections")
-                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.GLOBAL, "GLOBAL Scope for exception"));;
+                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.GLOBAL, "GLOBAL Scope for exception"));
     }
 
     @Test
     void testExceptionThrownIfPrivateKeyMissing() {
-        when(almSettingDto.getPrivateKey()).thenReturn(null);
-        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server);
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn(null);
+        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server, settings);
         assertThatThrownBy(() -> underTest.createClient(projectAlmSettingDto, almSettingDto))
                 .isInstanceOf(InvalidConfigurationException.class)
                 .hasMessage("No private key has been set for Github connections")
-                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.GLOBAL, "GLOBAL Scope for exception"));;
+                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.GLOBAL, "GLOBAL Scope for exception"));
     }
 
     @Test
     void testExceptionThrownIfAlmRepoMissing() {
         when(projectAlmSettingDto.getAlmRepo()).thenReturn(null);
-        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server);
+        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server, settings);
         assertThatThrownBy(() -> underTest.createClient(projectAlmSettingDto, almSettingDto))
                 .isInstanceOf(InvalidConfigurationException.class)
                 .hasMessage("No repository name has been set for Github connections")
-                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.PROJECT, "PROJECT Scope for exception"));;
+                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.PROJECT, "PROJECT Scope for exception"));
     }
 
     @Test
     void testExceptionThrownIfAppIdMissing() {
         when(almSettingDto.getAppId()).thenReturn(null);
-        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server);
+        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server, settings);
         assertThatThrownBy(() -> underTest.createClient(projectAlmSettingDto, almSettingDto))
                 .isInstanceOf(InvalidConfigurationException.class)
                 .hasMessage("No App ID has been set for Github connections")
-                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.GLOBAL, "GLOBAL Scope for exception"));;
+                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.GLOBAL, "GLOBAL Scope for exception"));
     }
 
     @Test
     void testExceptionThrownIfAuthenticationProviderThrowsException() throws IOException {
-        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server);
+        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server, settings);
         when(restApplicationAuthenticationProvider.getInstallationToken(any(), any(), any(), any())).thenThrow(new IOException("dummy"));
         assertThatThrownBy(() -> underTest.createClient(projectAlmSettingDto, almSettingDto))
                 .isInstanceOf(InvalidConfigurationException.class)
                 .hasMessage("Could not create Github client - dummy")
-                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.PROJECT, "PROJECT Scope for exception"));;
+                .has(new Condition<>(t -> ((InvalidConfigurationException) t).getScope() == InvalidConfigurationException.Scope.PROJECT, "PROJECT Scope for exception"));
     }
 
     @Test
     void testHappyPath() throws IOException {
-        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server);
+        DefaultGithubClientFactory underTest = new DefaultGithubClientFactory(restApplicationAuthenticationProvider, server, settings);
 
         RepositoryAuthenticationToken repositoryAuthenticationToken = mock(RepositoryAuthenticationToken.class);
         when(restApplicationAuthenticationProvider.getInstallationToken(any(), any(), any(), any())).thenReturn(repositoryAuthenticationToken);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
@@ -110,7 +110,7 @@ public class GraphqlGithubClientTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("http://host.name");
         when(almSettingDto.getAppId()).thenReturn("app id");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("private key");
 
         GraphqlGithubClient testCase =
                 new GraphqlGithubClient(graphqlProvider, clock, repositoryAuthenticationToken, server);
@@ -156,7 +156,7 @@ public class GraphqlGithubClientTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("url");
         when(almSettingDto.getAppId()).thenReturn("app ID");
-        when(almSettingDto.getPrivateKey()).thenReturn("key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("key");
         when(projectAlmSettingDto.getAlmRepo()).thenReturn("group/repo");
 
         GraphqlGithubClient testCase =
@@ -441,7 +441,7 @@ public class GraphqlGithubClientTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn(basePath);
         when(almSettingDto.getAppId()).thenReturn("app id");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("private key");
 
         GraphqlGithubClient testCase =
                 new GraphqlGithubClient(graphqlProvider, clock, repositoryAuthenticationToken, server);
@@ -637,7 +637,7 @@ public class GraphqlGithubClientTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("http://host.name");
         when(almSettingDto.getAppId()).thenReturn("app id");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedClientSecret(any())).thenReturn("private key");
 
         GraphqlGithubClient testCase = new GraphqlGithubClient(graphqlProvider, clock, repositoryAuthenticationToken, server);
         testCase.createCheckRun(analysisDetails, almSettingDto, projectAlmSettingDto);
@@ -680,7 +680,7 @@ public class GraphqlGithubClientTest {
         AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("url");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("private key");
         ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
 
         GraphqlGithubClient underTest = new GraphqlGithubClient(mock(RepositoryAuthenticationToken.class), mock(Server.class));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTaskTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTaskTest.java
@@ -127,7 +127,7 @@ public class PullRequestPostAnalysisTaskTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("http://host.name");
         when(almSettingDto.getAppId()).thenReturn("app id");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("private key");
         when(almSettingDto.getAlm()).thenReturn(ALM.GITHUB);
         when(dbClient.openSession(anyBoolean())).thenReturn(mock(DbSession.class));
         AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
@@ -163,7 +163,7 @@ public class PullRequestPostAnalysisTaskTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("http://host.name");
         when(almSettingDto.getAppId()).thenReturn("app id");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("private key");
         when(almSettingDto.getAlm()).thenReturn(ALM.AZURE_DEVOPS);
         when(dbClient.openSession(anyBoolean())).thenReturn(mock(DbSession.class));
         AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
@@ -201,7 +201,7 @@ public class PullRequestPostAnalysisTaskTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("http://host.name");
         when(almSettingDto.getAppId()).thenReturn("app id");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("private key");
         when(almSettingDto.getAlm()).thenReturn(ALM.GITHUB);
         when(dbClient.openSession(anyBoolean())).thenReturn(mock(DbSession.class));
         AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
@@ -241,7 +241,7 @@ public class PullRequestPostAnalysisTaskTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("http://host.name");
         when(almSettingDto.getAppId()).thenReturn("app id");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("private key");
         when(almSettingDto.getAlm()).thenReturn(ALM.GITHUB);
         when(dbClient.openSession(anyBoolean())).thenReturn(mock(DbSession.class));
         AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
@@ -273,7 +273,7 @@ public class PullRequestPostAnalysisTaskTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("http://host.name");
         when(almSettingDto.getAppId()).thenReturn("app id");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("private key");
         when(almSettingDto.getAlm()).thenReturn(ALM.GITHUB);
         when(dbClient.openSession(anyBoolean())).thenReturn(mock(DbSession.class));
         AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
@@ -470,7 +470,7 @@ public class PullRequestPostAnalysisTaskTest {
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
         when(almSettingDto.getUrl()).thenReturn("http://host.name");
         when(almSettingDto.getAppId()).thenReturn("app id");
-        when(almSettingDto.getPrivateKey()).thenReturn("private key");
+        when(almSettingDto.getDecryptedPrivateKey(any())).thenReturn("private key");
         when(almSettingDto.getAlm()).thenReturn(ALM.GITHUB);
         when(dbClient.openSession(anyBoolean())).thenReturn(mock(DbSession.class));
         AlmSettingDao almSettingDao = mock(AlmSettingDao.class);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
@@ -6,9 +6,12 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.config.internal.Encryption;
+import org.sonar.api.config.internal.Settings;
 import org.sonar.api.issue.Issue;
 import org.sonar.api.platform.Server;
 import org.sonar.api.rule.RuleKey;
@@ -64,20 +67,27 @@ public class AzureDevOpsPullRequestDecoratorTest {
     private final String authorId = "author-id";
     private final String projectName = "Project Name";
 
-    private ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
-    private AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
-    private Server server = mock(Server.class);
-    private ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
-    private AzureDevOpsPullRequestDecorator pullRequestDecorator = new AzureDevOpsPullRequestDecorator(server, scmInfoRepository, new DefaultAzureDevopsClientFactory());
-    private AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
+    private final ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
+    private final AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
+    private final Server server = mock(Server.class);
+    private final ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
+    private final Settings settings = mock(Settings.class);
+    private final Encryption encryption = mock(Encryption.class);
+    private final AzureDevOpsPullRequestDecorator pullRequestDecorator = new AzureDevOpsPullRequestDecorator(server, scmInfoRepository, new DefaultAzureDevopsClientFactory(settings));
+    private final AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
 
-    private PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
-    private PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
-    private PostAnalysisIssueVisitor.LightIssue defaultIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
-    private Component component = mock(Component.class);
+    private final PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
+    private final PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
+    private final PostAnalysisIssueVisitor.LightIssue defaultIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
+    private final Component component = mock(Component.class);
+
+    @Before
+    public void setUp() {
+        when(settings.getEncryption()).thenReturn(encryption);
+    }
 
     private void configureTestDefaults() {
-        when(almSettingDto.getPersonalAccessToken()).thenReturn(token);
+        when(almSettingDto.getDecryptedPersonalAccessToken(any())).thenReturn(token);
         when(almSettingDto.getUrl()).thenReturn(wireMockRule.baseUrl());
 
         when(analysisDetails.getAnalysisProjectName()).thenReturn(projectName);
@@ -506,7 +516,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
     @Test
     public void testDecorateQualityGateRepoNameException() {
         when(almSettingDto.getUrl()).thenReturn("almUrl");
-        when(almSettingDto.getPersonalAccessToken()).thenReturn("personalAccessToken");
+        when(almSettingDto.getDecryptedPersonalAccessToken(any())).thenReturn("personalAccessToken");
         when(analysisDetails.getBranchName()).thenReturn("123");
         when(projectAlmSettingDto.getAlmSlug()).thenReturn("prj");
 
@@ -518,7 +528,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
     @Test
     public void testDecorateQualityGateRepoSlugException() {
         when(almSettingDto.getUrl()).thenReturn("almUrl");
-        when(almSettingDto.getPersonalAccessToken()).thenReturn("personalAccessToken");
+        when(almSettingDto.getDecryptedPersonalAccessToken(any())).thenReturn("personalAccessToken");
         when(analysisDetails.getBranchName()).thenReturn("123");
         when(projectAlmSettingDto.getAlmRepo()).thenReturn("repo");
 
@@ -530,7 +540,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
     @Test
     public void testDecorateQualityGateProjectIDException() {
         when(almSettingDto.getUrl()).thenReturn("almUrl");
-        when(almSettingDto.getPersonalAccessToken()).thenReturn("personalAccessToken");
+        when(almSettingDto.getDecryptedPersonalAccessToken(any())).thenReturn("personalAccessToken");
         when(projectAlmSettingDto.getAlmRepo()).thenReturn("repo");
         when(projectAlmSettingDto.getAlmSlug()).thenReturn("slug");
 
@@ -542,7 +552,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
     @Test
     public void testDecorateQualityGatePRBranchException() {
         when(almSettingDto.getUrl()).thenReturn("almUrl");
-        when(almSettingDto.getPersonalAccessToken()).thenReturn("personalAccessToken");
+        when(almSettingDto.getDecryptedPersonalAccessToken(any())).thenReturn("personalAccessToken");
         when(analysisDetails.getBranchName()).thenReturn("NON-NUMERIC");
         when(projectAlmSettingDto.getAlmSlug()).thenReturn("prj");
         when(projectAlmSettingDto.getAlmRepo()).thenReturn("repo");

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
@@ -26,6 +26,8 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.config.internal.Encryption;
+import org.sonar.api.config.internal.Settings;
 import org.sonar.api.issue.Issue;
 import org.sonar.api.platform.Server;
 import org.sonar.ce.task.projectanalysis.component.Component;
@@ -88,7 +90,7 @@ public class GitlabMergeRequestDecoratorIntegrationTest {
 
         ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
         AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
-        when(almSettingDto.getPersonalAccessToken()).thenReturn("token");
+        when(almSettingDto.getDecryptedPersonalAccessToken(any())).thenReturn("token");
         when(almSettingDto.getUrl()).thenReturn(wireMockRule.baseUrl()+"/api/v4");
         when(projectAlmSettingDto.getAlmRepo()).thenReturn(repositorySlug);
 
@@ -227,8 +229,11 @@ public class GitlabMergeRequestDecoratorIntegrationTest {
         LinkHeaderReader linkHeaderReader = mock(LinkHeaderReader.class);
         Server server = mock(Server.class);
         when(server.getPublicRootUrl()).thenReturn(sonarRootUrl);
+        Settings settings = mock(Settings.class);
+        Encryption encryption = mock(Encryption.class);
+        when(settings.getEncryption()).thenReturn(encryption);
         GitlabMergeRequestDecorator pullRequestDecorator =
-                new GitlabMergeRequestDecorator(server, scmInfoRepository, new DefaultGitlabClientFactory(linkHeaderReader));
+                new GitlabMergeRequestDecorator(server, scmInfoRepository, new DefaultGitlabClientFactory(linkHeaderReader, settings));
 
 
         assertThat(pullRequestDecorator.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto).getPullRequestUrl()).isEqualTo(Optional.of("http://gitlab.example.com/my-group/my-project/merge_requests/1"));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/action/SetBindingActionTest.java
@@ -103,7 +103,7 @@ public class SetBindingActionTest {
 
         testCase.handle(request, response);
 
-        verify(projectAlmSettingDao).insertOrUpdate(eq(dbSession), eq(projectAlmSettingDto));
+        verify(projectAlmSettingDao).insertOrUpdate(eq(dbSession), eq(projectAlmSettingDto), any(), any(), any());
         verify(dbSession).commit();
         verify(response).noContent();
     }


### PR DESCRIPTION
Sonarqube 9.1 encrypts the sensitive fields for DevOps decorators, such as private keys and personal access tokens. To allow the decorators to access these properties, the relevant methods now require encryption details to be provided, so the encryption handlers are now being loaded from the internal Sonarqube settings and passed to the appropriate target methods.

A change is also required in `SetBindingsAction` to pass additional fields for recording on the audit log when settings are saved. No additional settings are being added for the auditing as community edition does not provide a user interface for accessing audit logs, and uses a default cleaner task for purging logs after 30 days.