### PR TITLE
#442: Pass preview flag on Azure Devops status requests

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClient.java
@@ -51,6 +51,7 @@ public class AzureDevopsRestClient implements AzureDevopsClient {
 
     private static final Logger LOGGER = Loggers.get(AzureDevopsRestClient.class);
     private static final String API_VERSION = "4.1";
+    private static final String API_VERSION_PREVIEW = API_VERSION + "-preview";
 
     private final String authToken;
     private final String apiUrl;
@@ -65,7 +66,7 @@ public class AzureDevopsRestClient implements AzureDevopsClient {
 
     @Override
     public void submitPullRequestStatus(String projectId, String repositoryName, int pullRequestId, GitPullRequestStatus status) throws IOException {
-        String url = String.format("%s/%s/_apis/git/repositories/%s/pullRequests/%s/statuses?api-version=%s", apiUrl, URLEncoder.encode(projectId, StandardCharsets.UTF_8), URLEncoder.encode(repositoryName, StandardCharsets.UTF_8), pullRequestId, API_VERSION);
+        String url = String.format("%s/%s/_apis/git/repositories/%s/pullRequests/%s/statuses?api-version=%s", apiUrl, URLEncoder.encode(projectId, StandardCharsets.UTF_8), URLEncoder.encode(repositoryName, StandardCharsets.UTF_8), pullRequestId, API_VERSION_PREVIEW);
         execute(url, "post", objectMapper.writeValueAsString(status), null);
     }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
@@ -362,7 +362,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
                         "}]}")));
 
 
-        wireMockRule.stubFor(post(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/"+ pullRequestId +"/statuses?api-version=4.1"))
+        wireMockRule.stubFor(post(urlEqualTo("/azure+Project/_apis/git/repositories/my+Repository/pullRequests/"+ pullRequestId +"/statuses?api-version=4.1-preview"))
                 .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
                 .withHeader("Authorization", equalTo(authHeader))
                 .withRequestBody(equalTo("{" +


### PR DESCRIPTION
Azure DevOps on-premise responds with an error if the `-preview` is not appended to the version number during the request to submit the pipeline status during Pull Request decoration. As the use of a preview version for this call does not seem to adversely affect invocation of this endpoint on Azure DevOps Cloud, the `-preview` flag has been unconditionally added to the status update, although it has not been added to any other invocations since they do not encounter the same error.