### PR TITLE
Fix #77 approve bitbucket PRs when configured.

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -58,6 +58,7 @@ import org.sonar.core.extension.CoreExtension;
 public class CommunityBranchPlugin implements Plugin, CoreExtension {
 
     public static final String IMAGE_URL_BASE = "com.github.mc1arke.sonarqube.plugin.branch.image-url-base";
+    public static final String PULL_REQUEST_APPROVE_ENABLED = "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.approve.enabled";
 
     @Override
     public String getName() {
@@ -134,7 +135,14 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                                           .description("Base URL used to load the images for the PR comments (please use this only if images are not displayed properly).")
                                           .type(PropertyType.STRING)
                                           .build());
-
+            context.addExtensions(PropertyDefinition.builder(PULL_REQUEST_APPROVE_ENABLED)
+                                          .category(CoreProperties.CATEGORY_ALM_INTEGRATION)
+                                          .subCategory("bitbucket")
+                                          .type(PropertyType.BOOLEAN)
+                                          .defaultValue(String.valueOf(false))
+                                          .name("Enable approving pull requests")
+                                          .description("This approve pull request when quality gate is passed (if implemented).")
+                                          .build());
         }
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
@@ -132,4 +132,12 @@ public interface BitbucketClient {
      */
     Repository retrieveRepository(String project, String repo) throws IOException;
 
+    /**
+     * Marks the specified pull request as approved by logged user.
+     * @param approve or not the pull request
+     * @param project the project as resolved from {@link #resolveProject(AlmSettingDto, ProjectAlmSettingDto)}
+     * @param repo the repository as resolved from {@link #resolveRepository(AlmSettingDto, ProjectAlmSettingDto)}
+     * @param prId the branch name
+     */
+    void setApproval(boolean approve, String project, String repository, String prId) throws IOException;
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
@@ -169,6 +169,45 @@ class BitbucketCloudClient implements BitbucketClient {
         }
     }
 
+    public void setApproval(boolean approve, String project, String repository, String prId) throws IOException {
+        if (prId == null) {
+            return;
+        }
+
+        String reqURL = format("https://api.bitbucket.org/2.0/repositories/%s/%s/pullrequests/%s/approve", project, repository, prId);
+        // relying on approve response error code we can understand if already
+        // approved without extra calls on activity resource
+        if (!approve) {
+            Request req = new Request.Builder()
+                    .delete()
+                    .url(reqURL)
+                    .build();
+            try (Response response = okHttpClient.newCall(req).execute()) {
+                if (response.code() == 404) {
+                    // it is already not approved
+                    LOGGER.info("Pull request {} already disapproved", prId);
+                } else {
+                    validate(response);
+                    LOGGER.debug("Pull request {} disapproved", prId);
+                }
+            }
+        } else {
+            Request req = new Request.Builder()
+                    .post(RequestBody.create(new byte[0]))
+                    .url(reqURL)
+                    .build();
+            try (Response response = okHttpClient.newCall(req).execute()) {
+                if (response.code() == 409) {
+                    // it is already approved nothing to do
+                    LOGGER.info("Pull request {} already approved", prId);
+                } else {
+                    validate(response);
+                    LOGGER.debug("Pull request {} approved", prId);
+                }
+            }
+        }
+    }
+
     @Override
     public boolean supportsCodeInsights() {
         return true;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -363,6 +363,10 @@ public class AnalysisDetails {
                                                                                  .filter(i -> k == i.type()).count()));
     }
 
+    public boolean getApproval() {
+        return configuration.getBoolean(CommunityBranchPlugin.PULL_REQUEST_APPROVE_ENABLED).orElse(false);
+    }
+
     private static String pluralOf(long value, String singleLabel, String multiLabel) {
         return value + " " + (1 == value ? singleLabel : multiLabel);
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
@@ -98,6 +98,11 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                     analysisDetails.getCommitSha(), codeInsightsReport);
 
             updateAnnotations(client, project, repo, analysisDetails);
+
+            if (analysisDetails.getApproval()) {
+                String prId = analysisDetails.getBranchName();
+                client.setApproval(QualityGate.Status.ERROR != analysisDetails.getQualityGateStatus(), project, repo, prId);
+            }
         } catch (IOException e) {
             LOGGER.error("Could not decorate pull request for project {}", analysisDetails.getAnalysisProjectKey(), e);
         }


### PR DESCRIPTION
This feature requires a write access configured in OAuth consumers.
Add a new configuration parameter under ALMSettings/Bitbucket to enable or not this behavior (default false). When enabled and sonar analysis a pull request branch the logged user will approve/disapprove current PR based on quality gate result.

Before spend time to implement test case please let me know if you are yet interested on this (#77) feature

![immagine](https://user-images.githubusercontent.com/4160180/151950662-9b23dda4-057d-4ec5-b73e-a55e376a5f93.png)
In picture seems I can not change how "bitbucket" sub category appears, adding a description for example. It looks like something that depends on sonarqube server.