### PR TITLE
Add configuration option to delete notes instead of resolving them

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -132,6 +132,19 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                                           .defaultValue("true")
                                           .onQualifiers(Qualifiers.PROJECT)
                                           .build()
+                                  ,
+
+                                  PropertyDefinition
+                                          .builder(DiscussionAwarePullRequestDecorator.KEEP_OLD_NOTES)
+                                          .name("Keep old issue and summary notes")
+                                          .description("Whether or not to keep stale notes on decorated Pull Requests. If enabled, old discussion will be "
+                                                + "resolved where possible. If disabled, old notes will be removed. The latter reduces clutter in decorated PRs")
+                                          .category(CoreProperties.CATEGORY_GENERAL)
+                                          .subCategory(CoreProperties.SUBCATEGORY_GENERAL)
+                                          .type(PropertyType.BOOLEAN)
+                                          .defaultValue("true")
+                                          .onQualifiers(Qualifiers.PROJECT)
+                                          .build()
 
                                  );
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -25,6 +25,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.github.DefaultGithubClientF
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.RestApplicationAuthenticationProvider;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.DefaultGitlabClientFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.CommunityReportAnalysisComponentProvider;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DiscussionAwarePullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchConfigurationLoader;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchParamsValidator;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityProjectBranchesLoader;
@@ -118,6 +119,18 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                                           .defaultValue("master,develop,trunk")
                                           .onQualifiers(Qualifiers.PROJECT)
                                           .index(2)
+                                          .build()
+                                  ,
+
+                                  PropertyDefinition
+                                          .builder(DiscussionAwarePullRequestDecorator.SUBMIT_ISSUE_NOTES)
+                                          .name("Submit notes for issues")
+                                          .description("Whether or not to submit notes for each raised issue when decorating Pull Requests.")
+                                          .category(CoreProperties.CATEGORY_GENERAL)
+                                          .subCategory(CoreProperties.SUBCATEGORY_GENERAL)
+                                          .type(PropertyType.BOOLEAN)
+                                          .defaultValue("true")
+                                          .onQualifiers(Qualifiers.PROJECT)
                                           .build()
 
                                  );

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabClient.java
@@ -45,6 +45,8 @@ public interface GitlabClient {
 
     void resolveMergeRequestDiscussion(long projectId, long mergeRequestIid, String discussionId) throws IOException;
 
+    void deleteMergeRequestDiscussionNote(long projectId, long mergeRequestIid, String discussionId, long noteId) throws IOException;
+
     void setMergeRequestPipelineStatus(long projectId, String commitRevision, PipelineStatus status) throws IOException;
 
     Project getProject(String projectSlug) throws IOException;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClient.java
@@ -31,10 +31,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.User;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.*;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
@@ -132,6 +129,14 @@ class GitlabRestClient implements GitlabClient {
 
         HttpPut httpPut = new HttpPut(discussionIdUrl);
         entity(httpPut, null);
+    }
+
+    public void deleteMergeRequestDiscussionNote(long projectId, long mergeRequestIid, String discussionId, long noteId) throws IOException {
+        String noteIdUrl = String.format("%s/projects/%s/merge_requests/%s/discussions/%s/notes/%s", baseGitlabApiUrl, projectId, mergeRequestIid, discussionId, noteId);
+        HttpDelete httpDelete = new HttpDelete(noteIdUrl);
+        entity(httpDelete, null, httpResponse -> {
+            validateResponse(httpResponse, 204, "Merge request discussions note deleted");
+        });
     }
 
     @Override

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
@@ -41,6 +41,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactor
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.apache.commons.lang.StringUtils;
 import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.platform.Server;
 import org.sonar.ce.task.projectanalysis.scm.ScmInfoRepository;
 import org.sonar.db.alm.setting.ALM;
@@ -63,8 +64,8 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
     private final AzureDevopsClientFactory azureDevopsClientFactory;
     private final FormatterFactory formatterFactory;
 
-    public AzureDevOpsPullRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, AzureDevopsClientFactory azureDevopsClientFactory) {
-        super(server, scmInfoRepository);
+    public AzureDevOpsPullRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, Configuration configuration, AzureDevopsClientFactory azureDevopsClientFactory) {
+        super(server, scmInfoRepository, configuration);
         this.azureDevopsClientFactory = azureDevopsClientFactory;
         this.formatterFactory = new MarkdownFormatterFactory();
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
@@ -231,6 +231,11 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
     }
 
     @Override
