### PR TITLE
#569: Add support for release 9.4 of Sonarqube

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '9.1.0.47736'
+def sonarqubeVersion = '9.4.0.54424'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Marvin Wichmann, Michael Clarke
+ * Copyright (C) 2020-2022 Marvin Wichmann, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -35,6 +35,7 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -48,6 +49,7 @@ public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
     private final Supplier<OkHttpClient.Builder> okHttpClientBuilderSupplier;
     private final Settings settings;
 
+    @Autowired
     public DefaultBitbucketClientFactory(Settings settings) {
         this(settings, OkHttpClient.Builder::new);
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Michael Clarke
+ * Copyright (C) 2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -35,6 +35,7 @@ import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.server.ServerSide;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -64,6 +65,7 @@ public class RestApplicationAuthenticationProvider implements GithubApplicationA
     private final UrlConnectionProvider urlProvider;
     private final ObjectMapper objectMapper;
 
+    @Autowired
     public RestApplicationAuthenticationProvider(LinkHeaderReader linkHeaderReader) {
         this(Clock.systemDefaultZone(), linkHeaderReader, new DefaultUrlConnectionProvider());
     }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgentTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgentTest.java
@@ -66,7 +66,7 @@ public class CommunityBranchAgentTest {
         verify(instrumentation).retransformClasses(MultipleAlmFeatureProvider.class);
         verify(instrumentation, times(3)).addTransformer(classFileTransformerArgumentCaptor.capture());
 
-        try (InputStream inputStream = MultipleAlmFeatureProvider.class.getResourceAsStream(MultipleAlmFeatureProvider.class.getSimpleName())) {
+        try (InputStream inputStream = MultipleAlmFeatureProvider.class.getResourceAsStream(MultipleAlmFeatureProvider.class.getSimpleName() + ".class")) {
             byte[] input = IOUtils.toByteArray(inputStream);
             byte[] result = classFileTransformerArgumentCaptor.getAllValues().get(0).transform(classLoader, MultipleAlmFeatureProvider.class.getName().replaceAll("\\.", "/"), getClass(), getClass().getProtectionDomain(), input);
             Class<?> redefined = classLoader.loadClass(MultipleAlmFeatureProvider.class.getName(), result);
@@ -92,7 +92,7 @@ public class CommunityBranchAgentTest {
         verify(instrumentation).retransformClasses(SetAction.class);
         verify(instrumentation, times(3)).addTransformer(classFileTransformerArgumentCaptor.capture());
 
-        try (InputStream inputStream = SetAction.class.getResourceAsStream(SetAction.class.getSimpleName())) {
+        try (InputStream inputStream = SetAction.class.getResourceAsStream(SetAction.class.getSimpleName() + ".class")) {
             byte[] input = IOUtils.toByteArray(inputStream);
             byte[] result = classFileTransformerArgumentCaptor.getAllValues().get(1).transform(classLoader, SetAction.class.getName().replaceAll("\\.", "/"), getClass(), getClass().getProtectionDomain(), input);
 
@@ -124,7 +124,7 @@ public class CommunityBranchAgentTest {
         verify(instrumentation).retransformClasses(UnsetAction.class);
         verify(instrumentation, times(3)).addTransformer(classFileTransformerArgumentCaptor.capture());
 
-        try (InputStream inputStream = SetAction.class.getResourceAsStream(SetAction.class.getSimpleName())) {
+        try (InputStream inputStream = UnsetAction.class.getResourceAsStream(UnsetAction.class.getSimpleName() + ".class")) {
             byte[] input = IOUtils.toByteArray(inputStream);
             byte[] result = classFileTransformerArgumentCaptor.getAllValues().get(2).transform(classLoader, UnsetAction.class.getName().replaceAll("\\.", "/"), getClass(), getClass().getProtectionDomain(), input);
 
@@ -204,6 +204,6 @@ public class CommunityBranchAgentTest {
             return defineClass(name, value, 0, value.length);
         }
 
-    };
+    }
 
 }


### PR DESCRIPTION
The latest release of Sonarqube switches from using Pico Container for
dependency injection to using Spring. The method used for detecting the
constructor to be used for injecting in a multi-constructor class varies
between the 2 frameworks, with Pico only looking for public constructors
but Spring looking for any visible constructor, and then excluding any
constructors that do not have the `@Autowired` annotation on a muti-
constructor class. This change adds the relevant annotation onto the two
classes impacted by this change in frameworks, thereby allowing for the
Compute Engine to have the appropriate components generated for
completing decoration of Pull Requests.