### PR TITLE
Add missing base url while using bitbucket client

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
@@ -179,7 +179,7 @@ class BitbucketServerClient implements BitbucketClient {
     public Repository retrieveRepository(String project, String repo) throws IOException {
         Request req = new Request.Builder()
                 .get()
-                .url(format("/rest/api/1.0/projects/%s/repos/%s", project, repo))
+                .url(format("%s/rest/api/1.0/projects/%s/repos/%s", config.getUrl(), project, repo))
                 .build();
         try (Response response = okHttpClient.newCall(req).execute()) {
             validate(response);


### PR DESCRIPTION
One of the method of BitbucketServerClient is not using correct url to call bitbucket client what results in error in UI

![image](https://user-images.githubusercontent.com/18039160/142896698-5c1c8c02-0a62-4b3f-8ce0-5dc8f74b0e42.png)
