### PR TITLE
#523: Add auto-detection for all CIs in Sonarqube commercial editions

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,11 +25,19 @@ import com.github.mc1arke.sonarqube.plugin.almclient.github.DefaultGithubClientF
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.RestApplicationAuthenticationProvider;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.DefaultGitlabClientFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.CommunityReportAnalysisComponentProvider;
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchConfigurationLoader;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityBranchParamsValidator;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityProjectBranchesLoader;
 import com.github.mc1arke.sonarqube.plugin.scanner.CommunityProjectPullRequestsLoader;
 import com.github.mc1arke.sonarqube.plugin.scanner.ScannerPullRequestPropertySensor;
+import com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration.AzureDevopsAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration.BitbucketPipelinesAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration.CirrusCiAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration.CodeMagicAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration.GithubActionsAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration.GitlabCiAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration.JenkinsAutoConfigurer;
 import com.github.mc1arke.sonarqube.plugin.server.CommunityBranchFeatureExtension;
 import com.github.mc1arke.sonarqube.plugin.server.CommunityBranchSupportDelegate;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.validator.AzureDevopsValidator;
@@ -143,7 +151,11 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
         if (SonarQubeSide.SCANNER == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(CommunityProjectBranchesLoader.class, CommunityProjectPullRequestsLoader.class,
                                   CommunityBranchConfigurationLoader.class, CommunityBranchParamsValidator.class,
-                                  ScannerPullRequestPropertySensor.class);
+                                  ScannerPullRequestPropertySensor.class, BranchConfigurationFactory.class,
+                                  AzureDevopsAutoConfigurer.class, BitbucketPipelinesAutoConfigurer.class,
+                                  CirrusCiAutoConfigurer.class, CodeMagicAutoConfigurer.class,
+                                  GithubActionsAutoConfigurer.class, GitlabCiAutoConfigurer.class,
+                                  JenkinsAutoConfigurer.class);
         }
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchAutoConfigurer.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchAutoConfigurer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner;
+
+import org.sonar.api.scanner.ScannerSide;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import java.util.Optional;
+
+@ScannerSide
+public interface BranchAutoConfigurer {
+
+    Optional<BranchConfiguration> detectConfiguration(System2 system, ProjectBranches projectBranches);
+
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchConfigurationFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchConfigurationFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner;
+
+import org.sonar.api.scanner.ScannerSide;
+import org.sonar.api.utils.MessageException;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.BranchInfo;
+import org.sonar.scanner.scan.branch.BranchType;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import java.util.Optional;
+
+@ScannerSide
+public class BranchConfigurationFactory {
+
+    public BranchConfiguration createBranchConfiguration(String branchName, ProjectBranches branches) {
+        if (branches.isEmpty()) {
+            return new CommunityBranchConfiguration(branchName, BranchType.BRANCH, null, null, null);
+        }
+
+        String targetBranchName = branches.get(branchName) == null ? branches.defaultBranchName() : branchName;
+        return new CommunityBranchConfiguration(branchName, BranchType.BRANCH, targetBranchName, null, null);
+    }
+
+    public BranchConfiguration createPullRequestConfiguration(String pullRequestKey, String pullRequestBranch, String pullRequestBase, ProjectBranches branches) {
+        if (branches.isEmpty()) {
+            return new CommunityBranchConfiguration(pullRequestBranch, BranchType.PULL_REQUEST, null, pullRequestBase, pullRequestKey);
+        }
+
+        String referenceBranch = branches.get(pullRequestBase) == null ? branches.defaultBranchName() : findReferenceBranch(pullRequestBase, branches);
+        return new CommunityBranchConfiguration(pullRequestBranch, BranchType.PULL_REQUEST, referenceBranch, pullRequestBase, pullRequestKey);
+
+    }
+
+    private static String findReferenceBranch(String targetBranch, ProjectBranches branches) {
+        BranchInfo target = Optional.ofNullable(branches.get(targetBranch))
+                .orElseThrow(() -> MessageException.of("No branch exists in Sonarqube with the name " + targetBranch));
+
+        if (target.type() == BranchType.BRANCH) {
+            return targetBranch;
+        }
+
+        String targetBranchTarget = target.branchTargetName();
+        if (targetBranchTarget == null) {
+            throw MessageException.of(String.format("The branch '%s' of type %s does not have a target", target.name(), target.type()));
+        }
+
+        return findReferenceBranch(targetBranchTarget, branches);
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/AzureDevopsAutoConfigurer.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/AzureDevopsAutoConfigurer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import java.util.Optional;
+
+public class AzureDevopsAutoConfigurer implements BranchAutoConfigurer {
+
+    private final BranchConfigurationFactory branchConfigurationFactory;
+
+    public AzureDevopsAutoConfigurer(BranchConfigurationFactory branchConfigurationFactory) {
+        this.branchConfigurationFactory = branchConfigurationFactory;
+    }
+
+    @Override
+    public Optional<BranchConfiguration> detectConfiguration(System2 system2, ProjectBranches projectBranches) {
+        if (!Boolean.parseBoolean(system2.envVariable("TF_BUILD"))) {
+            return Optional.empty();
+        }
+
+        String key = system2.envVariable("SYSTEM_PULLREQUEST_PULLREQUESTID");
+        if (key != null) {
+            String sourceBranch = system2.envVariable("SYSTEM_PULLREQUEST_SOURCEBRANCH");
+            String targetBranch = system2.envVariable("SYSTEM_PULLREQUEST_TARGETBRANCH");
+
+            return Optional.of(branchConfigurationFactory.createPullRequestConfiguration(key, sourceBranch, targetBranch, projectBranches));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/BitbucketPipelinesAutoConfigurer.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/BitbucketPipelinesAutoConfigurer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import java.util.Optional;
+
+public class BitbucketPipelinesAutoConfigurer implements BranchAutoConfigurer {
+
+    private final BranchConfigurationFactory branchConfigurationFactory;
+
+    public BitbucketPipelinesAutoConfigurer(BranchConfigurationFactory branchConfigurationFactory) {
+        this.branchConfigurationFactory = branchConfigurationFactory;
+    }
+
+    @Override
+    public Optional<BranchConfiguration> detectConfiguration(System2 system2, ProjectBranches projectBranches) {
+        if (!Boolean.parseBoolean(system2.envVariable("CI"))) {
+            return Optional.empty();
+        }
+
+        String branch = system2.envVariable("BITBUCKET_BRANCH");
+        if (StringUtils.isEmpty(branch)) {
+            return Optional.empty();
+        }
+
+        String prId = system2.envVariable("BITBUCKET_PR_ID");
+        String targetBranch = system2.envVariable("BITBUCKET_PR_DESTINATION_BRANCH");
+        if (StringUtils.isEmpty(prId)) {
+            return Optional.of(branchConfigurationFactory.createBranchConfiguration(branch, projectBranches));
+        } else {
+            return Optional.of(branchConfigurationFactory.createPullRequestConfiguration(prId, branch, targetBranch, projectBranches));
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/CirrusCiAutoConfigurer.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/CirrusCiAutoConfigurer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import java.util.Optional;
+
+public class CirrusCiAutoConfigurer implements BranchAutoConfigurer {
+
+    private final BranchConfigurationFactory branchConfigurationFactory;
+
+    public CirrusCiAutoConfigurer(BranchConfigurationFactory branchConfigurationFactory) {
+        this.branchConfigurationFactory = branchConfigurationFactory;
+    }
+
+    @Override
+    public Optional<BranchConfiguration> detectConfiguration(System2 system2, ProjectBranches projectBranches) {
+        if (!Boolean.parseBoolean(system2.envVariable("CIRRUS_CI"))) {
+            return Optional.empty();
+        }
+
+        String branch = system2.envVariable("CIRRUS_BRANCH");
+        if (StringUtils.isEmpty(branch)) {
+            return Optional.empty();
+        }
+
+        String pullRequestId = system2.envVariable("CIRRUS_PR");
+        if (StringUtils.isEmpty(pullRequestId)) {
+            return Optional.of(branchConfigurationFactory.createBranchConfiguration(branch, projectBranches));
+        } else {
+            String targetBranch = system2.envVariable("CIRRUS_BASE_BRANCH");
+            return Optional.of(branchConfigurationFactory.createPullRequestConfiguration(pullRequestId, branch, targetBranch, projectBranches));
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/CodeMagicAutoConfigurer.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/CodeMagicAutoConfigurer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import java.util.Optional;
+
+public class CodeMagicAutoConfigurer implements BranchAutoConfigurer {
+
+    private final BranchConfigurationFactory branchConfigurationFactory;
+
+    public CodeMagicAutoConfigurer(BranchConfigurationFactory branchConfigurationFactory) {
+        this.branchConfigurationFactory = branchConfigurationFactory;
+    }
+
+    @Override
+    public Optional<BranchConfiguration> detectConfiguration(System2 system2, ProjectBranches projectBranches) {
+        if (!Boolean.parseBoolean(system2.envVariable("CI"))) {
+            return Optional.empty();
+        }
+
+        String sourceBranch = system2.envVariable("FCI_BRANCH");
+        if (StringUtils.isEmpty(sourceBranch)) {
+            return Optional.empty();
+        }
+
+        if (Boolean.parseBoolean(system2.envVariable("FCI_PULL_REQUEST"))) {
+            String pullRequestId = system2.envVariable("FCI_PULL_REQUEST_NUMBER");
+            String targetBranch = system2.envVariable("FCI_PULL_REQUEST_DEST");
+            return Optional.of(branchConfigurationFactory.createPullRequestConfiguration(pullRequestId, sourceBranch, targetBranch, projectBranches));
+        } else {
+            return Optional.of(branchConfigurationFactory.createBranchConfiguration(sourceBranch, projectBranches));
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/GithubActionsAutoConfigurer.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/GithubActionsAutoConfigurer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import java.util.Optional;
+
+public class GithubActionsAutoConfigurer implements BranchAutoConfigurer {
+
+    private static final String PULL_REQUEST_REF_PREFIX = "refs/pull/";
+    private static final String PULL_REQUEST_REF_POSTFIX = "/merge";
+
+    private final BranchConfigurationFactory branchConfigurationFactory;
+
+    public GithubActionsAutoConfigurer(BranchConfigurationFactory branchConfigurationFactory) {
+        this.branchConfigurationFactory = branchConfigurationFactory;
+    }
+
+    @Override
+    public Optional<BranchConfiguration> detectConfiguration(System2 system, ProjectBranches projectBranches) {
+        if (!Boolean.parseBoolean(system.envVariable("GITHUB_ACTIONS"))) {
+            return Optional.empty();
+        }
+
+        String ref = system.envVariable("GITHUB_REF");
+        if (StringUtils.isEmpty(ref)) {
+            return Optional.empty();
+        }
+
+        String sourceBranch = system.envVariable("GITHUB_HEAD_REF");
+        if (ref.startsWith(PULL_REQUEST_REF_PREFIX) && ref.endsWith(PULL_REQUEST_REF_POSTFIX) && StringUtils.isNotEmpty(sourceBranch)) {
+            String key = ref.substring(PULL_REQUEST_REF_PREFIX.length(), ref.length() - PULL_REQUEST_REF_POSTFIX.length());
+            String targetBranch = system.envVariable("GITHUB_BASE_REF");
+            return Optional.of(branchConfigurationFactory.createPullRequestConfiguration(key, sourceBranch, targetBranch, projectBranches));
+        } else {
+            String branch = system.envVariable("GITHUB_REF_NAME");
+            return Optional.of(branchConfigurationFactory.createBranchConfiguration(branch, projectBranches));
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/GitlabCiAutoConfigurer.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/GitlabCiAutoConfigurer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import java.util.Optional;
+
+public class GitlabCiAutoConfigurer implements BranchAutoConfigurer {
+
+    private final BranchConfigurationFactory branchConfigurationFactory;
+
+    public GitlabCiAutoConfigurer(BranchConfigurationFactory branchConfigurationFactory) {
+        this.branchConfigurationFactory = branchConfigurationFactory;
+    }
+
+    @Override
+    public Optional<BranchConfiguration> detectConfiguration(System2 system2, ProjectBranches projectBranches) {
+        if (!Boolean.parseBoolean(system2.envVariable("GITLAB_CI"))) {
+            return Optional.empty();
+        }
+
+        String mergeRequestId = system2.envVariable("CI_MERGE_REQUEST_IID");
+        if (StringUtils.isEmpty(mergeRequestId)) {
+            return Optional.of(branchConfigurationFactory.createBranchConfiguration(system2.envVariable("CI_COMMIT_REF_NAME"), projectBranches));
+        } else {
+            return Optional.of(branchConfigurationFactory.createPullRequestConfiguration(mergeRequestId, system2.envVariable("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"), system2.envVariable("CI_MERGE_REQUEST_TARGET_BRANCH_NAME"), projectBranches));
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/JenkinsAutoConfigurer.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/JenkinsAutoConfigurer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchAutoConfigurer;
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import java.util.Optional;
+
+public class JenkinsAutoConfigurer implements BranchAutoConfigurer {
+
+    private final BranchConfigurationFactory branchConfigurationFactory;
+
+    public JenkinsAutoConfigurer(BranchConfigurationFactory branchConfigurationFactory) {
+        this.branchConfigurationFactory = branchConfigurationFactory;
+    }
+
+    @Override
+    public Optional<BranchConfiguration> detectConfiguration(System2 system2, ProjectBranches projectBranches) {
+        if (StringUtils.isEmpty(system2.envVariable("JENKINS_HOME"))) {
+            return Optional.empty();
+        }
+
+        String pullRequestId = system2.envVariable("CHANGE_ID");
+        if (StringUtils.isEmpty(pullRequestId)) {
+            return Optional.of(branchConfigurationFactory.createBranchConfiguration(system2.envVariable("BRANCH_NAME"), projectBranches));
+        } else {
+            String changeBranch = system2.envVariable("CHANGE_BRANCH");
+            String changeTarget = system2.envVariable("CHANGE_TARGET");
+            return Optional.of(branchConfigurationFactory.createPullRequestConfiguration(pullRequestId, changeBranch, changeTarget, projectBranches));
+        }
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchConfigurationFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchConfigurationFactoryTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.BranchInfo;
+import org.sonar.scanner.scan.branch.BranchType;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BranchConfigurationFactoryTest {
+
+    @Test
+    void shouldReturnBranchWithNoTargetIfNoProjectBranchesExist() {
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+        when(projectBranches.isEmpty()).thenReturn(true);
+
+        BranchConfigurationFactory underTest = new BranchConfigurationFactory();
+        BranchConfiguration actual = underTest.createBranchConfiguration("branch", projectBranches);
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(new CommunityBranchConfiguration("branch", BranchType.BRANCH, null, null, null));
+    }
+
+    @Test
+    void shouldReturnBranchWithDefaultReferenceIfSpecifiedBranchDoesNotExist() {
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+        when(projectBranches.isEmpty()).thenReturn(false);
+        when(projectBranches.defaultBranchName()).thenReturn("default");
+        when(projectBranches.get(any())).thenReturn(null);
+
+        BranchConfigurationFactory underTest = new BranchConfigurationFactory();
+        BranchConfiguration actual = underTest.createBranchConfiguration("branch", projectBranches);
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(new CommunityBranchConfiguration("branch", BranchType.BRANCH, "default", null, null));
+    }
+
+    @Test
+    void shouldReturnBranchWithSelfReferenceIfSpecifiedBranchDoesExist() {
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+        when(projectBranches.isEmpty()).thenReturn(false);
+        when(projectBranches.defaultBranchName()).thenReturn("default");
+        when(projectBranches.get(any())).thenReturn(mock(BranchInfo.class));
+
+        BranchConfigurationFactory underTest = new BranchConfigurationFactory();
+        BranchConfiguration actual = underTest.createBranchConfiguration("branch", projectBranches);
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(new CommunityBranchConfiguration("branch", BranchType.BRANCH, "branch", null, null));
+    }
+
+    @Test
+    void shouldReturnPullRequestWithNoTargetIfNoProjectBranchesExist() {
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+        when(projectBranches.isEmpty()).thenReturn(true);
+
+        BranchConfigurationFactory underTest = new BranchConfigurationFactory();
+        BranchConfiguration actual = underTest.createPullRequestConfiguration("key", "source", "target", projectBranches);
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(new CommunityBranchConfiguration("source", BranchType.PULL_REQUEST, null, "target", "key"));
+    }
+
+    @Test
+    void shouldReturnPullRequestWithTargetOfTargetAsReferenceIfTargetBranchExists() {
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+        when(projectBranches.isEmpty()).thenReturn(false);
+        BranchInfo branchInfo = new BranchInfo("target", BranchType.PULL_REQUEST, false, "target2");
+        when(projectBranches.get("target")).thenReturn(branchInfo);
+        BranchInfo branchInfo2 = new BranchInfo("target2", BranchType.BRANCH, false, "target3");
+        when(projectBranches.get("target2")).thenReturn(branchInfo2);
+
+        BranchConfigurationFactory underTest = new BranchConfigurationFactory();
+        BranchConfiguration actual = underTest.createPullRequestConfiguration("key", "source", "target", projectBranches);
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(new CommunityBranchConfiguration("source", BranchType.PULL_REQUEST, "target2", "target", "key"));
+    }
+
+    @Test
+    void shouldThrowExceptionIfPullRequestTargetsOtherPullRequestWithoutATarget() {
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+        when(projectBranches.isEmpty()).thenReturn(false);
+        BranchInfo branchInfo = new BranchInfo("target", BranchType.PULL_REQUEST, false, null);
+        when(projectBranches.get("target")).thenReturn(branchInfo);
+
+        BranchConfigurationFactory underTest = new BranchConfigurationFactory();
+        assertThatThrownBy(() -> underTest.createPullRequestConfiguration("key", "source", "target", projectBranches)).hasMessage("The branch 'target' of type PULL_REQUEST does not have a target");
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/AzureDevopsAutoConfigurerTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/AzureDevopsAutoConfigurerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AzureDevopsAutoConfigurerTest {
+
+    @Test
+    void shouldReturnOptionalEmptyIfNotTfBuild() {
+        System2 system2 = mock(System2.class);
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        AzureDevopsAutoConfigurer underTest = new AzureDevopsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyIfTfBuildWithNoPullRequestId() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("TF_BUILD")).thenReturn("true");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        AzureDevopsAutoConfigurer underTest = new AzureDevopsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnConfigurationBasedOnAllEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("TF_BUILD")).thenReturn("true");
+        when(system2.envVariable("SYSTEM_PULLREQUEST_PULLREQUESTID")).thenReturn("id");
+        when(system2.envVariable("SYSTEM_PULLREQUEST_SOURCEBRANCH")).thenReturn("source");
+        when(system2.envVariable("SYSTEM_PULLREQUEST_TARGETBRANCH")).thenReturn("target");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createPullRequestConfiguration(any(), any(), any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        AzureDevopsAutoConfigurer underTest = new AzureDevopsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createPullRequestConfiguration("id", "source", "target", projectBranches);
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/BitbucketPipelinesAutoConfigurerTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/BitbucketPipelinesAutoConfigurerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BitbucketPipelinesAutoConfigurerTest {
+
+    @Test
+    void shouldReturnOptionalEmptyIfNotCi() {
+        System2 system2 = mock(System2.class);
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        BitbucketPipelinesAutoConfigurer underTest = new BitbucketPipelinesAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyIfCiWithNoBranchProperty() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("CI")).thenReturn("true");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        BitbucketPipelinesAutoConfigurer underTest = new BitbucketPipelinesAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnBranchConfigurationBasedOnNoPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("CI")).thenReturn("true");
+        when(system2.envVariable("BITBUCKET_BRANCH")).thenReturn("branch");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createBranchConfiguration(any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        BitbucketPipelinesAutoConfigurer underTest = new BitbucketPipelinesAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createBranchConfiguration("branch", projectBranches);
+    }
+
+    @Test
+    void shouldReturnPullRequestConfigurationBasedOnPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("CI")).thenReturn("true");
+        when(system2.envVariable("BITBUCKET_BRANCH")).thenReturn("source");
+        when(system2.envVariable("BITBUCKET_PR_ID")).thenReturn("id");
+        when(system2.envVariable("BITBUCKET_PR_DESTINATION_BRANCH")).thenReturn("target");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createPullRequestConfiguration(any(), any(), any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        BitbucketPipelinesAutoConfigurer underTest = new BitbucketPipelinesAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createPullRequestConfiguration("id", "source", "target", projectBranches);
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/CirrusCiAutoConfigurerTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/CirrusCiAutoConfigurerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CirrusCiAutoConfigurerTest {
+
+    @Test
+    void shouldReturnOptionalEmptyIfNotCirrusCi() {
+        System2 system2 = mock(System2.class);
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        CirrusCiAutoConfigurer underTest = new CirrusCiAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyIfCirrusCiWithNoBranchProperty() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("CIRRUS_CI")).thenReturn("true");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        CirrusCiAutoConfigurer underTest = new CirrusCiAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnBranchConfigurationBasedOnNoPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("CIRRUS_CI")).thenReturn("true");
+        when(system2.envVariable("CIRRUS_BRANCH")).thenReturn("branch");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createBranchConfiguration(any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        CirrusCiAutoConfigurer underTest = new CirrusCiAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createBranchConfiguration("branch", projectBranches);
+    }
+
+    @Test
+    void shouldReturnPullRequestConfigurationBasedOnPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("CIRRUS_CI")).thenReturn("true");
+        when(system2.envVariable("CIRRUS_BRANCH")).thenReturn("source");
+        when(system2.envVariable("CIRRUS_PR")).thenReturn("id");
+        when(system2.envVariable("CIRRUS_BASE_BRANCH")).thenReturn("target");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createPullRequestConfiguration(any(), any(), any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        CirrusCiAutoConfigurer underTest = new CirrusCiAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createPullRequestConfiguration("id", "source", "target", projectBranches);
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/CodeMagicAutoConfigurerTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/CodeMagicAutoConfigurerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CodeMagicAutoConfigurerTest {
+
+    @Test
+    void shouldReturnOptionalEmptyIfNotCi() {
+        System2 system2 = mock(System2.class);
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        CodeMagicAutoConfigurer underTest = new CodeMagicAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyIfCiWithNoFciBranchProperty() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("CI")).thenReturn("true");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        CodeMagicAutoConfigurer underTest = new CodeMagicAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnBranchConfigurationBasedOnNoPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("CI")).thenReturn("true");
+        when(system2.envVariable("FCI_BRANCH")).thenReturn("branch");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createBranchConfiguration(any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        CodeMagicAutoConfigurer underTest = new CodeMagicAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createBranchConfiguration("branch", projectBranches);
+    }
+
+    @Test
+    void shouldReturnPullRequestConfigurationBasedOnPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("CI")).thenReturn("true");
+        when(system2.envVariable("FCI_BRANCH")).thenReturn("source");
+        when(system2.envVariable("FCI_PULL_REQUEST")).thenReturn("true");
+        when(system2.envVariable("FCI_PULL_REQUEST_NUMBER")).thenReturn("id");
+        when(system2.envVariable("FCI_PULL_REQUEST_DEST")).thenReturn("target");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createPullRequestConfiguration(any(), any(), any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        CodeMagicAutoConfigurer underTest = new CodeMagicAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createPullRequestConfiguration("id", "source", "target", projectBranches);
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/GithubActionsAutoConfigurerTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/GithubActionsAutoConfigurerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GithubActionsAutoConfigurerTest {
+
+    @Test
+    void shouldReturnOptionalEmptyIfNotGithubActions() {
+        System2 system2 = mock(System2.class);
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        GithubActionsAutoConfigurer underTest = new GithubActionsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalEmptyIfGithubActionsWithNoGithubRefProperty() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("GITHUB_ACTIONS")).thenReturn("true");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        GithubActionsAutoConfigurer underTest = new GithubActionsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnBranchConfigurationBasedOnNoPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("GITHUB_ACTIONS")).thenReturn("true");
+        when(system2.envVariable("GITHUB_REF")).thenReturn("refs/heads/branch");
+        when(system2.envVariable("GITHUB_REF_NAME")).thenReturn("branch");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createBranchConfiguration(any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        GithubActionsAutoConfigurer underTest = new GithubActionsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createBranchConfiguration("branch", projectBranches);
+    }
+
+    @Test
+    void shouldReturnPullRequestConfigurationBasedOnPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("GITHUB_ACTIONS")).thenReturn("true");
+        when(system2.envVariable("GITHUB_HEAD_REF")).thenReturn("source");
+        when(system2.envVariable("GITHUB_REF")).thenReturn("refs/pull/id/merge");
+        when(system2.envVariable("GITHUB_BASE_REF")).thenReturn("target");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createPullRequestConfiguration(any(), any(), any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        GithubActionsAutoConfigurer underTest = new GithubActionsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createPullRequestConfiguration("id", "source", "target", projectBranches);
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/GitlabCiAutoConfigurerTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/GitlabCiAutoConfigurerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GitlabCiAutoConfigurerTest {
+
+    @Test
+    void shouldReturnOptionalEmptyIfNotGitlabCi() {
+        System2 system2 = mock(System2.class);
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        GitlabCiAutoConfigurer underTest = new GitlabCiAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnBranchConfigurationBasedOnNoPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("GITLAB_CI")).thenReturn("true");
+        when(system2.envVariable("CI_COMMIT_REF_NAME")).thenReturn("branch");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createBranchConfiguration(any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        GitlabCiAutoConfigurer underTest = new GitlabCiAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createBranchConfiguration("branch", projectBranches);
+    }
+
+    @Test
+    void shouldReturnPullRequestConfigurationBasedOnPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("GITLAB_CI")).thenReturn("true");
+        when(system2.envVariable("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME")).thenReturn("source");
+        when(system2.envVariable("CI_MERGE_REQUEST_IID")).thenReturn("id");
+        when(system2.envVariable("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")).thenReturn("target");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createPullRequestConfiguration(any(), any(), any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        GitlabCiAutoConfigurer underTest = new GitlabCiAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createPullRequestConfiguration("id", "source", "target", projectBranches);
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/JenkinsAutoConfigurerTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/autoconfiguration/JenkinsAutoConfigurerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.scanner.autoconfiguration;
+
+import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.scan.branch.BranchConfiguration;
+import org.sonar.scanner.scan.branch.ProjectBranches;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JenkinsAutoConfigurerTest {
+
+    @Test
+    void shouldReturnOptionalEmptyIfNotJenkins() {
+        System2 system2 = mock(System2.class);
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        JenkinsAutoConfigurer underTest = new JenkinsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnBranchConfigurationBasedOnNoPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("JENKINS_HOME")).thenReturn("/path/to/home");
+        when(system2.envVariable("BRANCH_NAME")).thenReturn("branch");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createBranchConfiguration(any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        JenkinsAutoConfigurer underTest = new JenkinsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createBranchConfiguration("branch", projectBranches);
+    }
+
+    @Test
+    void shouldReturnPullRequestConfigurationBasedOnPrIdInEnvironmentParameters() {
+        System2 system2 = mock(System2.class);
+        when(system2.envVariable("JENKINS_HOME")).thenReturn("/path/to/home");
+        when(system2.envVariable("CHANGE_BRANCH")).thenReturn("source");
+        when(system2.envVariable("CHANGE_ID")).thenReturn("id");
+        when(system2.envVariable("CHANGE_TARGET")).thenReturn("target");
+        BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
+        BranchConfiguration branchConfiguration = mock(BranchConfiguration.class);
+        when(branchConfigurationFactory.createPullRequestConfiguration(any(), any(), any(), any())).thenReturn(branchConfiguration);
+        ProjectBranches projectBranches = mock(ProjectBranches.class);
+
+        JenkinsAutoConfigurer underTest = new JenkinsAutoConfigurer(branchConfigurationFactory);
+        assertThat(underTest.detectConfiguration(system2, projectBranches)).contains(branchConfiguration);
+        verify(branchConfigurationFactory).createPullRequestConfiguration("id", "source", "target", projectBranches);
+    }
+}


### PR DESCRIPTION
The plugin previously only provided support for auto-detecting and configuring the scanner properties for a Pull Request in Azure Devops and a Merge Request or Branch in Gitlab CI. The Sonarqube documentation also stated that Bitbucket Pipelines, Github Actions, CodeMagic, Jenkins Branch API, and Cirrus CI could also be used to auto-discover Pull Request or Branch information although the plugin did not provide these.

This change adds support for detecting these additional CIs based on the various environment variables they provide, and to auto-configure Pull Request or Branch parameters in the scanner when a suitable build job is detected.

Includes the general clean-up of the creation of Branch and Pull Request configuration to force fail-fast behaviour where target branches are not provided or can't be matched against known branches, to ensure the correct reference branch is selected for Pull Request analysis, and to force an error to be displayed if a user mixes Pull Rrequest and Branch parameters in their launch properties.