### PR TITLE
#421: Don't trim whitespace during Markdown rendering

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactory.java
@@ -77,6 +77,6 @@ public final class MarkdownFormatterFactory extends BaseFormatterFactory {
 
     @Override
     public Formatter<Text> textFormatter() {
-        return node -> htmlEscaper().escape(node.getContent()).trim();
+        return node -> htmlEscaper().escape(node.getContent());
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactoryTest.java
@@ -96,14 +96,8 @@ class MarkdownFormatterFactoryTest {
     @Test
     void testContentTextFormatterEscapedHtml(){
         MarkdownFormatterFactory testCase = new MarkdownFormatterFactory();
-        assertEquals("&lt;p&gt; no html allowed", testCase.textFormatter().format(new Text("<p> no html allowed")));
+        assertEquals("&lt;p&gt; no html allowed  ", testCase.textFormatter().format(new Text("<p> no html allowed  ")));
         assertEquals("no html &lt;p&gt; allowed", testCase.textFormatter().format(new Text("no html <p> allowed")));
         assertEquals("&lt;/i&gt;no html &lt;p&gt; allowed&lt;i&gt;", testCase.textFormatter().format(new Text("</i>no html <p> allowed<i>")));
-    }
-
-    @Test
-    void testContentTextFormatterTrimWhitespaceAtBeginAndEnd(){
-        MarkdownFormatterFactory testCase = new MarkdownFormatterFactory();
-        assertEquals("", testCase.textFormatter().format(new Text("             ")));
     }
 }


### PR DESCRIPTION
The text renderer for the `MarkdownFormatterFactory` had been performing
a `trim` on any inputs, which caused the single whitespace entries being
added as spacers after some inline images to be removed. As the
structure of the document should be presumed to match what the
generating component requires, it's unnecessary for the renderer to
attempt to alter this structure whilst rendering to a relevant document
format. Instead, any constraints on formatting should be left to the
system rendering the generated output.