+    protected void deleteDiscussionNote(AzureDevopsClient client, CommentThread discussion, Comment note, PullRequest pullRequest) {
+        throw new UnsupportedOperationException("Deleting notes on Azure is not yet implemented.");
+    }
+
+    @Override
     protected Optional<AnalysisDetails.ProjectIssueIdentifier> parseIssueDetails(AzureDevopsClient client, Comment note, AnalysisDetails analysisDetails) {
         Optional<AnalysisDetails.ProjectIssueIdentifier> issueIdentifier = super.parseIssueDetails(client, note, analysisDetails);
         if (issueIdentifier.isPresent()) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
@@ -34,6 +34,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisit
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.platform.Server;
 import org.sonar.ce.task.projectanalysis.scm.ScmInfoRepository;
 import org.sonar.db.alm.setting.ALM;
@@ -58,8 +59,8 @@ public class GitlabMergeRequestDecorator extends DiscussionAwarePullRequestDecor
     private final GitlabClientFactory gitlabClientFactory;
     private final FormatterFactory formatterFactory;
 
-    public GitlabMergeRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, GitlabClientFactory gitlabClientFactory) {
-        super(server, scmInfoRepository);
+    public GitlabMergeRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, Configuration configuration, GitlabClientFactory gitlabClientFactory) {
+        super(server, scmInfoRepository, configuration);
         this.gitlabClientFactory = gitlabClientFactory;
         this.formatterFactory = new MarkdownFormatterFactory();
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
@@ -236,4 +236,12 @@ public class GitlabMergeRequestDecorator extends DiscussionAwarePullRequestDecor
         }
     }
 
+    protected void deleteDiscussionNote(GitlabClient client, Discussion discussion, Note note, MergeRequest pullRequest) {
+        try {
+            client.deleteMergeRequestDiscussionNote(pullRequest.getSourceProjectId(), pullRequest.getIid(), discussion.getId(), note.getId());
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not delete Merge Request discussion", ex);
+        }
+    }
+
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -118,7 +118,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(23, argumentCaptor.getAllValues().size());
+        assertEquals(24, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -118,7 +118,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(22, argumentCaptor.getAllValues().size());
+        assertEquals(23, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.config.internal.Encryption;
 import org.sonar.api.config.internal.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.issue.Issue;
 import org.sonar.api.platform.Server;
 import org.sonar.api.rule.RuleKey;
@@ -73,7 +74,8 @@ public class AzureDevOpsPullRequestDecoratorTest {
     private final ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
     private final Settings settings = mock(Settings.class);
     private final Encryption encryption = mock(Encryption.class);
-    private final AzureDevOpsPullRequestDecorator pullRequestDecorator = new AzureDevOpsPullRequestDecorator(server, scmInfoRepository, new DefaultAzureDevopsClientFactory(settings));
+    private Configuration configuration = mock(Configuration.class);
+    private final AzureDevOpsPullRequestDecorator pullRequestDecorator = new AzureDevOpsPullRequestDecorator(server, scmInfoRepository, configuration, new DefaultAzureDevopsClientFactory(settings));
     private final AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
 
     private final PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
@@ -510,7 +512,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
 
     @Test
     public void testName() {
-        assertThat(new AzureDevOpsPullRequestDecorator(mock(Server.class), mock(ScmInfoRepository.class), mock(AzureDevopsClientFactory.class)).alm()).isEqualTo(Collections.singletonList(ALM.AZURE_DEVOPS));
+        assertThat(new AzureDevOpsPullRequestDecorator(mock(Server.class), mock(ScmInfoRepository.class), mock(Configuration.class), mock(AzureDevopsClientFactory.class)).alm()).isEqualTo(Collections.singletonList(ALM.AZURE_DEVOPS));
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.config.internal.Encryption;
 import org.sonar.api.config.internal.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.issue.Issue;
 import org.sonar.api.platform.Server;
 import org.sonar.ce.task.projectanalysis.component.Component;
@@ -228,12 +229,13 @@ public class GitlabMergeRequestDecoratorIntegrationTest {
 
         LinkHeaderReader linkHeaderReader = mock(LinkHeaderReader.class);
         Server server = mock(Server.class);
+        Configuration configuration = mock(Configuration.class);
         when(server.getPublicRootUrl()).thenReturn(sonarRootUrl);
         Settings settings = mock(Settings.class);
         Encryption encryption = mock(Encryption.class);
         when(settings.getEncryption()).thenReturn(encryption);
         GitlabMergeRequestDecorator pullRequestDecorator =
-                new GitlabMergeRequestDecorator(server, scmInfoRepository, new DefaultGitlabClientFactory(linkHeaderReader, settings));
+                new GitlabMergeRequestDecorator(server, scmInfoRepository, configuration, new DefaultGitlabClientFactory(linkHeaderReader, settings));
 
 
         assertThat(pullRequestDecorator.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto).getPullRequestUrl()).isEqualTo(Optional.of("http://gitlab.example.com/my-group/my-project/merge_requests/1"));


### PR DESCRIPTION
This will reduce PR decoration clutter where lots of commits are added. Note that it only works for GitLab.

To reduce merge conflicts, the commit in this PR is done on top of that of #487. Hence this PR contains also the diff of #487. To see the diff of the relevant commit go to 21e3ec41734dbfbff953fea786e475d5a02c1e55.