### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           java-package: jdk
-          distribution: adopt
+          distribution: 'zulu'
       -
         name: Cache deps
         uses: actions/cache@v2
@@ -89,7 +89,7 @@ jobs:
         with:
           java-version: 11
           java-package: jdk
-          distribution: adopt
+          distribution: 'zulu'
       -
         name: Cache deps
         uses: actions/cache@v2
@@ -150,7 +150,7 @@ jobs:
         with:
           java-version: 11
           java-package: jdk
-          distribution: adopt
+          distribution: 'zulu'
       -
         name: Cache deps
         uses: actions/cache@v2


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many non LTS (long term support) releases if you plan to try out newer features in the language.