### PR TITLE
Allow multiple reports in one Bitbucket PR

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
@@ -69,7 +69,7 @@ public interface BitbucketClient {
      *
      * @throws IOException if the annotations cannot be uploaded
      */
-    void uploadAnnotations(String project, String repo, String commitSha, Set<CodeInsightsAnnotation> annotations, String projectName) throws IOException;
+    void uploadAnnotations(String project, String repo, String commitSha, Set<CodeInsightsAnnotation> annotations, String reportKey) throws IOException;
 
     /**
      * Creates a DataValue of type DataValue.Link or DataValue.CloudLink depending on the implementation

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
@@ -62,14 +62,14 @@ public interface BitbucketClient {
      *
      * @throws IOException if the annotations cannot be deleted
      */
-    void deleteAnnotations(String project, String repo, String commitSha) throws IOException;
+    void deleteAnnotations(String project, String repo, String commitSha, String reportKey) throws IOException;
 
     /**
      * Uploads CodeInsights Annotations for the given commit.
      *
      * @throws IOException if the annotations cannot be uploaded
      */
-    void uploadAnnotations(String project, String repo, String commitSha, Set<CodeInsightsAnnotation> annotations) throws IOException;
+    void uploadAnnotations(String project, String repo, String commitSha, Set<CodeInsightsAnnotation> annotations, String projectName) throws IOException;
 
     /**
      * Creates a DataValue of type DataValue.Link or DataValue.CloudLink depending on the implementation
@@ -79,7 +79,7 @@ public interface BitbucketClient {
     /**
      * Uploads the code insights report for the given commit
      */
-    void uploadReport(String project, String repo, String commitSha, CodeInsightsReport codeInsightReport) throws IOException;
+    void uploadReport(String project, String repo, String commitSha, CodeInsightsReport codeInsightReport, String reportKey) throws IOException;
 
     /**
      * <p>

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
@@ -56,7 +56,6 @@ import static java.lang.String.format;
 class BitbucketCloudClient implements BitbucketClient {
 
     private static final Logger LOGGER = Loggers.get(BitbucketCloudClient.class);
-    private static final String REPORT_KEY = "com.github.mc1arke.sonarqube";
     private static final MediaType APPLICATION_JSON_MEDIA_TYPE = MediaType.get("application/json");
     private static final String TITLE = "SonarQube";
     private static final String REPORTER = "SonarQube";
@@ -121,11 +120,11 @@ class BitbucketCloudClient implements BitbucketClient {
     }
 
     @Override
-    public void deleteAnnotations(String project, String repo, String commitSha) {
+    public void deleteAnnotations(String project, String repo, String commitSha, String reportKey) {
         // not needed here.
     }
 
-    public void uploadAnnotations(String project, String repository, String commit, Set<CodeInsightsAnnotation> baseAnnotations) throws IOException {
+    public void uploadAnnotations(String project, String repository, String commit, Set<CodeInsightsAnnotation> baseAnnotations, String reportKey) throws IOException {
         Set<CloudAnnotation> annotations = baseAnnotations.stream().map(CloudAnnotation.class::cast).collect(Collectors.toSet());
 
         if (annotations.isEmpty()) {
@@ -134,7 +133,7 @@ class BitbucketCloudClient implements BitbucketClient {
 
         Request req = new Request.Builder()
                 .post(RequestBody.create(objectMapper.writeValueAsString(annotations), APPLICATION_JSON_MEDIA_TYPE))
-                .url(format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s/annotations", project, repository, commit, REPORT_KEY))
+                .url(format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s/annotations", project, repository, commit, reportKey))
                 .build();
 
         LOGGER.info("Creating annotations on bitbucket cloud");
@@ -151,10 +150,10 @@ class BitbucketCloudClient implements BitbucketClient {
     }
 
     @Override
-    public void uploadReport(String project, String repository, String commit, CodeInsightsReport codeInsightReport) throws IOException {
-        deleteExistingReport(project, repository, commit);
+    public void uploadReport(String project, String repository, String commit, CodeInsightsReport codeInsightReport, String reportKey) throws IOException {
+        deleteExistingReport(project, repository, commit, reportKey);
 
-        String targetUrl = format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s", project, repository, commit, REPORT_KEY);
+        String targetUrl = format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s", project, repository, commit, reportKey);
         String body = objectMapper.writeValueAsString(codeInsightReport);
         Request req = new Request.Builder()
                 .put(RequestBody.create(body, APPLICATION_JSON_MEDIA_TYPE))
@@ -205,10 +204,10 @@ class BitbucketCloudClient implements BitbucketClient {
         }
     }
 
-    void deleteExistingReport(String project, String repository, String commit) throws IOException {
+    void deleteExistingReport(String project, String repository, String commit, String reportKey) throws IOException {
         Request req = new Request.Builder()
                 .delete()
-                .url(format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s", project, repository, commit, REPORT_KEY))
+                .url(format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s", project, repository, commit, reportKey))
                 .build();
 
         LOGGER.info("Deleting existing reports on bitbucket cloud");

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
@@ -53,7 +53,6 @@ import static java.lang.String.format;
 
 class BitbucketServerClient implements BitbucketClient {
     private static final Logger LOGGER = Loggers.get(BitbucketServerClient.class);
-    private static final String REPORT_KEY = "com.github.mc1arke.sonarqube";
     private static final MediaType APPLICATION_JSON_MEDIA_TYPE = MediaType.get("application/json");
     private static final String TITLE = "SonarQube";
     private static final String REPORTER = "SonarQube";
@@ -98,10 +97,10 @@ class BitbucketServerClient implements BitbucketClient {
         );
     }
 
-    public void deleteAnnotations(String project, String repository, String commit) throws IOException {
+    public void deleteAnnotations(String project, String repository, String commit, String reportKey) throws IOException {
         Request req = new Request.Builder()
                 .delete()
-                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", config.getUrl(), project, repository, commit, REPORT_KEY))
+                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", config.getUrl(), project, repository, commit, reportKey))
                 .build();
         try (Response response = okHttpClient.newCall(req).execute()) {
             validate(response);
@@ -109,7 +108,7 @@ class BitbucketServerClient implements BitbucketClient {
     }
 
     @Override
-    public void uploadAnnotations(String project, String repository, String commit, Set<CodeInsightsAnnotation> annotations) throws IOException {
+    public void uploadAnnotations(String project, String repository, String commit, Set<CodeInsightsAnnotation> annotations, String reportKey) throws IOException {
         if (annotations.isEmpty()) {
             return;
         }
@@ -117,7 +116,7 @@ class BitbucketServerClient implements BitbucketClient {
         CreateAnnotationsRequest request = new CreateAnnotationsRequest(annotationSet);
         Request req = new Request.Builder()
                 .post(RequestBody.create(objectMapper.writeValueAsString(request), APPLICATION_JSON_MEDIA_TYPE))
-                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", config.getUrl(), project, repository, commit, REPORT_KEY))
+                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", config.getUrl(), project, repository, commit, reportKey))
                 .build();
         try (Response response = okHttpClient.newCall(req).execute()) {
             validate(response);
@@ -130,11 +129,11 @@ class BitbucketServerClient implements BitbucketClient {
     }
 
     @Override
-    public void uploadReport(String project, String repository, String commit, CodeInsightsReport codeInsightReport) throws IOException {
+    public void uploadReport(String project, String repository, String commit, CodeInsightsReport codeInsightReport, String reportKey) throws IOException {
         String body = objectMapper.writeValueAsString(codeInsightReport);
         Request req = new Request.Builder()
                 .put(RequestBody.create(body, APPLICATION_JSON_MEDIA_TYPE))
-                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s", config.getUrl(), project, repository, commit, REPORT_KEY))
+                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s", config.getUrl(), project, repository, commit, reportKey))
                 .build();
 
         try (Response response = okHttpClient.newCall(req).execute()) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
@@ -95,7 +95,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
             );
 
             client.uploadReport(project, repo,
-                    analysisDetails.getCommitSha(), codeInsightsReport);
+                    analysisDetails.getCommitSha(), codeInsightsReport, analysisDetails.getAnalysisProjectKey());
 
             updateAnnotations(client, project, repo, analysisDetails);
         } catch (IOException e) {
@@ -127,7 +127,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
     private void updateAnnotations(BitbucketClient client, String project, String repo, AnalysisDetails analysisDetails) throws IOException {
         final AtomicInteger chunkCounter = new AtomicInteger(0);
 
-        client.deleteAnnotations(project, repo, analysisDetails.getCommitSha());
+        client.deleteAnnotations(project, repo, analysisDetails.getCommitSha(), analysisDetails.getAnalysisProjectKey());
 
         AnnotationUploadLimit uploadLimit = client.getAnnotationUploadLimit();
 
@@ -136,7 +136,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                 .filter(i -> i.getComponent().getType() == Component.Type.FILE)
                 .filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().status()))
                 .filter(i -> !(i.getIssue().type() == RuleType.SECURITY_HOTSPOT && Issue.SECURITY_HOTSPOT_RESOLUTIONS
-                    .contains(i.getIssue().resolution())))
+                        .contains(i.getIssue().resolution())))
                 .sorted(Comparator.comparing(a -> Severity.ALL.indexOf(a.getIssue().severity())))
                 .map(componentIssue -> {
                     String path = componentIssue.getComponent().getReportAttributes().getScmPath().get();
@@ -158,7 +158,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                     break;
                 }
 
-                client.uploadAnnotations(project, repo, analysisDetails.getCommitSha(), annotations);
+                client.uploadAnnotations(project, repo, analysisDetails.getCommitSha(), annotations, analysisDetails.getAnalysisProjectKey());
             } catch (BitbucketException e) {
                 if (e.isError(BitbucketException.PAYLOAD_TOO_LARGE)) {
                     LOGGER.warn("The annotations will be truncated since the maximum number of annotations for this report has been reached.");

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClientUnitTest.java
@@ -87,13 +87,13 @@ public class BitbucketCloudClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when
-        underTest.uploadReport("project", "repository", "commit", report);
+        underTest.uploadReport("project", "repository", "commit", report, "reportKey");
 
         // then
         verify(client, times(2)).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("PUT", request.method());
-        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/com.github.mc1arke.sonarqube", request.url().toString());
+        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/reportKey", request.url().toString());
     }
 
     @Test
@@ -107,13 +107,13 @@ public class BitbucketCloudClientUnitTest {
         when(call.execute()).thenReturn(response);
 
         // when
-        underTest.deleteExistingReport("project", "repository", "commit");
+        underTest.deleteExistingReport("project", "repository", "commit", "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("DELETE", request.method());
-        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/com.github.mc1arke.sonarqube", request.url().toString());
+        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/reportKey", request.url().toString());
     }
 
     @Test
@@ -132,13 +132,13 @@ public class BitbucketCloudClientUnitTest {
         when(mapper.writeValueAsString(any())).thenReturn("{payload}");
 
         // when
-        underTest.uploadAnnotations("project", "repository", "commit", annotations);
+        underTest.uploadAnnotations("project", "repository", "commit", annotations, "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("POST", request.method());
-        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/reportKey/annotations", request.url().toString());
     }
 
     @Test
@@ -170,7 +170,7 @@ public class BitbucketCloudClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when,then
-        assertThatThrownBy(() -> underTest.uploadReport("project", "repository", "commit", report))
+        assertThatThrownBy(() -> underTest.uploadReport("project", "repository", "commit", report, "reportKey"))
                 .isInstanceOf(BitbucketCloudException.class)
                 .hasMessage("HTTP Status Code: 400; Message:error!")
                 .extracting(e -> ((BitbucketCloudException) e).isError(400))
@@ -183,7 +183,7 @@ public class BitbucketCloudClientUnitTest {
         Set<CodeInsightsAnnotation> annotations = Sets.newHashSet();
 
         // when
-        underTest.uploadAnnotations("project", "repository", "commit", annotations);
+        underTest.uploadAnnotations("project", "repository", "commit", annotations, "reportKey");
 
         // then
         verify(client, never()).newCall(any());

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
@@ -240,13 +240,13 @@ public class BitbucketServerClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when
-        underTest.uploadReport("project", "repository", "commit", report);
+        underTest.uploadReport("project", "repository", "commit", report, "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("PUT", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/reportKey", request.url().toString());
     }
 
     @Test
@@ -264,7 +264,7 @@ public class BitbucketServerClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when,then
-        assertThatThrownBy(() -> underTest.uploadReport("project", "repository", "commit", report))
+        assertThatThrownBy(() -> underTest.uploadReport("project", "repository", "commit", report, "reportKey"))
                 .isInstanceOf(BitbucketException.class);
     }
 
@@ -295,7 +295,7 @@ public class BitbucketServerClientUnitTest {
 
 
         // when,then
-        assertThatThrownBy(() -> underTest.uploadReport("project", "repository", "commit", report))
+        assertThatThrownBy(() -> underTest.uploadReport("project", "repository", "commit", report, "reportKey"))
                 .isInstanceOf(BitbucketException.class)
                 .hasMessage("error!")
                 .extracting(e -> ((BitbucketException) e).isError(400))
@@ -323,13 +323,13 @@ public class BitbucketServerClientUnitTest {
         when(response.isSuccessful()).thenReturn(true);
 
         // when
-        underTest.uploadAnnotations("project", "repository", "commit", annotations);
+        underTest.uploadAnnotations("project", "repository", "commit", annotations, "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("POST", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/reportKey/annotations", request.url().toString());
 
         try (Buffer bodyContent = new Buffer()) {
             request.body().writeTo(bodyContent);
@@ -343,7 +343,7 @@ public class BitbucketServerClientUnitTest {
         Set<CodeInsightsAnnotation> annotations = Sets.newHashSet();
 
         // when
-        underTest.uploadAnnotations("project", "repository", "commit", annotations);
+        underTest.uploadAnnotations("project", "repository", "commit", annotations, "reportKey");
 
         // then
         verify(client, never()).newCall(any());
@@ -361,13 +361,13 @@ public class BitbucketServerClientUnitTest {
         when(response.isSuccessful()).thenReturn(true);
 
         // when
-        underTest.deleteAnnotations("project", "repository", "commit");
+        underTest.deleteAnnotations("project", "repository", "commit", "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("DELETE", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/reportKey/annotations", request.url().toString());
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -122,7 +122,7 @@ public class BitbucketPullRequestDecoratorTest {
     private void mockValidAnalysis() {
         when(analysisDetails.getCommitSha()).thenReturn(COMMIT);
         when(analysisDetails.getQualityGateStatus()).thenReturn(QualityGate.Status.OK);
-        when(analysisDetails.getAnalysisProjectName()).thenReturn(REPORT_KEY);
+        when(analysisDetails.getAnalysisProjectKey()).thenReturn(REPORT_KEY);
 
         Map<RuleType, Long> ruleCount = new HashMap<>();
         ruleCount.put(RuleType.CODE_SMELL, 1L);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -40,6 +40,7 @@ public class BitbucketPullRequestDecoratorTest {
     private static final String PROJECT = "project";
     private static final String REPO = "repo";
     private static final String COMMIT = "commit";
+    private static final String REPORT_KEY = "report-key";
 
     private static final String ISSUE_KEY = "issue-key";
     private static final int ISSUE_LINE = 1;
@@ -76,7 +77,7 @@ public class BitbucketPullRequestDecoratorTest {
         verify(client).createCodeInsightsAnnotation(eq(ISSUE_KEY), eq(ISSUE_LINE), eq(ISSUE_LINK), eq(ISSUE_MESSAGE), eq(ISSUE_PATH), eq("HIGH"), eq("BUG"));
         verify(client).createLinkDataValue(DASHBOARD_URL);
         verify(client).createCodeInsightsReport(any(), eq("Quality Gate passed" + System.lineSeparator()), any(), eq(DASHBOARD_URL), eq(String.format("%s/common/icon.png", IMAGE_URL)), eq(QualityGate.Status.OK));
-        verify(client).deleteAnnotations(PROJECT, REPO, COMMIT);
+        verify(client).deleteAnnotations(PROJECT, REPO, COMMIT, REPORT_KEY);
     }
 
     @Test
@@ -121,6 +122,7 @@ public class BitbucketPullRequestDecoratorTest {
     private void mockValidAnalysis() {
         when(analysisDetails.getCommitSha()).thenReturn(COMMIT);
         when(analysisDetails.getQualityGateStatus()).thenReturn(QualityGate.Status.OK);
+        when(analysisDetails.getAnalysisProjectName()).thenReturn(REPORT_KEY);
 
         Map<RuleType, Long> ruleCount = new HashMap<>();
         ruleCount.put(RuleType.CODE_SMELL, 1L);


### PR DESCRIPTION
Since the previous implementation had a static report key, Bitbucket wasn't able to show multiple reports on its "Integration" window. To solve this issue the project key is used as the report key since report keys have to be unique or otherwise the reports will be overwritten. This was tested on a 8.9 LTS on-prem instance and works perfectly fine.