### PR TITLE
#298: Prevent NullPointerException when branch with cancelled analysi…

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectPullRequestsLoader.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectPullRequestsLoader.java
@@ -70,8 +70,13 @@ public class CommunityProjectPullRequestsLoader implements ProjectPullRequestsLo
             JsonObject jsonObject = jsonElement.getAsJsonObject();
             long parsedDate = 0;
             try {
-                parsedDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
-                        .parse(jsonObject.get("analysisDate").getAsString()).getTime();
+                String analysisDate = Optional.ofNullable(jsonObject.get("analysisDate")).map(JsonElement::getAsString).orElse(null);
+                if(analysisDate == null) {
+                    LOGGER.warn("Analysis Date not provided in Pull Requests API response. Will use '0' date");
+                } else {
+                    parsedDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+                            .parse(analysisDate).getTime();
+                }
             } catch (ParseException e) {
                 LOGGER.warn("Could not parse date from Pull Requests API response. Will use '0' date", e);
             }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectPullRequestsLoaderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityProjectPullRequestsLoaderTest.java
@@ -139,6 +139,28 @@ public class CommunityProjectPullRequestsLoaderTest {
     }
 
     @Test
+    public void testAllPullRequestsFromNonEmptyServerResponseWithoutAnalysisDateAndQualityGateStatusForCancelledPr() throws ParseException {
+        WsResponse mockResponse = mock(WsResponse.class);
+        when(scannerWsClient.call(any())).thenReturn(mockResponse);
+
+        StringReader stringReader = new StringReader(
+                "{\"pullRequests\":[{\"key\":\"101\",\"title\":\"dummybranch\",\"branch\":\"dummybranch\",\"base\":\"master\",\"status\":{\"bugs\":0,\"vulnerabilities\":0,\"codeSmells\":0}}]}");
+        when(mockResponse.contentReader()).thenReturn(stringReader);
+
+        CommunityProjectPullRequestsLoader testCase = new CommunityProjectPullRequestsLoader(scannerWsClient);
+        ProjectPullRequests response = testCase.load("key");
+        assertFalse(response.isEmpty());
+
+        PullRequestInfo responseInfo = response.get("dummybranch");
+        assertNotNull(responseInfo);
+        assertEquals(0,
+                responseInfo.getAnalysisDate());
+        assertEquals("master", responseInfo.getBase());
+        assertEquals("dummybranch", responseInfo.getBranch());
+        assertEquals("101", responseInfo.getKey());
+    }
+
+    @Test
     public void testMessageExceptionOnIOException() {
         WsResponse mockResponse = mock(WsResponse.class);
         when(scannerWsClient.call(any())).thenReturn(mockResponse);


### PR DESCRIPTION
Apply the fix `#298: Prevent NullPointerException when branch with cancelled analysis is rescanned` to release/1_3