### PR TITLE
Add configuration option to disable issue comments on PR decoration

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -25,6 +25,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.github.DefaultGithubClientF
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.RestApplicationAuthenticationProvider;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.DefaultGitlabClientFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.CommunityReportAnalysisComponentProvider;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DiscussionAwarePullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchConfigurationLoader;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchParamsValidator;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityProjectBranchesLoader;
@@ -118,6 +119,18 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                                           .defaultValue("master,develop,trunk")
                                           .onQualifiers(Qualifiers.PROJECT)
                                           .index(2)
+                                          .build()
+                                  ,
+
+                                  PropertyDefinition
+                                          .builder(DiscussionAwarePullRequestDecorator.SUBMIT_ISSUE_NOTES)
+                                          .name("Submit notes for issues")
+                                          .description("Whether or not to submit notes for each raised issue when decorating Pull Requests.")
+                                          .category(CoreProperties.CATEGORY_GENERAL)
+                                          .subCategory(CoreProperties.SUBCATEGORY_GENERAL)
+                                          .type(PropertyType.BOOLEAN)
+                                          .defaultValue("true")
+                                          .onQualifiers(Qualifiers.PROJECT)
                                           .build()
 
                                  );

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
@@ -41,6 +41,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactor
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.apache.commons.lang.StringUtils;
 import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.platform.Server;
 import org.sonar.ce.task.projectanalysis.scm.ScmInfoRepository;
 import org.sonar.db.alm.setting.ALM;
@@ -63,8 +64,8 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
     private final AzureDevopsClientFactory azureDevopsClientFactory;
     private final FormatterFactory formatterFactory;
 
-    public AzureDevOpsPullRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, AzureDevopsClientFactory azureDevopsClientFactory) {
-        super(server, scmInfoRepository);
+    public AzureDevOpsPullRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, Configuration configuration, AzureDevopsClientFactory azureDevopsClientFactory) {
+        super(server, scmInfoRepository, configuration);
         this.azureDevopsClientFactory = azureDevopsClientFactory;
         this.formatterFactory = new MarkdownFormatterFactory();
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
@@ -34,6 +34,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisit
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.platform.Server;
 import org.sonar.ce.task.projectanalysis.scm.ScmInfoRepository;
 import org.sonar.db.alm.setting.ALM;
@@ -58,8 +59,8 @@ public class GitlabMergeRequestDecorator extends DiscussionAwarePullRequestDecor
     private final GitlabClientFactory gitlabClientFactory;
     private final FormatterFactory formatterFactory;
 
-    public GitlabMergeRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, GitlabClientFactory gitlabClientFactory) {
-        super(server, scmInfoRepository);
+    public GitlabMergeRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, Configuration configuration, GitlabClientFactory gitlabClientFactory) {
+        super(server, scmInfoRepository, configuration);
         this.gitlabClientFactory = gitlabClientFactory;
         this.formatterFactory = new MarkdownFormatterFactory();
     }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -118,7 +118,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(22, argumentCaptor.getAllValues().size());
+        assertEquals(23, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.config.internal.Encryption;
 import org.sonar.api.config.internal.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.issue.Issue;
 import org.sonar.api.platform.Server;
 import org.sonar.api.rule.RuleKey;
@@ -73,7 +74,8 @@ public class AzureDevOpsPullRequestDecoratorTest {
     private final ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
     private final Settings settings = mock(Settings.class);
     private final Encryption encryption = mock(Encryption.class);
-    private final AzureDevOpsPullRequestDecorator pullRequestDecorator = new AzureDevOpsPullRequestDecorator(server, scmInfoRepository, new DefaultAzureDevopsClientFactory(settings));
+    private Configuration configuration = mock(Configuration.class);
+    private final AzureDevOpsPullRequestDecorator pullRequestDecorator = new AzureDevOpsPullRequestDecorator(server, scmInfoRepository, configuration, new DefaultAzureDevopsClientFactory(settings));
     private final AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
 
     private final PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
@@ -510,7 +512,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
 
     @Test
     public void testName() {
-        assertThat(new AzureDevOpsPullRequestDecorator(mock(Server.class), mock(ScmInfoRepository.class), mock(AzureDevopsClientFactory.class)).alm()).isEqualTo(Collections.singletonList(ALM.AZURE_DEVOPS));
+        assertThat(new AzureDevOpsPullRequestDecorator(mock(Server.class), mock(ScmInfoRepository.class), mock(Configuration.class), mock(AzureDevopsClientFactory.class)).alm()).isEqualTo(Collections.singletonList(ALM.AZURE_DEVOPS));
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.config.internal.Encryption;
 import org.sonar.api.config.internal.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.issue.Issue;
 import org.sonar.api.platform.Server;
 import org.sonar.ce.task.projectanalysis.component.Component;
@@ -228,12 +229,13 @@ public class GitlabMergeRequestDecoratorIntegrationTest {
 
         LinkHeaderReader linkHeaderReader = mock(LinkHeaderReader.class);
         Server server = mock(Server.class);
+        Configuration configuration = mock(Configuration.class);
         when(server.getPublicRootUrl()).thenReturn(sonarRootUrl);
         Settings settings = mock(Settings.class);
         Encryption encryption = mock(Encryption.class);
         when(settings.getEncryption()).thenReturn(encryption);
         GitlabMergeRequestDecorator pullRequestDecorator =
-                new GitlabMergeRequestDecorator(server, scmInfoRepository, new DefaultGitlabClientFactory(linkHeaderReader, settings));
+                new GitlabMergeRequestDecorator(server, scmInfoRepository, configuration, new DefaultGitlabClientFactory(linkHeaderReader, settings));
 
 
         assertThat(pullRequestDecorator.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto).getPullRequestUrl()).isEqualTo(Optional.of("http://gitlab.example.com/my-group/my-project/merge_requests/1"));


### PR DESCRIPTION
For PRs with lots of issues, it can be quite noisy to post comments each raised issue. This change adds the option to disable comments for issues, leaving only the summary comment. The option can be found in both the global settings ("General -> General" for lack of a better place), and in the project settings.

Note that the project settings currently do not have an effect due to [SONAR-13711](https://jira.sonarsource.com/browse/SONAR-13711).

Also, this will only affect Azure and GitLab integrations.