### PR TITLE
Refactor Github operations to prevent leaking scope

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -23,7 +23,9 @@ import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.DefaultAzureDev
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.DefaultBitbucketClientFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.HttpClientBuilderFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.DefaultGithubClientFactory;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.DefaultUrlConnectionProvider;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.RestApplicationAuthenticationProvider;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.DefaultGraphqlProvider;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.DefaultGitlabClientFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.CommunityReportAnalysisComponentProvider;
 import com.github.mc1arke.sonarqube.plugin.scanner.BranchConfigurationFactory;
@@ -88,8 +90,10 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                     ValidateBindingAction.class,
 
                     GithubValidator.class,
+                    DefaultGraphqlProvider.class,
                     DefaultGithubClientFactory.class,
                     DefaultLinkHeaderReader.class,
+                    DefaultUrlConnectionProvider.class,
                     RestApplicationAuthenticationProvider.class,
                     HttpClientBuilderFactory.class,
                     DefaultBitbucketClientFactory.class,

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/DefaultGithubClientFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/DefaultGithubClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Michael Clarke
+ * Copyright (C) 2021-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,9 +20,9 @@ package com.github.mc1arke.sonarqube.plugin.almclient.github;
 
 import com.github.mc1arke.sonarqube.plugin.InvalidConfigurationException;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.GraphqlGithubClient;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.GraphqlProvider;
 import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.config.internal.Settings;
-import org.sonar.api.platform.Server;
 import org.sonar.api.server.ServerSide;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
