### PR TITLE
#445: Specify encoding when creating Gitlab decoration requests

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClient.java
@@ -35,7 +35,6 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -58,10 +57,6 @@ public class AzureDevopsRestClient implements AzureDevopsClient {
     private final String apiUrl;
     private final ObjectMapper objectMapper;
     private final Supplier<CloseableHttpClient> httpClientFactory;
-
-    public AzureDevopsRestClient(String apiUrl, String authToken, ObjectMapper objectMapper) {
-        this(apiUrl, authToken, objectMapper, HttpClients::createSystem);
-    }
 
     AzureDevopsRestClient(String apiUrl, String authToken, ObjectMapper objectMapper, Supplier<CloseableHttpClient> httpClientFactory) {
         super();

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/DefaultAzureDevopsClientFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/DefaultAzureDevopsClientFactory.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.impl.client.HttpClients;
 import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.config.internal.Settings;
 import org.sonar.api.server.ServerSide;
@@ -54,6 +55,6 @@ public class DefaultAzureDevopsClientFactory implements AzureDevopsClientFactory
     public AzureDevopsClient createClient(ProjectAlmSettingDto projectAlmSettingDto, AlmSettingDto almSettingDto) {
         String apiUrl = Optional.ofNullable(almSettingDto.getUrl()).map(StringUtils::trimToNull).orElseThrow(() -> new IllegalStateException("ALM URL must be provided"));
         String accessToken = Optional.ofNullable(almSettingDto.getDecryptedPersonalAccessToken(settings.getEncryption())).map(StringUtils::trimToNull).orElseThrow(() -> new IllegalStateException("Personal Access Token must be provided"));
-        return new AzureDevopsRestClient(apiUrl, Base64.getEncoder().encodeToString((":" + accessToken).getBytes(StandardCharsets.UTF_8)), objectMapper);
+        return new AzureDevopsRestClient(apiUrl, Base64.getEncoder().encodeToString((":" + accessToken).getBytes(StandardCharsets.UTF_8)), objectMapper, HttpClients::createSystem);
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/DefaultGitlabClientFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/DefaultGitlabClientFactory.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mc1arke.sonarqube.plugin.InvalidConfigurationException;
 import com.github.mc1arke.sonarqube.plugin.almclient.LinkHeaderReader;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.impl.client.HttpClients;
 import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.config.internal.Settings;
 import org.sonar.api.server.ServerSide;
@@ -55,6 +56,6 @@ public class DefaultGitlabClientFactory implements GitlabClientFactory {
                 .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "ALM URL must be specified"));
         String apiToken = almSettingDto.getDecryptedPersonalAccessToken(settings.getEncryption());
 
-        return new GitlabRestClient(apiURL, apiToken, linkHeaderReader, objectMapper);
+        return new GitlabRestClient(apiURL, apiToken, linkHeaderReader, objectMapper, HttpClients::createSystem);
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClientTest.java
@@ -1,0 +1,87 @@
+package com.github.mc1arke.sonarqube.plugin.almclient.gitlab;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mc1arke.sonarqube.plugin.almclient.LinkHeaderReader;
+import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.MergeRequestNote;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.StatusLine;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GitlabRestClientTest {
+
+    private final CloseableHttpClient closeableHttpClient = mock(CloseableHttpClient.class);
+    private final LinkHeaderReader linkHeaderReader = mock(LinkHeaderReader.class);
+    private final ObjectMapper objectMapper = mock(ObjectMapper.class);
+
+    @Test
+    void checkErrorThrownOnNonSuccessResponseStatus() throws IOException {
+        GitlabRestClient underTest = new GitlabRestClient("http://url.test/api", "token", linkHeaderReader, objectMapper, () -> closeableHttpClient);
+
+        CloseableHttpResponse closeableHttpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(500);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(statusLine);
+        when(closeableHttpClient.execute(any())).thenReturn(closeableHttpResponse);
+
+        MergeRequestNote mergeRequestNote = mock(MergeRequestNote.class);
+        when(mergeRequestNote.getContent()).thenReturn("note");
+
+        assertThatThrownBy(() -> underTest.addMergeRequestDiscussion(101, 99, mergeRequestNote))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("An unexpected response code was returned from the Gitlab API - Expected: 201, Got: 500")
+                .hasNoCause();
+
+        ArgumentCaptor<HttpUriRequest> requestArgumentCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(closeableHttpClient).execute(requestArgumentCaptor.capture());
+
+        HttpEntityEnclosingRequest request = (HttpEntityEnclosingRequest) requestArgumentCaptor.getValue();
+
+        assertThat(request.getRequestLine().getMethod()).isEqualTo("POST");
+        assertThat(request.getRequestLine().getUri()).isEqualTo("http://url.test/api/projects/101/merge_requests/99/discussions");
+        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new UrlEncodedFormEntity(List.of(new BasicNameValuePair("body", "note")), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void checkCorrectEncodingUsedOnMergeRequestDiscussion() throws IOException {
+        CloseableHttpResponse closeableHttpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(201);
+        when(closeableHttpResponse.getStatusLine()).thenReturn(statusLine);
+        HttpEntity httpEntity = mock(HttpEntity.class);
+        when(closeableHttpResponse.getEntity()).thenReturn(httpEntity);
+        when(closeableHttpClient.execute(any())).thenReturn(closeableHttpResponse);
+
+        MergeRequestNote mergeRequestNote = new MergeRequestNote("Merge request note");
+
+        GitlabRestClient underTest = new GitlabRestClient("http://api.url", "token", linkHeaderReader, objectMapper, () -> closeableHttpClient);
+        underTest.addMergeRequestDiscussion(123, 321, mergeRequestNote);
+
+        ArgumentCaptor<HttpUriRequest> requestArgumentCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(closeableHttpClient).execute(requestArgumentCaptor.capture());
+
+        HttpEntityEnclosingRequest request = (HttpEntityEnclosingRequest) requestArgumentCaptor.getValue();
+
+        assertThat(request.getRequestLine().getMethod()).isEqualTo("POST");
+        assertThat(request.getRequestLine().getUri()).isEqualTo("http://api.url/projects/123/merge_requests/321/discussions");
+        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new UrlEncodedFormEntity(List.of(new BasicNameValuePair("body", "Merge request note")), StandardCharsets.UTF_8));
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
@@ -130,8 +130,8 @@ public class GitlabMergeRequestDecoratorIntegrationTest {
         }
         when(issueVisitor.getIssues()).thenReturn(issues);
         when(analysisDetails.getPostAnalysisIssueVisitor()).thenReturn(issueVisitor);
-        when(analysisDetails.createAnalysisSummary(any())).thenReturn("summary comment\n\n[link text]");
-        when(analysisDetails.createAnalysisIssueSummary(any(), any())).thenReturn("issue");
+        when(analysisDetails.createAnalysisSummary(any())).thenReturn("summary commént\n\n[link text]");
+        when(analysisDetails.createAnalysisIssueSummary(any(), any())).thenReturn("issué");
         when(analysisDetails.parseIssueIdFromUrl(any())).thenCallRealMethod();
 
         wireMockRule.stubFor(get(urlPathEqualTo("/api/v4/user")).withHeader("PRIVATE-TOKEN", equalTo("token")).willReturn(okJson("{\n" +
@@ -202,11 +202,11 @@ public class GitlabMergeRequestDecoratorIntegrationTest {
                 .willReturn(created()));
 
         wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + sourceProjectId + "/merge_requests/" + mergeRequestIid + "/discussions"))
-                .withRequestBody(equalTo("body=summary+comment%0A%0A%5Blink+text%5D"))
+                .withRequestBody(equalTo("body=summary+comm%C3%A9nt%0A%0A%5Blink+text%5D"))
                 .willReturn(created().withBody(discussionPostResponseBody(discussionId, discussionNote(noteId, user, "summary comment", true, false)))));
 
         wireMockRule.stubFor(post(urlPathEqualTo("/api/v4/projects/" + sourceProjectId + "/merge_requests/" + mergeRequestIid + "/discussions"))
-                .withRequestBody(equalTo("body=issue&" +
+                .withRequestBody(equalTo("body=issu%C3%A9&" +
                         urlEncode("position[base_sha]") + "=d6a420d043dfe85e7c240fd136fc6e197998b10a&" +
                         urlEncode("position[start_sha]") + "=d6a420d043dfe85e7c240fd136fc6e197998b10a&" +
                         urlEncode("position[head_sha]") + "=" + commitSHA + "&" +


### PR DESCRIPTION
When calling the Gitlab API with content that contains accented or cyrillic characters, the API returns an error response and fails to complete the decoration. Explicitly setting the encoding for all body content to UTF-8 on Gitlab API requests results in the content being encoded in a way for the Gitlab API handles correctly.