### PR TITLE
#461: Correctly encode spaces in Azure DevOps URLs

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClientTest.java
@@ -1,0 +1,133 @@
+package com.github.mc1arke.sonarqube.plugin.almclient.azuredevops;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.model.CreateCommentRequest;
+import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.model.GitPullRequestStatus;
+import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.model.GitStatusContext;
+import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.model.PullRequest;
+import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.model.enums.GitStatusState;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AzureDevopsRestClientTest {
+
+    private final ObjectMapper objectMapper = mock(ObjectMapper.class);
+    private final CloseableHttpClient closeableHttpClient = mock(CloseableHttpClient.class);
+
+    @Test
+    void checkErrorThrownOnNonSuccessResponseStatus() throws IOException {
+        AzureDevopsRestClient underTest = new AzureDevopsRestClient("http://url.test/api", "token", objectMapper, () -> closeableHttpClient);
+
+        CloseableHttpResponse closeableHttpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(500);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(statusLine);
+        when(closeableHttpClient.execute(any())).thenReturn(closeableHttpResponse);
+        when(objectMapper.writeValueAsString(any())).thenReturn("json");
+
+        GitPullRequestStatus gitPullRequestStatus = mock(GitPullRequestStatus.class);
+        assertThatThrownBy(() -> underTest.submitPullRequestStatus("project", "repo", 101, gitPullRequestStatus))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("An unexpected response code was returned from the Azure Devops API - Expected: 200, Got: 500")
+                .hasNoCause();
+
+        ArgumentCaptor<HttpUriRequest> requestArgumentCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(closeableHttpClient).execute(requestArgumentCaptor.capture());
+
+        RequestBuilder request = RequestBuilder.copy(requestArgumentCaptor.getValue());
+
+        assertThat(request.getMethod()).isEqualTo("post");
+        assertThat(request.getUri()).isEqualTo(URI.create("http://url.test/api/project/_apis/git/repositories/repo/pullRequests/101/statuses?api-version=4.1-preview"));
+        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new StringEntity("json", StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void checkSubmitPullRequestStatusSubmitsCorrectContent() throws IOException {
+        AzureDevopsRestClient underTest = new AzureDevopsRestClient("http://url.test/api", "token", objectMapper, () -> closeableHttpClient);
+
+        CloseableHttpResponse closeableHttpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(statusLine);
+        when(closeableHttpClient.execute(any())).thenReturn(closeableHttpResponse);
+        when(objectMapper.writeValueAsString(any())).thenReturn("json");
+
+        underTest.submitPullRequestStatus("project Id With Spaces", "repository Name With Spaces", 123, new GitPullRequestStatus(GitStatusState.SUCCEEDED, "description", new GitStatusContext("name", "genre"), "url"));
+
+        ArgumentCaptor<HttpUriRequest> requestArgumentCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(closeableHttpClient).execute(requestArgumentCaptor.capture());
+
+        RequestBuilder request = RequestBuilder.copy(requestArgumentCaptor.getValue());
+
+        assertThat(request.getMethod()).isEqualTo("post");
+        assertThat(request.getUri()).isEqualTo(URI.create("http://url.test/api/project%20Id%20With%20Spaces/_apis/git/repositories/repository%20Name%20With%20Spaces/pullRequests/123/statuses?api-version=4.1-preview"));
+        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new StringEntity("json", StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void checkAddCommentToThreadSubmitsCorrectContent() throws IOException {
+        AzureDevopsRestClient underTest = new AzureDevopsRestClient("http://test.url", "authToken", objectMapper, () -> closeableHttpClient);
+
+        CloseableHttpResponse closeableHttpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(statusLine);
+        when(closeableHttpClient.execute(any())).thenReturn(closeableHttpResponse);
+        when(objectMapper.writeValueAsString(any())).thenReturn("json");
+
+        underTest.addCommentToThread("projectId", "repository Name", 123, 321, new CreateCommentRequest("comment"));
+
+        ArgumentCaptor<HttpUriRequest> requestArgumentCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(closeableHttpClient).execute(requestArgumentCaptor.capture());
+
+        RequestBuilder request = RequestBuilder.copy(requestArgumentCaptor.getValue());
+
+        assertThat(request.getMethod()).isEqualTo("post");
+        assertThat(request.getUri()).isEqualTo(URI.create("http://test.url/projectId/_apis/git/repositories/repository%20Name/pullRequests/123/threads/321/comments?api-version=4.1"));
+        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new StringEntity("json", StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void checkRetrievePullRequestReturnsCorrectContent() throws IOException {
+        AzureDevopsRestClient underTest = new AzureDevopsRestClient("http://test.url", "authToken", objectMapper, () -> closeableHttpClient);
+
+        CloseableHttpResponse closeableHttpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(statusLine);
+        when(closeableHttpResponse.getEntity()).thenReturn(new StringEntity("content", StandardCharsets.UTF_8));
+        when(closeableHttpClient.execute(any())).thenReturn(closeableHttpResponse);
+        PullRequest pullRequest = mock(PullRequest.class);
+        when(objectMapper.readValue(any(String.class), eq(PullRequest.class))).thenReturn(pullRequest);
+
+        PullRequest result = underTest.retrievePullRequest("projectId", "repository Name", 123);
+
+        ArgumentCaptor<HttpUriRequest> requestArgumentCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(closeableHttpClient).execute(requestArgumentCaptor.capture());
+
+        RequestBuilder request = RequestBuilder.copy(requestArgumentCaptor.getValue());
+
+        assertThat(request.getMethod()).isEqualTo("get");
+        assertThat(request.getUri()).isEqualTo(URI.create("http://test.url/projectId/_apis/git/repositories/repository%20Name/pullRequests/123?api-version=4.1"));
+        assertThat(request.getEntity()).isNull();
+        assertThat(result).isSameAs(pullRequest);
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
@@ -123,7 +123,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
     }
 
     private void setupStubs() {
-        wireMockRule.stubFor(get(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/"+ pullRequestId +"/threads?api-version=4.1"))
+        wireMockRule.stubFor(get(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/"+ pullRequestId +"/threads?api-version=4.1"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Authorization", equalTo(authHeader))
                 .willReturn(aResponse()
@@ -198,7 +198,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
                         "    \"count\": 2" + System.lineSeparator() +
                         "}")));
 
-        wireMockRule.stubFor(get(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/" + pullRequestId +"?api-version=4.1"))
+        wireMockRule.stubFor(get(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/" + pullRequestId +"?api-version=4.1"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Authorization", equalTo(authHeader))
                 .willReturn(aResponse()
@@ -303,7 +303,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
                                 "  \"artifactId\": \"vstfs:///Git/PullRequestId/a7573007-bbb3-4341-b726-0c4148a07853%2f3411ebc1-d5aa-464f-9615-0b527bc66719%2f22\"" + System.lineSeparator() +
                                 "}")));
 
-        wireMockRule.stubFor(post(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/" + pullRequestId + "/threads/" + threadId + "/comments?api-version=4.1"))
+        wireMockRule.stubFor(post(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/" + pullRequestId + "/threads/" + threadId + "/comments?api-version=4.1"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authHeader))
@@ -311,7 +311,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
                 )
                 .willReturn(ok()));
 
-        wireMockRule.stubFor(get(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/" + pullRequestId + "/commits?api-version=4.1"))
+        wireMockRule.stubFor(get(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/" + pullRequestId + "/commits?api-version=4.1"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Authorization", equalTo(authHeader))
                 .willReturn(aResponse().withStatus(200).withBody("{\"value\": [{" + System.lineSeparator() +
@@ -362,7 +362,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
                         "}]}")));
 
 
-        wireMockRule.stubFor(post(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/"+ pullRequestId +"/statuses?api-version=4.1-preview"))
+        wireMockRule.stubFor(post(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/"+ pullRequestId +"/statuses?api-version=4.1-preview"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authHeader))
                 .withRequestBody(equalTo("{" +
@@ -374,7 +374,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
                 )
                 .willReturn(ok()));
 
-        wireMockRule.stubFor(post(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/"+ pullRequestId +"/threads?api-version=4.1"))
+        wireMockRule.stubFor(post(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/"+ pullRequestId +"/threads?api-version=4.1"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authHeader))
@@ -431,7 +431,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
                         "  }" + System.lineSeparator() +
                         "}")));
 
-        wireMockRule.stubFor(post(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/"+ pullRequestId +"/threads?api-version=4.1"))
+        wireMockRule.stubFor(post(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/"+ pullRequestId +"/threads?api-version=4.1"))
                 .withHeader("Accept", equalTo("application/json"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authHeader))
@@ -488,7 +488,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
                         "  }" + System.lineSeparator() +
                         "}")));
 
-        wireMockRule.stubFor(patch(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/" + pullRequestId + "/threads/" + threadId + "?api-version=4.1"))
+        wireMockRule.stubFor(patch(urlEqualTo("/azure%20Project/_apis/git/repositories/my%20Repository/pullRequests/" + pullRequestId + "/threads/" + threadId + "?api-version=4.1"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authHeader))
                 .withRequestBody(equalTo("{" +


### PR DESCRIPTION
Azure DevOps does not correctly resolve URLs that contains spaces encoded as a `+`. To allow projects containg spaces to be decorated, the `+` from an the encoded names is being replaced with a `%20` since Azure Devops resolves spaces encoded this way properly.