@@ -35,13 +35,13 @@ import java.util.Optional;
 public class DefaultGithubClientFactory implements GithubClientFactory {
 
     private final GithubApplicationAuthenticationProvider githubApplicationAuthenticationProvider;
-    private final Server server;
     private final Settings settings;
+    private final GraphqlProvider graphqlProvider;
 
-    public DefaultGithubClientFactory(GithubApplicationAuthenticationProvider githubApplicationAuthenticationProvider, Server server, Settings settings) {
+    public DefaultGithubClientFactory(GithubApplicationAuthenticationProvider githubApplicationAuthenticationProvider, Settings settings, GraphqlProvider graphqlProvider) {
         this.githubApplicationAuthenticationProvider = githubApplicationAuthenticationProvider;
-        this.server = server;
         this.settings = settings;
+        this.graphqlProvider = graphqlProvider;
     }
 
     @Override
@@ -55,7 +55,7 @@ public class DefaultGithubClientFactory implements GithubClientFactory {
             RepositoryAuthenticationToken repositoryAuthenticationToken =
                     githubApplicationAuthenticationProvider.getInstallationToken(apiUrl, appId, apiPrivateKey, projectPath);
 
-            return new GraphqlGithubClient(repositoryAuthenticationToken, server);
+            return new GraphqlGithubClient(graphqlProvider, apiUrl, repositoryAuthenticationToken);
         } catch (IOException ex) {
             throw new InvalidConfigurationException(InvalidConfigurationException.Scope.PROJECT, "Could not create Github client - " + ex.getMessage(), ex);
         }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/GithubClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/GithubClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,14 +18,12 @@
  */
 package com.github.mc1arke.sonarqube.plugin.almclient.github;
 
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
-import org.sonar.db.alm.setting.AlmSettingDto;
-import org.sonar.db.alm.setting.ProjectAlmSettingDto;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.model.CheckRunDetails;
 
 import java.io.IOException;
 
 public interface GithubClient {
-    DecorationResult createCheckRun(AnalysisDetails analysisDetails, AlmSettingDto almSettingDto,
-                        ProjectAlmSettingDto projectAlmSettingDto) throws IOException;
+    String createCheckRun(CheckRunDetails checkRunDetails, boolean postSummaryComment) throws IOException;
+
+    String getRepositoryUrl();
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/RepositoryAuthenticationToken.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/RepositoryAuthenticationToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2019-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,12 +23,16 @@ public class RepositoryAuthenticationToken {
     private final String repositoryId;
     private final String authenticationToken;
     private final String repositoryUrl;
+    private final String repositoryName;
+    private final String ownerName;
 
-    public RepositoryAuthenticationToken(String repositoryId, String authenticationToken, String repositoryUrl) {
+    public RepositoryAuthenticationToken(String repositoryId, String authenticationToken, String repositoryUrl, String repositoryName, String ownerName) {
         super();
         this.repositoryId = repositoryId;
         this.authenticationToken = authenticationToken;
         this.repositoryUrl = repositoryUrl;
+        this.repositoryName = repositoryName;
+        this.ownerName = ownerName;
     }
 
     public String getRepositoryId() {
@@ -41,5 +45,13 @@ public class RepositoryAuthenticationToken {
 
     public String getRepositoryUrl() {
         return repositoryUrl;
+    }
+
+    public String getRepositoryName() {
+        return repositoryName;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/model/Annotation.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/model/Annotation.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.almclient.github.model;
+
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.CheckAnnotationLevel;
+
+public class Annotation {
+
+    private final Integer line;
+    private final String scmPath;
+    private final CheckAnnotationLevel severity;
+    private final String message;
+
+    private Annotation(Builder builder) {
+        line = builder.line;
+        scmPath = builder.scmPath;
+        severity = builder.severity;
+        message = builder.message;
+    }
+
+    public Integer getLine() {
+        return line;
+    }
+
+    public String getScmPath() {
+        return scmPath;
+    }
+
+    public CheckAnnotationLevel getSeverity() {
+        return severity;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private Integer line;
+        private String scmPath;
+        private CheckAnnotationLevel severity;
+        private String message;
+
+        private Builder() {
+            super();
+        }
+
+        public Builder withLine(Integer line) {
+            this.line = line;
+            return this;
+        }
+
+        public Builder withScmPath(String scmPath) {
+            this.scmPath = scmPath;
+            return this;
+        }
+
+        public Builder withSeverity(CheckAnnotationLevel severity) {
+            this.severity = severity;
+            return this;
+        }
+
+        public Builder withMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Annotation build() {
+            return new Annotation(this);
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/model/CheckRunDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/model/CheckRunDetails.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.almclient.github.model;
+
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.CheckConclusionState;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class CheckRunDetails {
+
+    private final String summary;
+    private final String title;
+    private final String name;
+    private final String dashboardUrl;
+    private final ZonedDateTime startTime;
+    private final ZonedDateTime endTime;
+    private final String externalId;
+    private final String commitId;
+    private final List<Annotation> annotations;
+    private final CheckConclusionState checkConclusionState;
+    private final int pullRequestId;
+
+    private CheckRunDetails(Builder builder) {
+        summary = builder.summary;
+        title = builder.title;
+        name = builder.name;
+        dashboardUrl = builder.dashboardUrl;
+        startTime = builder.startTime;
+        endTime = builder.endTime;
+        externalId = builder.externalId;
+        commitId = builder.commitId;
+        annotations = builder.annotations;
+        checkConclusionState = builder.checkConclusionState;
+        pullRequestId = builder.pullRequestId;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDashboardUrl() {
+        return dashboardUrl;
+    }
+
+    public ZonedDateTime getStartTime() {
+        return startTime;
+    }
+
+    public ZonedDateTime getEndTime() {
+        return endTime;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getCommitId() {
+        return commitId;
+    }
+
+    public List<Annotation> getAnnotations() {
+        return annotations;
+    }
+
+    public CheckConclusionState getCheckConclusionState() {
+        return checkConclusionState;
+    }
+
+    public int getPullRequestId() {
+        return pullRequestId;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String summary;
+        private String title;
+        private String name;
+        private String dashboardUrl;
+        private ZonedDateTime startTime;
+        private ZonedDateTime endTime;
+        private String externalId;
+        private String commitId;
+        private List<Annotation> annotations;
+        private CheckConclusionState checkConclusionState;
+        private int pullRequestId;
+
+        private Builder() {
+            super();
+        }
+
+        public Builder withSummary(String summary) {
+            this.summary = summary;
+            return this;
+        }
+
+        public Builder withTitle(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withDashboardUrl(String dashboardUrl) {
+            this.dashboardUrl = dashboardUrl;
+            return this;
+        }
+
+        public Builder withStartTime(ZonedDateTime startTime) {
+            this.startTime = startTime;
+            return this;
+        }
+
+        public Builder withEndTime(ZonedDateTime endTime) {
+            this.endTime = endTime;
+            return this;
+        }
+
+        public Builder withExternalId(String externalId) {
+            this.externalId = externalId;
+            return this;
+        }
+
+        public Builder withCommitId(String commitId) {
+            this.commitId = commitId;
+            return this;
+        }
+
+        public Builder withAnnotations(List<Annotation> annotations) {
+            this.annotations = annotations;
+            return this;
+        }
+
+        public Builder withCheckConclusionState(CheckConclusionState checkConclusionState) {
+            this.checkConclusionState = checkConclusionState;
+            return this;
+        }
+
+        public Builder withPullRequestId(int pullRequestId) {
+            this.pullRequestId = pullRequestId;
+            return this;
+        }
+
+        public CheckRunDetails build() {
+            return new CheckRunDetails(this);
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/DefaultUrlConnectionProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/DefaultUrlConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2019-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,10 +18,15 @@
  */
 package com.github.mc1arke.sonarqube.plugin.almclient.github.v3;
 
+import org.sonar.api.ce.ComputeEngineSide;
+import org.sonar.api.server.ServerSide;
+
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 
+@ComputeEngineSide
+@ServerSide
 public final class DefaultUrlConnectionProvider implements UrlConnectionProvider {
 
     @Override

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -64,11 +64,7 @@ public class RestApplicationAuthenticationProvider implements GithubApplicationA
     private final UrlConnectionProvider urlProvider;
     private final ObjectMapper objectMapper;
 
-    public RestApplicationAuthenticationProvider(LinkHeaderReader linkHeaderReader) {
-        this(Clock.systemDefaultZone(), linkHeaderReader, new DefaultUrlConnectionProvider());
-    }
-
-    RestApplicationAuthenticationProvider(Clock clock, LinkHeaderReader linkHeaderReader, UrlConnectionProvider urlProvider) {
+    public RestApplicationAuthenticationProvider(Clock clock, LinkHeaderReader linkHeaderReader, UrlConnectionProvider urlProvider) {
         super();
         this.clock = clock;
         this.urlProvider = urlProvider;
@@ -135,7 +131,7 @@ public class RestApplicationAuthenticationProvider implements GithubApplicationA
                     objectMapper.readerFor(InstallationRepositories.class).readValue(installationRepositoriesReader);
             for (Repository repository : installationRepositories.getRepositories()) {
                 if (projectPath.equals(repository.getFullName())) {
-                    return Optional.of(new RepositoryAuthenticationToken(repository.getNodeId(), appToken.getToken(), repository.getHtmlUrl()));
+                    return Optional.of(new RepositoryAuthenticationToken(repository.getNodeId(), appToken.getToken(), repository.getHtmlUrl(), repository.getName(), repository.getOwner().getLogin()));
                 }
             }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/model/Owner.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/model/Owner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Michael Clarke
+ * Copyright (C) 2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,40 +21,16 @@ package com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Repository {
+public class Owner {
 
-    private final String nodeId;
-    private final String fullName;
-    private final String htmlUrl;
-    private final String name;
-    private final Owner owner;
+    private final String login;
 
     @JsonCreator
-    public Repository(@JsonProperty("node_id") String nodeId, @JsonProperty("full_name") String fullName, @JsonProperty("html_url") String htmlUrl, @JsonProperty("name") String name, @JsonProperty("owner") Owner owner) {
-        this.nodeId = nodeId;
-        this.fullName = fullName;
-        this.htmlUrl = htmlUrl;
-        this.name = name;
-        this.owner = owner;
+    public Owner(@JsonProperty("login") String login) {
+        this.login = login;
     }
 
-    public String getFullName() {
-        return fullName;
-    }
-
-    public String getNodeId() {
-        return nodeId;
-    }
-
-    public String getHtmlUrl() {
-        return htmlUrl;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public Owner getOwner() {
-        return owner;
+    public String getLogin() {
+        return login;
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/DefaultGraphqlProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/DefaultGraphqlProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2019-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,8 +21,12 @@ package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
 import io.aexp.nodes.graphql.GraphQLRequestEntity;
 import io.aexp.nodes.graphql.GraphQLTemplate;
 import io.aexp.nodes.graphql.InputObject;
+import org.sonar.api.ce.ComputeEngineSide;
+import org.sonar.api.server.ServerSide;
 
-final class DefaultGraphqlProvider implements GraphqlProvider {
+@ComputeEngineSide
+@ServerSide
+public final class DefaultGraphqlProvider implements GraphqlProvider {
 
     @Override
     public GraphQLTemplate createGraphQLTemplate() {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GetRepository.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GetRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Julien Roy
+ * Copyright (C) 2021-2022 Julien Roy, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -24,7 +24,7 @@ import io.aexp.nodes.graphql.annotations.GraphQLArgument;
 import io.aexp.nodes.graphql.annotations.GraphQLProperty;
 
 @GraphQLProperty(name = "repository", arguments = {@GraphQLArgument(name = "owner"), @GraphQLArgument(name = "name")})
-public class GetPullRequest {
+public class GetRepository {
 
     private final String url;
 
@@ -32,7 +32,7 @@ public class GetPullRequest {
     private final PullRequest pullRequest;
 
     @JsonCreator
-    public GetPullRequest(@JsonProperty("url") String url, @JsonProperty("pullRequest") PullRequest pullRequest) {
+    public GetRepository(@JsonProperty("url") String url, @JsonProperty("pullRequest") PullRequest pullRequest) {
         this.url = url;
         this.pullRequest = pullRequest;
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,14 +20,10 @@ package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
 
 import com.github.mc1arke.sonarqube.plugin.almclient.github.GithubClient;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.RepositoryAuthenticationToken;
-import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.CheckAnnotationLevel;
-import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.CheckConclusionState;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.model.Annotation;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.model.CheckRunDetails;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.CommentClassifiers;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.RequestableCheckStatusState;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import io.aexp.nodes.graphql.Argument;
 import io.aexp.nodes.graphql.Arguments;
 import io.aexp.nodes.graphql.GraphQLRequestEntity;
@@ -35,22 +31,11 @@ import io.aexp.nodes.graphql.GraphQLResponseEntity;
 import io.aexp.nodes.graphql.GraphQLTemplate;
 import io.aexp.nodes.graphql.InputObject;
 import io.aexp.nodes.graphql.internal.Error;
-import org.sonar.api.ce.posttask.QualityGate;
-import org.sonar.api.issue.Issue;
-import org.sonar.api.platform.Server;
-import org.sonar.api.rule.Severity;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonar.ce.task.projectanalysis.component.Component;
-import org.sonar.db.alm.setting.AlmSettingDto;
-import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
-import java.time.Clock;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -58,7 +43,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TimeZone;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -67,78 +51,44 @@ import static org.apache.commons.lang.ArrayUtils.isEmpty;
 public class GraphqlGithubClient implements GithubClient {
 
     private static final Logger LOGGER = Loggers.get(GraphqlGithubClient.class);
-    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ssXXX";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX")
+            .withZone(ZoneId.of("UTC"));
     private static final String INPUT = "input";
 
     private final GraphqlProvider graphqlProvider;
-    private final Clock clock;
     private final RepositoryAuthenticationToken repositoryAuthenticationToken;
-    private final Server server;
+    private final String apiUrl;
 
-    private static final List<String> OPEN_ISSUE_STATUSES =
-            Issue.STATUSES.stream().filter(s -> !Issue.STATUS_CLOSED.equals(s) && !Issue.STATUS_RESOLVED.equals(s))
-                    .collect(Collectors.toList());
 
-    public GraphqlGithubClient(RepositoryAuthenticationToken repositoryAuthenticationToken,
-                               Server server) {
-        this(new DefaultGraphqlProvider(), Clock.systemDefaultZone(), repositoryAuthenticationToken, server);
-    }
-
-    GraphqlGithubClient(GraphqlProvider graphqlProvider, Clock clock,
-                        RepositoryAuthenticationToken repositoryAuthenticationToken,
-                        Server server) {
+    public GraphqlGithubClient(GraphqlProvider graphqlProvider, String apiUrl,
+                               RepositoryAuthenticationToken repositoryAuthenticationToken) {
         super();
         this.graphqlProvider = graphqlProvider;
-        this.clock = clock;
+        this.apiUrl = apiUrl;
         this.repositoryAuthenticationToken = repositoryAuthenticationToken;
-        this.server = server;
     }
 
     @Override
-    public DecorationResult createCheckRun(AnalysisDetails analysisDetails, AlmSettingDto almSettingDto,
-                               ProjectAlmSettingDto projectAlmSettingDto) throws IOException {
-        String apiUrl = Optional.ofNullable(almSettingDto.getUrl()).orElseThrow(() -> new IllegalArgumentException("No URL has been set for Github connections"));
-        String projectPath = Optional.ofNullable(projectAlmSettingDto.getAlmRepo()).orElseThrow(() -> new IllegalArgumentException("No repository name has been set for Github connections"));
-
-
+    public String createCheckRun(CheckRunDetails checkRunDetails, boolean postSummaryComment) throws IOException {
         Map<String, String> headers = new HashMap<>();
         headers.put("Authorization", "Bearer " + repositoryAuthenticationToken.getAuthenticationToken());
         headers.put("Accept", "application/vnd.github.antiope-preview+json");
 
+        List<InputObject<Object>> annotations = createAnnotations(checkRunDetails.getAnnotations());
 
-        String summary = analysisDetails.createAnalysisSummary(new MarkdownFormatterFactory());
-
-        List<PostAnalysisIssueVisitor.ComponentIssue> issues = analysisDetails.getPostAnalysisIssueVisitor().getIssues();
-
-        List<InputObject<Object>> annotations = createAnnotations(issues);
-
-        InputObject.Builder<Object> checkRunOutputContentBuilder = graphqlProvider.createInputObject().put("title", "Quality Gate " +
-                                                                                                     (analysisDetails
-                                                                                                              .getQualityGateStatus() ==
-                                                                                                      QualityGate.Status.OK ?
-                                                                                                      "success" :
-                                                                                                      "failed"))
-                .put("summary", summary)
+        InputObject.Builder<Object> checkRunOutputContentBuilder = graphqlProvider.createInputObject().put("title", checkRunDetails.getTitle())
+                .put("summary", checkRunDetails.getSummary())
                 .put("annotations", annotations);
-
-        SimpleDateFormat startedDateFormat = new SimpleDateFormat(DATE_TIME_PATTERN);
-        startedDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         Map<String, Object> inputObjectArguments = new HashMap<>();
         inputObjectArguments.put("repositoryId", repositoryAuthenticationToken.getRepositoryId());
-        inputObjectArguments.put("name", String.format("%s Sonarqube Results", analysisDetails.getAnalysisProjectName()));
+        inputObjectArguments.put("name", checkRunDetails.getName());
         inputObjectArguments.put("status", RequestableCheckStatusState.COMPLETED);
-        inputObjectArguments.put("conclusion", QualityGate.Status.OK == analysisDetails.getQualityGateStatus() ?
-                                   CheckConclusionState.SUCCESS : CheckConclusionState.FAILURE);
-        inputObjectArguments.put("detailsUrl", String.format("%s/dashboard?id=%s&pullRequest=%s", server.getPublicRootUrl(),
-                                                 URLEncoder.encode(analysisDetails.getAnalysisProjectKey(),
-                                                                   StandardCharsets.UTF_8), URLEncoder
-                                                         .encode(analysisDetails.getBranchName(),
-                                                                 StandardCharsets.UTF_8)));
-        inputObjectArguments.put("startedAt", startedDateFormat.format(analysisDetails.getAnalysisDate()));
-        inputObjectArguments.put("completedAt", DateTimeFormatter.ofPattern(DATE_TIME_PATTERN).withZone(ZoneId.of("UTC"))
-                        .format(clock.instant()));
-        inputObjectArguments.put("externalId", analysisDetails.getAnalysisId());
+        inputObjectArguments.put("conclusion", checkRunDetails.getCheckConclusionState());
+        inputObjectArguments.put("detailsUrl", checkRunDetails.getDashboardUrl());
+        inputObjectArguments.put("startedAt", DATE_TIME_FORMATTER.format(checkRunDetails.getStartTime()));
+        inputObjectArguments.put("completedAt", DATE_TIME_FORMATTER.format(checkRunDetails.getEndTime()));
+        inputObjectArguments.put("externalId", checkRunDetails.getExternalId());
         inputObjectArguments.put("output", checkRunOutputContentBuilder.build());
 
         InputObject.Builder<Object> repositoryInputObjectBuilder = graphqlProvider.createInputObject();
@@ -152,7 +102,7 @@ public class GraphqlGithubClient implements GithubClient {
                         .headers(headers)
                         .request(CreateCheckRun.class)
                         .arguments(new Arguments("createCheckRun", new Argument<>(INPUT, repositoryInputObjectBuilder
-                                .put("headSha", analysisDetails.getCommitSha())
+                                .put("headSha", checkRunDetails.getCommitId())
                                 .build())))
                         .requestMethod(GraphQLTemplate.GraphQLMethod.MUTATE);
 
@@ -161,31 +111,30 @@ public class GraphqlGithubClient implements GithubClient {
         GraphQLResponseEntity<CreateCheckRun> graphQLResponseEntity = executeRequest((r, t) -> graphqlProvider.createGraphQLTemplate().mutate(r, t),
                                                                                      graphQLRequestEntity, CreateCheckRun.class);
 
-        reportRemainingIssues(issues, graphQLResponseEntity.getResponse().getCheckRun().getId(),
+        reportRemainingAnnotations(checkRunDetails.getAnnotations(), graphQLResponseEntity.getResponse().getCheckRun().getId(),
                               inputObjectArguments, checkRunOutputContentBuilder, graphQLRequestEntityBuilder);
 
 
-        if (Optional.ofNullable(projectAlmSettingDto.getSummaryCommentEnabled()).orElse(true)) {
-            postSummaryComment(graphqlUrl, headers, projectPath, analysisDetails.getBranchName(), summary);
+        if (postSummaryComment) {
+            postSummaryComment(graphqlUrl, headers, checkRunDetails.getPullRequestId(), checkRunDetails.getSummary());
         }
 
-        return DecorationResult.builder()
-                .withPullRequestUrl(repositoryAuthenticationToken.getRepositoryUrl() + "/pull/" + analysisDetails.getBranchName())
-                .build();
+        return graphQLResponseEntity.getResponse().getCheckRun().getId();
 
     }
 
-    private void postSummaryComment(String graphqlUrl, Map<String, String> headers, String projectPath, String pullRequestKey, String summary) throws IOException {
+    @Override
+    public String getRepositoryUrl() {
+        return repositoryAuthenticationToken.getRepositoryUrl();
+    }
+
+    private void postSummaryComment(String graphqlUrl, Map<String, String> headers, int pullRequestKey, String summary) throws IOException {
         String login = getLogin(graphqlUrl, headers);
 
-        String[] paths = projectPath.split("/", 2);
-        String owner = paths[0];
-        String projectName = paths[1];
-
-        GetPullRequest.PullRequest pullRequest = getPullRequest(graphqlUrl, headers, projectName, pullRequestKey, owner);
+        GetRepository.PullRequest pullRequest = getPullRequest(graphqlUrl, headers, pullRequestKey);
         String pullRequestId = pullRequest.getId();
 
-        getComments(pullRequest, graphqlUrl, headers, projectName, pullRequestKey, owner).stream()
+        getComments(pullRequest, graphqlUrl, headers, pullRequestKey).stream()
             .filter(c -> "Bot".equalsIgnoreCase(c.getAuthor().getType()) && login.equalsIgnoreCase(c.getAuthor().getLogin()))
             .filter(c -> !c.isMinimized())
             .map(Comments.CommentNode::getId)
@@ -211,36 +160,36 @@ public class GraphqlGithubClient implements GithubClient {
 
     }
 
-    private List<Comments.CommentNode> getComments(GetPullRequest.PullRequest pullRequest, String graphqlUrl, Map<String, String> headers, String projectName, String pullRequestKey, String owner) throws MalformedURLException {
+    private List<Comments.CommentNode> getComments(GetRepository.PullRequest pullRequest, String graphqlUrl, Map<String, String> headers, int pullRequestKey) throws MalformedURLException {
         List<Comments.CommentNode> comments = new ArrayList<>(pullRequest.getComments().getNodes());
 
         PageInfo currentPageInfo = pullRequest.getComments().getPageInfo();
         if (currentPageInfo.hasNextPage()) {
-            GetPullRequest.PullRequest response = getPullRequest(graphqlUrl, headers, projectName, pullRequestKey, owner, currentPageInfo);
-            comments.addAll(getComments(response, graphqlUrl, headers, projectName, pullRequestKey, owner));
+            GetRepository.PullRequest response = getPullRequest(graphqlUrl, headers, pullRequestKey, currentPageInfo);
+            comments.addAll(getComments(response, graphqlUrl, headers, pullRequestKey));
         }
 
         return comments;
     }
 
-    private GetPullRequest.PullRequest getPullRequest(String graphqlUrl, Map<String, String> headers, String projectName, String pullRequestKey, String owner) throws MalformedURLException {
-        return getPullRequest(graphqlUrl, headers, projectName, pullRequestKey, owner, null);
+    private GetRepository.PullRequest getPullRequest(String graphqlUrl, Map<String, String> headers, int pullRequestKey) throws MalformedURLException {
+        return getPullRequest(graphqlUrl, headers, pullRequestKey, null);
     }
 
-    private GetPullRequest.PullRequest getPullRequest(String graphqlUrl, Map<String, String> headers, String projectName, String pullRequestKey, String owner, PageInfo pageInfo) throws MalformedURLException {
+    private GetRepository.PullRequest getPullRequest(String graphqlUrl, Map<String, String> headers, int pullRequestKey, PageInfo pageInfo) throws MalformedURLException {
         GraphQLRequestEntity getPullRequest =
                 graphqlProvider.createRequestBuilder()
                         .url(graphqlUrl)
                         .headers(headers)
-                        .request(GetPullRequest.class)
+                        .request(GetRepository.class)
                         .arguments(
-                                new Arguments("repository", new Argument<>("owner", owner), new Argument<>("name", projectName)),
-                                new Arguments("repository.pullRequest", new Argument<>("number", Integer.valueOf(pullRequestKey))),
+                                new Arguments("repository", new Argument<>("owner", repositoryAuthenticationToken.getOwnerName()), new Argument<>("name", repositoryAuthenticationToken.getRepositoryName())),
+                                new Arguments("repository.pullRequest", new Argument<>("number", pullRequestKey)),
                                 new Arguments("repository.pullRequest.comments", new Argument<>("first", 100), new Argument<>("after", Optional.ofNullable(pageInfo).map(PageInfo::getEndCursor).orElse(null)))
                         )
                         .build();
 
-        return executeRequest((r, t) -> graphqlProvider.createGraphQLTemplate().query(r, t), getPullRequest, GetPullRequest.class).getResponse().getPullRequest();
+        return executeRequest((r, t) -> graphqlProvider.createGraphQLTemplate().query(r, t), getPullRequest, GetRepository.class).getResponse().getPullRequest();
     }
 
     private void minimizeComment(String graphqlUrl, Map<String, String> headers, String commentId) {
@@ -300,18 +249,18 @@ public class GraphqlGithubClient implements GithubClient {
         return response;
     }
 
-    private void reportRemainingIssues(List<PostAnalysisIssueVisitor.ComponentIssue> outstandingIssues, String checkRunId,
-                                       Map<String, Object> repositoryInputArguments, InputObject.Builder<Object> outputObjectBuilder,
-                                       GraphQLRequestEntity.RequestBuilder graphQLRequestEntityBuilder) {
+    private void reportRemainingAnnotations(List<Annotation> outstandingAnnotations, String checkRunId,
+                                            Map<String, Object> repositoryInputArguments, InputObject.Builder<Object> outputObjectBuilder,
+                                            GraphQLRequestEntity.RequestBuilder graphQLRequestEntityBuilder) {
 
-        if (outstandingIssues.size() <= 50) {
+        if (outstandingAnnotations.size() <= 50) {
             return;
         }
 
-        List<PostAnalysisIssueVisitor.ComponentIssue> issues = outstandingIssues.subList(50, outstandingIssues.size());
+        List<Annotation> annotations = outstandingAnnotations.subList(50, outstandingAnnotations.size());
 
         InputObject<Object> outputObject = outputObjectBuilder
-                .put("annotations", createAnnotations(issues))
+                .put("annotations", createAnnotations(annotations))
                 .build();
 
         InputObject.Builder<Object> repositoryInputObjectBuilder = graphqlProvider.createInputObject();
@@ -330,25 +279,23 @@ public class GraphqlGithubClient implements GithubClient {
 
        executeRequest((r, t) -> graphqlProvider.createGraphQLTemplate().mutate(r, t), graphQLRequestEntity, UpdateCheckRun.class);
 
-       reportRemainingIssues(issues, checkRunId, repositoryInputArguments, outputObjectBuilder, graphQLRequestEntityBuilder);
+       reportRemainingAnnotations(annotations, checkRunId, repositoryInputArguments, outputObjectBuilder, graphQLRequestEntityBuilder);
     }
 
-    private List<InputObject<Object>> createAnnotations(List<PostAnalysisIssueVisitor.ComponentIssue> issues) {
-        return issues.stream()
+    private List<InputObject<Object>> createAnnotations(List<Annotation> annotations) {
+        return annotations.stream()
                 .limit(50)
-                .filter(i -> i.getComponent().getReportAttributes().getScmPath().isPresent())
-                .filter(i -> i.getComponent().getType() == Component.Type.FILE)
-                .filter(i -> i.getIssue().resolution() == null)
-                .filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().status())).map(componentIssue -> {
+                .map(annotation -> {
             InputObject<Object> issueLocation = graphqlProvider.createInputObject()
-                    .put("startLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0))
-                    .put("endLine", Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0))
+                    .put("startLine", Optional.ofNullable(annotation.getLine()).orElse(0))
+                    .put("endLine", Optional.ofNullable(annotation.getLine()).orElse(0))
                     .build();
             return graphqlProvider.createInputObject()
-                    .put("path", componentIssue.getComponent().getReportAttributes().getScmPath().get())
+                    .put("path", annotation.getScmPath())
                     .put("location", issueLocation)
-                    .put("annotationLevel", mapToGithubAnnotationLevel(componentIssue.getIssue().severity()))
-                    .put("message", componentIssue.getIssue().getMessage().replace("\\","\\\\").replace("\"", "\\\"")).build();
+                    .put("annotationLevel", annotation.getSeverity())
+                    .put("message", annotation.getMessage())
+                    .build();
         }).collect(Collectors.toList());
     }
 
@@ -362,21 +309,6 @@ public class GraphqlGithubClient implements GithubClient {
         apiUrl = apiUrl + "/graphql";
 
         return apiUrl;
-    }
-
-    private static CheckAnnotationLevel mapToGithubAnnotationLevel(String sonarqubeSeverity) {
-        switch (sonarqubeSeverity) {
-            case Severity.INFO:
-                return CheckAnnotationLevel.NOTICE;
-            case Severity.MINOR:
-            case Severity.MAJOR:
-                return CheckAnnotationLevel.WARNING;
-            case Severity.CRITICAL:
-            case Severity.BLOCKER:
-                return CheckAnnotationLevel.FAILURE;
-            default:
-                throw new IllegalArgumentException("Unknown severity value: " + sonarqubeSeverity);
-        }
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2019-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,7 @@ import io.aexp.nodes.graphql.GraphQLRequestEntity;
 import io.aexp.nodes.graphql.GraphQLTemplate;
 import io.aexp.nodes.graphql.InputObject;
 
-interface GraphqlProvider {
+public interface GraphqlProvider {
 
     GraphQLTemplate createGraphQLTemplate();
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
@@ -23,7 +23,9 @@ import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.DefaultAzureDev
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.DefaultBitbucketClientFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.HttpClientBuilderFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.DefaultGithubClientFactory;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.DefaultUrlConnectionProvider;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.RestApplicationAuthenticationProvider;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.DefaultGraphqlProvider;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.DefaultGitlabClientFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestPostAnalysisTask;
@@ -31,6 +33,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops.AzureDevOp
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.BitbucketPullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.GithubPullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabMergeRequestDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.sonar.ce.task.projectanalysis.container.ReportAnalysisComponentProvider;
 
 import java.util.Arrays;
@@ -45,6 +48,7 @@ public class CommunityReportAnalysisComponentProvider implements ReportAnalysisC
     public List<Object> getComponents() {
         return Arrays.asList(CommunityBranchLoaderDelegate.class, PullRequestPostAnalysisTask.class,
                              PostAnalysisIssueVisitor.class, DefaultLinkHeaderReader.class,
+                             MarkdownFormatterFactory.class, DefaultGraphqlProvider.class, DefaultUrlConnectionProvider.class,
                              DefaultGithubClientFactory.class, RestApplicationAuthenticationProvider.class, GithubPullRequestDecorator.class,
                              HttpClientBuilderFactory.class, DefaultBitbucketClientFactory.class, BitbucketPullRequestDecorator.class,
                              DefaultGitlabClientFactory.class, GitlabMergeRequestDecorator.class,

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Markus Heberling, Michael Clarke
+ * Copyright (C) 2020-2022 Markus Heberling, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -37,7 +37,6 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DiscussionAwarePullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.apache.commons.lang.StringUtils;
 import org.sonar.api.ce.posttask.QualityGate;
@@ -61,12 +60,12 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
 
     private static final Pattern NOTE_MARKDOWN_LEGACY_SEE_LINK_PATTERN = Pattern.compile("^\\[See in SonarQube]\\((.*?)\\)$");
     private final AzureDevopsClientFactory azureDevopsClientFactory;
-    private final FormatterFactory formatterFactory;
+    private final MarkdownFormatterFactory markdownFormatterFactory;
 
-    public AzureDevOpsPullRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, AzureDevopsClientFactory azureDevopsClientFactory) {
+    public AzureDevOpsPullRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, AzureDevopsClientFactory azureDevopsClientFactory, MarkdownFormatterFactory markdownFormatterFactory) {
         super(server, scmInfoRepository);
         this.azureDevopsClientFactory = azureDevopsClientFactory;
-        this.formatterFactory = new MarkdownFormatterFactory();
+        this.markdownFormatterFactory = markdownFormatterFactory;
     }
 
     @Override
@@ -140,7 +139,7 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
     @Override
     protected void submitCommitNoteForIssue(AzureDevopsClient client, PullRequest pullRequest, PostAnalysisIssueVisitor.ComponentIssue issue, String filePath,
                                             AnalysisDetails analysis) {
-        String issueSummary = analysis.createAnalysisIssueSummary(issue, formatterFactory);
+        String issueSummary = analysis.createAnalysisIssueSummary(issue, markdownFormatterFactory);
         DbIssues.Locations location = issue.getIssue().getLocations();
 
         try {
@@ -166,7 +165,7 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
     @Override
     protected void submitSummaryNote(AzureDevopsClient client, PullRequest pullRequest, AnalysisDetails analysis) {
         try {
-            String summaryCommentBody = analysis.createAnalysisSummary(formatterFactory);
+            String summaryCommentBody = analysis.createAnalysisSummary(markdownFormatterFactory);
             CreateCommentRequest comment = new CreateCommentRequest(summaryCommentBody);
             CreateCommentThreadRequest commentThread = new CreateCommentThreadRequest(null, Collections.singletonList(comment), CommentThreadStatus.ACTIVE);
             CommentThread summaryComment = client.createThread(pullRequest.getRepository().getProject().getName(), pullRequest.getRepository().getName(), pullRequest.getId(), commentThread);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,31 +18,73 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github;
 
+import com.github.mc1arke.sonarqube.plugin.almclient.github.GithubClient;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.GithubClientFactory;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.model.Annotation;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.model.CheckRunDetails;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.CheckAnnotationLevel;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.CheckConclusionState;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
+import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.rule.Severity;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorator {
 
     private final GithubClientFactory githubClientFactory;
+    private final MarkdownFormatterFactory markdownFormatterFactory;
+    private final Clock clock;
 
-    public GithubPullRequestDecorator(GithubClientFactory githubClientFactory) {
+    public GithubPullRequestDecorator(GithubClientFactory githubClientFactory,
+                                      MarkdownFormatterFactory markdownFormatterFactory, Clock clock) {
         this.githubClientFactory = githubClientFactory;
+        this.markdownFormatterFactory = markdownFormatterFactory;
+        this.clock = clock;
     }
 
     @Override
     public DecorationResult decorateQualityGateStatus(AnalysisDetails analysisDetails, AlmSettingDto almSettingDto,
                                           ProjectAlmSettingDto projectAlmSettingDto) {
+        CheckRunDetails checkRunDetails = CheckRunDetails.builder()
+                .withAnnotations(analysisDetails.getScmReportableIssues().stream()
+                        .map(issue -> createAnnotation(issue, analysisDetails))
+                        .collect(Collectors.toList()))
+                .withCheckConclusionState(analysisDetails.getQualityGateStatus() == QualityGate.Status.OK ? CheckConclusionState.SUCCESS : CheckConclusionState.FAILURE)
+                .withCommitId(analysisDetails.getCommitSha())
+                .withSummary(analysisDetails.createAnalysisSummary(markdownFormatterFactory))
+                .withDashboardUrl(analysisDetails.getDashboardUrl())
+                .withPullRequestId(Integer.parseInt(analysisDetails.getBranchName()))
+                .withStartTime(analysisDetails.getAnalysisDate().toInstant().atZone(ZoneId.of("UTC")))
+                .withEndTime(ZonedDateTime.now(clock))
+                .withExternalId(analysisDetails.getAnalysisId())
+                .withName(String.format("%s Sonarqube Results", analysisDetails.getAnalysisProjectName()))
+                .withTitle("Quality Gate " + (analysisDetails.getQualityGateStatus() == QualityGate.Status.OK ? "success" : "failed"))
+                .build();
+
         try {
-            return githubClientFactory.createClient(projectAlmSettingDto, almSettingDto)
-                    .createCheckRun(analysisDetails, almSettingDto, projectAlmSettingDto);
+            GithubClient githubClient = githubClientFactory.createClient(projectAlmSettingDto, almSettingDto);
+
+            githubClient.createCheckRun(checkRunDetails,
+                            Optional.ofNullable(projectAlmSettingDto.getSummaryCommentEnabled())
+                                    .orElse(false));
+
+            return DecorationResult.builder()
+                    .withPullRequestUrl(githubClient.getRepositoryUrl() + "/pull/" + checkRunDetails.getPullRequestId())
+                    .build();
         } catch (Exception ex) {
             throw new IllegalStateException("Could not decorate Pull Request on Github", ex);
         }
@@ -52,6 +94,30 @@ public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorat
     @Override
     public List<ALM> alm() {
         return Collections.singletonList(ALM.GITHUB);
+    }
+
+    private static Annotation createAnnotation(PostAnalysisIssueVisitor.ComponentIssue componentIssue, AnalysisDetails analysisDetails) {
+        return Annotation.builder()
+                .withLine(Optional.ofNullable(componentIssue.getIssue().getLine()).orElse(0))
+                .withScmPath(analysisDetails.getSCMPathForIssue(componentIssue).orElseThrow())
+                .withMessage(Optional.ofNullable(componentIssue.getIssue().getMessage()).orElseThrow().replace("\\","\\\\").replace("\"", "\\\""))
+                .withSeverity(mapToGithubAnnotationLevel(componentIssue.getIssue().severity()))
+                .build();
+    }
+
+    private static CheckAnnotationLevel mapToGithubAnnotationLevel(String sonarqubeSeverity) {
+        switch (sonarqubeSeverity) {
+            case Severity.INFO:
+                return CheckAnnotationLevel.NOTICE;
+            case Severity.MINOR:
+            case Severity.MAJOR:
+                return CheckAnnotationLevel.WARNING;
+            case Severity.CRITICAL:
+            case Severity.BLOCKER:
+                return CheckAnnotationLevel.FAILURE;
+            default:
+                throw new IllegalArgumentException("Unknown severity value: " + sonarqubeSeverity);
+        }
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Markus Heberling, Michael Clarke
+ * Copyright (C) 2020-2022 Markus Heberling, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -58,10 +58,10 @@ public class GitlabMergeRequestDecorator extends DiscussionAwarePullRequestDecor
     private final GitlabClientFactory gitlabClientFactory;
     private final FormatterFactory formatterFactory;
 
-    public GitlabMergeRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, GitlabClientFactory gitlabClientFactory) {
+    public GitlabMergeRequestDecorator(Server server, ScmInfoRepository scmInfoRepository, GitlabClientFactory gitlabClientFactory, MarkdownFormatterFactory markdownFormatterFactory) {
         super(server, scmInfoRepository);
         this.gitlabClientFactory = gitlabClientFactory;
-        this.formatterFactory = new MarkdownFormatterFactory();
+        this.formatterFactory = markdownFormatterFactory;
     }
 
     @Override

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/FormatterFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/FormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2019-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,6 +18,9 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup;
 
+import org.sonar.api.ce.ComputeEngineSide;
+
+@ComputeEngineSide
 public interface FormatterFactory {
 
     Formatter<Document> documentFormatter();

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -118,7 +118,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(23, argumentCaptor.getAllValues().size());
+        assertEquals(25, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -37,7 +37,6 @@ import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -97,7 +96,7 @@ public class RestApplicationAuthenticationProviderTest {
         HttpURLConnection repositoriesUrlConnection = mock(HttpURLConnection.class);
         doReturn(new ByteArrayInputStream(
                 ("{\"repositories\": [{\"node_id\": \"" + expectedRepositoryId + "\", \"full_name\": \"" + projectPath +
-                 "\", \"html_url\": \"" + expectedHtmlUrl + "\"}]}").getBytes(StandardCharsets.UTF_8))).when(repositoriesUrlConnection).getInputStream();
+                 "\", \"html_url\": \"" + expectedHtmlUrl + "\", \"name\": \"project\", \"owner\": {\"login\": \"owner_name\"}}]}").getBytes(StandardCharsets.UTF_8))).when(repositoriesUrlConnection).getInputStream();
         doReturn(repositoriesUrlConnection).when(urlProvider).createUrlConnection("repositories_url");
 
         doReturn(installationsUrlConnection).when(urlProvider).createUrlConnection(fullUrl);
@@ -165,7 +164,7 @@ public class RestApplicationAuthenticationProviderTest {
             HttpURLConnection repositoriesUrlConnection = mock(HttpURLConnection.class);
             doReturn(new ByteArrayInputStream(
                     ("{\"repositories\": [{\"node_id\": \"" + expectedRepositoryId + (i == 0 ? "a" : "") + "\", \"full_name\": \"" +
-                     projectPath + (i == 0 ? "a" : "") + "\"}]}").getBytes(StandardCharsets.UTF_8))).when(repositoriesUrlConnection).getInputStream();
+                     projectPath + (i == 0 ? "a" : "") + "\", \"name\": \"name\", \"owner\": {\"login\": \"login\"}}]}").getBytes(StandardCharsets.UTF_8))).when(repositoriesUrlConnection).getInputStream();
 
             doReturn(i == 0 ? "a" : null).when(repositoriesUrlConnection).getHeaderField("Link");
             doReturn(repositoriesUrlConnection).when(urlProvider).createUrlConnection(i == 0 ? "repositories_url" : "https://dummy.url/path?param=dummy&page=" + (i + 1));
@@ -274,15 +273,5 @@ public class RestApplicationAuthenticationProviderTest {
                                    "Bearer " + expectedAuthenticationToken),
                      requestPropertyArgumentCaptor.getAllValues());
 
-    }
-
-    @Test
-    public void testDefaultParameters() {
-        Clock clock = Clock.systemDefaultZone();
-        LinkHeaderReader linkHeaderReader = mock(LinkHeaderReader.class);
-        assertThat(new RestApplicationAuthenticationProvider(clock, linkHeaderReader, new DefaultUrlConnectionProvider()))
-                .usingRecursiveComparison()
-                .ignoringFields("objectMapper")
-                .isEqualTo(new RestApplicationAuthenticationProvider(linkHeaderReader));
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProviderTest.java
@@ -32,7 +32,7 @@ public class CommunityReportAnalysisComponentProviderTest {
     @Test
     public void testGetComponents() {
         List<Object> result = new CommunityReportAnalysisComponentProvider().getComponents();
-        assertEquals(14, result.size());
+        assertEquals(17, result.size());
         assertEquals(CommunityBranchLoaderDelegate.class, result.get(0));
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
@@ -5,6 +5,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.DefaultAzureDev
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -73,7 +74,8 @@ public class AzureDevOpsPullRequestDecoratorTest {
     private final ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
     private final Settings settings = mock(Settings.class);
     private final Encryption encryption = mock(Encryption.class);
-    private final AzureDevOpsPullRequestDecorator pullRequestDecorator = new AzureDevOpsPullRequestDecorator(server, scmInfoRepository, new DefaultAzureDevopsClientFactory(settings));
+    private final MarkdownFormatterFactory markdownFormatterFactory = mock(MarkdownFormatterFactory.class);
+    private final AzureDevOpsPullRequestDecorator pullRequestDecorator = new AzureDevOpsPullRequestDecorator(server, scmInfoRepository, new DefaultAzureDevopsClientFactory(settings), markdownFormatterFactory);
     private final AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
 
     private final PostAnalysisIssueVisitor issueVisitor = mock(PostAnalysisIssueVisitor.class);
@@ -510,7 +512,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
 
     @Test
     public void testName() {
-        assertThat(new AzureDevOpsPullRequestDecorator(mock(Server.class), mock(ScmInfoRepository.class), mock(AzureDevopsClientFactory.class)).alm()).isEqualTo(Collections.singletonList(ALM.AZURE_DEVOPS));
+        assertThat(new AzureDevOpsPullRequestDecorator(mock(Server.class), mock(ScmInfoRepository.class), mock(AzureDevopsClientFactory.class), mock(MarkdownFormatterFactory.class)).alm()).isEqualTo(Collections.singletonList(ALM.AZURE_DEVOPS));
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,47 +20,91 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github;
 
 import com.github.mc1arke.sonarqube.plugin.almclient.github.GithubClient;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.GithubClientFactory;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.model.Annotation;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.model.CheckRunDetails;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.CheckAnnotationLevel;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v4.model.CheckConclusionState;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
-import org.junit.Test;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.rule.Severity;
+import org.sonar.ce.task.projectanalysis.component.Component;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
 import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class GithubPullRequestDecoratorTest {
+class GithubPullRequestDecoratorTest {
 
     private final GithubClient githubClient = mock(GithubClient.class);
     private final AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
     private final GithubClientFactory githubClientFactory = mock(GithubClientFactory.class);
-    private final GithubPullRequestDecorator testCase = new GithubPullRequestDecorator(githubClientFactory);
+    private final MarkdownFormatterFactory markdownFormatterFactory = mock(MarkdownFormatterFactory.class);
+    private final Clock clock = Clock.fixed(Instant.ofEpochSecond(102030405), ZoneId.of("UTC"));
+    private final GithubPullRequestDecorator testCase = new GithubPullRequestDecorator(githubClientFactory, markdownFormatterFactory, clock);
     private final ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
     private final AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
 
+    @BeforeEach
+    void setUp() {
+        doReturn("123").when(analysisDetails).getBranchName();
+        doReturn(Date.from(clock.instant())).when(analysisDetails).getAnalysisDate();
+        doReturn("analysis-id").when(analysisDetails).getAnalysisId();
+        doReturn("project-key").when(analysisDetails).getAnalysisProjectKey();
+        doReturn("Project Name").when(analysisDetails).getAnalysisProjectName();
+        doReturn(QualityGate.Status.OK).when(analysisDetails).getQualityGateStatus();
+        doReturn("commit-sha").when(analysisDetails).getCommitSha();
+        doReturn(IntStream.range(0, 20).mapToObj(i -> {
+            PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
+            Component component = mock(Component.class);
+            doReturn(Optional.of("path" + i)).when(analysisDetails).getSCMPathForIssue(componentIssue);
+            doReturn(component).when(componentIssue).getComponent();
+            PostAnalysisIssueVisitor.LightIssue lightIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
+            doReturn("issue message " + i).when(lightIssue).getMessage();
+            doReturn(i).when(lightIssue).getLine();
+            doReturn(Severity.ALL.get(i % Severity.ALL.size())).when(lightIssue).severity();
+            doReturn(lightIssue).when(componentIssue).getIssue();
+            return componentIssue;
+        }).collect(Collectors.toList())).when(analysisDetails).getScmReportableIssues();
+
+        doReturn("dashboard-url").when(analysisDetails).getDashboardUrl();
+        doReturn("report summary").when(analysisDetails).createAnalysisSummary(any());
+    }
 
     @Test
-    public void testName() {
+    void verifyCorrectNameReturned() {
         assertThat(testCase.alm()).isEqualTo(Collections.singletonList(ALM.GITHUB));
     }
 
     @Test
-    public void testDecorateQualityGatePropagateException() throws IOException {
+    void verifyClientExceptionPropagated() throws IOException {
         Exception dummyException = new IOException("Dummy Exception");
         doReturn(githubClient).when(githubClientFactory).createClient(any(), any());
-        doThrow(dummyException).when(githubClient).createCheckRun(any(), any(), any());
+        doThrow(dummyException).when(githubClient).createCheckRun(any(), anyBoolean());
 
         assertThatThrownBy(() -> testCase.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto))
                 .hasMessage("Could not decorate Pull Request on Github")
@@ -68,15 +112,37 @@ public class GithubPullRequestDecoratorTest {
     }
 
     @Test
-    public void testDecorateQualityGateReturnValue() throws IOException {
-        DecorationResult expectedResult = DecorationResult.builder().build();
+    void verifyCorrectArgumentsAndReturnValuesUsed() throws IOException {
+        doReturn(true).when(projectAlmSettingDto).getSummaryCommentEnabled();
+        DecorationResult expectedResult = DecorationResult.builder().withPullRequestUrl("http://github.url/repo/path/pull/123").build();
         doReturn(githubClient).when(githubClientFactory).createClient(any(), any());
-        doReturn(expectedResult).when(githubClient).createCheckRun(any(), any(), any());
+        doReturn("checkRunId").when(githubClient).createCheckRun(any(), anyBoolean());
+        doReturn("http://github.url/repo/path").when(githubClient).getRepositoryUrl();
         DecorationResult decorationResult = testCase.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
 
-        ArgumentCaptor<AnalysisDetails> argumentCaptor = ArgumentCaptor.forClass(AnalysisDetails.class);
-        verify(githubClient).createCheckRun(argumentCaptor.capture(), eq(almSettingDto), eq(projectAlmSettingDto));
-        assertEquals(analysisDetails, argumentCaptor.getValue());
-        assertThat(decorationResult).isSameAs(expectedResult);
+        ArgumentCaptor<CheckRunDetails> checkRunDetailsArgumentCaptor = ArgumentCaptor.forClass(CheckRunDetails.class);
+        verify(githubClient).createCheckRun(checkRunDetailsArgumentCaptor.capture(), eq(true));
+
+        assertThat(checkRunDetailsArgumentCaptor.getValue())
+                .usingRecursiveComparison()
+                        .isEqualTo(CheckRunDetails.builder()
+                                .withTitle("Quality Gate success")
+                                .withName("Project Name Sonarqube Results")
+                                .withExternalId("analysis-id")
+                                .withPullRequestId(123)
+                                .withStartTime(clock.instant().atZone(ZoneId.of("UTC")))
+                                .withEndTime(clock.instant().atZone(ZoneId.of("UTC")))
+                                .withDashboardUrl("dashboard-url")
+                                .withSummary("report summary")
+                                .withCommitId("commit-sha")
+                                .withAnnotations(IntStream.range(0, 20).mapToObj(i -> Annotation.builder()
+                                            .withScmPath("path" + i)
+                                            .withLine(i)
+                                            .withMessage("issue message " + i)
+                                            .withSeverity(i % 5 < 1 ? CheckAnnotationLevel.NOTICE : i % 5 > 2 ? CheckAnnotationLevel.FAILURE : CheckAnnotationLevel.WARNING)
+                                            .build()).collect(Collectors.toList()))
+                                .withCheckConclusionState(CheckConclusionState.SUCCESS)
+                                .build());
+        assertThat(decorationResult).usingRecursiveComparison().isEqualTo(expectedResult);
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Markus Heberling, Michael Clarke
+ * Copyright (C) 2019-2022 Markus Heberling, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,6 +22,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.LinkHeaderReader;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.DefaultGitlabClientFactory;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -233,7 +234,7 @@ public class GitlabMergeRequestDecoratorIntegrationTest {
         Encryption encryption = mock(Encryption.class);
         when(settings.getEncryption()).thenReturn(encryption);
         GitlabMergeRequestDecorator pullRequestDecorator =
-                new GitlabMergeRequestDecorator(server, scmInfoRepository, new DefaultGitlabClientFactory(linkHeaderReader, settings));
+                new GitlabMergeRequestDecorator(server, scmInfoRepository, new DefaultGitlabClientFactory(linkHeaderReader, settings), mock(MarkdownFormatterFactory.class));
 
 
         assertThat(pullRequestDecorator.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto).getPullRequestUrl()).isEqualTo(Optional.of("http://gitlab.example.com/my-group/my-project/merge_requests/1"));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Michael Clarke
+ * Copyright (C) 2021-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -32,6 +32,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.MergeRequestNo
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.Note;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.PipelineStatus;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.User;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -94,8 +95,9 @@ public class GitlabMergeRequestDecoratorTest {
     private final User sonarqubeUser = mock(User.class);
     private final PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
     private final DiffRefs diffRefs = mock(DiffRefs.class);
+    private final MarkdownFormatterFactory markdownFormatterFactory = mock(MarkdownFormatterFactory.class);
 
-    private final GitlabMergeRequestDecorator underTest = new GitlabMergeRequestDecorator(server, scmInfoRepository, gitlabClientFactory);
+    private final GitlabMergeRequestDecorator underTest = new GitlabMergeRequestDecorator(server, scmInfoRepository, gitlabClientFactory, markdownFormatterFactory);
 
     @Before
     public void setUp() throws IOException {


### PR DESCRIPTION
The GithubClient interface exposes a method that takes various Sonarqube
core classes and plugin constructed data as arguments and returns a
`DecorationResult`, all of which are items that the upstream decorator
should be aware of, but not the client responsible for communicating
with Github. Similarly, the `GraphqlGithubClient` had locally
constructed a `MarkdownFormatterFactory`, `DefaultGraphqlProvider`, and
`Clock` as well as requiring a Sonarqube `Server` instance for
instantiation, with the local construction requiring a second
constructor to be included purely for testing, and the `Server` instance
requiring the client have knowledge of Sonarqube's structure rather than
being passed a client configuration that had no external dependencies in
it.

This change alters the GithubClient implementation to use dependency
injection for all re-usable objects, and introduces a Github specific
object for submitting a check run, rather than relying on the
`AnlaysisDetails` object used in the plugin. The use of the settings
DTOs has been removed from the client, with the details being used in
the client factory and the relevant details being persisted in the
client from the constructor invocation. To support this, the
`MarkdownFormatterFactory` has been setup to be exposed for constructor
injection in Compute Engine components, and the `DefaultGraphqlProvider`
exposed in both Compute Engine and Server scopes.

The requirement of passing a `projectPath` inside the GithubClient has
also been removed, with the repository name and owner login being
extracted during the authentication phase and stored in the token for
the client to use them where needed.