### PR TITLE
Refactor Bitbucket operations to prevent leaking scope

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -21,6 +21,7 @@ package com.github.mc1arke.sonarqube.plugin;
 import com.github.mc1arke.sonarqube.plugin.almclient.DefaultLinkHeaderReader;
 import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.DefaultAzureDevopsClientFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.DefaultBitbucketClientFactory;
+import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.HttpClientBuilderFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.DefaultGithubClientFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.RestApplicationAuthenticationProvider;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.DefaultGitlabClientFactory;
@@ -90,6 +91,7 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                     DefaultGithubClientFactory.class,
                     DefaultLinkHeaderReader.class,
                     RestApplicationAuthenticationProvider.class,
+                    HttpClientBuilderFactory.class,
                     DefaultBitbucketClientFactory.class,
                     BitbucketValidator.class,
                     GitlabValidator.class,

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Marvin Wichmann, Michael Clarke
+ * Copyright (C) 2020-2022 Marvin Wichmann, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,10 +23,8 @@ import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.CodeInsight
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.CodeInsightsReport;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.DataValue;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.ReportData;
+import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.ReportStatus;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.Repository;
-import org.sonar.api.ce.posttask.QualityGate;
-import org.sonar.db.alm.setting.AlmSettingDto;
-import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -55,21 +53,21 @@ public interface BitbucketClient {
      */
     CodeInsightsReport createCodeInsightsReport(List<ReportData> reportData,
                                                 String reportDescription, Instant creationDate, String dashboardUrl,
-                                                String logoUrl, QualityGate.Status status);
+                                                String logoUrl, ReportStatus reportStatus);
 
     /**
      * Deletes all code insights annotations for the given parameters.
      *
      * @throws IOException if the annotations cannot be deleted
      */
-    void deleteAnnotations(String project, String repo, String commitSha) throws IOException;
+    void deleteAnnotations(String commitSha) throws IOException;
 
     /**
      * Uploads CodeInsights Annotations for the given commit.
      *
      * @throws IOException if the annotations cannot be uploaded
      */
-    void uploadAnnotations(String project, String repo, String commitSha, Set<CodeInsightsAnnotation> annotations) throws IOException;
+    void uploadAnnotations(String commitSha, Set<CodeInsightsAnnotation> annotations) throws IOException;
 
     /**
      * Creates a DataValue of type DataValue.Link or DataValue.CloudLink depending on the implementation
@@ -79,7 +77,7 @@ public interface BitbucketClient {
     /**
      * Uploads the code insights report for the given commit
      */
-    void uploadReport(String project, String repo, String commitSha, CodeInsightsReport codeInsightReport) throws IOException;
+    void uploadReport(String commitSha, CodeInsightsReport codeInsightReport) throws IOException;
 
     /**
      * <p>
@@ -105,31 +103,9 @@ public interface BitbucketClient {
     AnnotationUploadLimit getAnnotationUploadLimit();
 
     /**
-     * Extract the name of the project from the relevant configuration. The project is
-     * the value that should be used in the calls that take a `project` parameter.
-     *
-     * @param almSettingDto the global `AlmSettingDto` containing the global configuration for this ALM
-     * @param projectAlmSettingDto the `ProjectAlmSettingDto` assigned to the current project
-     * @return the resolved project name.
-     */
-    String resolveProject(AlmSettingDto almSettingDto, ProjectAlmSettingDto projectAlmSettingDto);
-
-    /**
-     * Extract the name of the repository from the relevant configuration. The project is
-     * the value that should be used in the calls that take a `repository` parameter.
-     *
-     * @param almSettingDto the global `AlmSettingDto` containing the global configuration for this ALM
-     * @param projectAlmSettingDto the `ProjectAlmSettingDto` assigned to the current project
-     * @return the resolved repository name.
-     */
-    String resolveRepository(AlmSettingDto almSettingDto, ProjectAlmSettingDto projectAlmSettingDto);
-
-    /**
      * Retrieve the details of the repository from the target Bitbucket instance.
-     * @param project the project as resolved from {@link #resolveProject(AlmSettingDto, ProjectAlmSettingDto)}
-     * @param repo the repository as resolved from {@link #resolveRepository(AlmSettingDto, ProjectAlmSettingDto)}
      * @return the repository details retrieved from Bitbucket.
      */
-    Repository retrieveRepository(String project, String repo) throws IOException;
+    Repository retrieveRepository() throws IOException;
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Marvin Wichmann, Michael Clarke
+ * Copyright (C) 2020-2022 Marvin Wichmann, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,9 +22,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mc1arke.sonarqube.plugin.InvalidConfigurationException;
-import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.cloud.BitbucketCloudConfiguration;
+import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.BitbucketConfiguration;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.server.BitbucketServerConfiguration;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.apache.commons.lang3.StringUtils;
 import org.sonar.api.ce.ComputeEngineSide;
@@ -37,7 +38,8 @@ import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
 import java.util.Optional;
-import java.util.function.Supplier;
+
+import static java.lang.String.format;
 
 @ServerSide
 @ComputeEngineSide
@@ -45,15 +47,11 @@ public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
 
     private static final Logger LOGGER = Loggers.get(DefaultBitbucketClientFactory.class);
 
-    private final Supplier<OkHttpClient.Builder> okHttpClientBuilderSupplier;
+    private final HttpClientBuilderFactory httpClientBuilderFactory;
     private final Settings settings;
 
-    public DefaultBitbucketClientFactory(Settings settings) {
-        this(settings, OkHttpClient.Builder::new);
-    }
-
-    DefaultBitbucketClientFactory(Settings settings, Supplier<OkHttpClient.Builder> okHttpClientBuilderSupplier) {
-        this.okHttpClientBuilderSupplier = okHttpClientBuilderSupplier;
+    public DefaultBitbucketClientFactory(Settings settings, HttpClientBuilderFactory httpClientBuilderFactory) {
+        this.httpClientBuilderFactory = httpClientBuilderFactory;
         this.settings = settings;
     }
 
@@ -61,6 +59,10 @@ public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
     public BitbucketClient createClient(ProjectAlmSettingDto projectAlmSettingDto, AlmSettingDto almSettingDto) {
         String almRepo = Optional.ofNullable(StringUtils.trimToNull(projectAlmSettingDto.getAlmRepo()))
                 .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.PROJECT, "ALM Repo must be set in configuration"));
+
+        ObjectMapper objectMapper = createObjectMapper();
+        OkHttpClient.Builder clientBuilder = createBaseClientBuilder(httpClientBuilderFactory);
+
         if (almSettingDto.getAlm() == ALM.BITBUCKET_CLOUD) {
             String appId = Optional.ofNullable(StringUtils.trimToNull(almSettingDto.getAppId()))
                     .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "App ID must be set in configuration"));
@@ -68,7 +70,8 @@ public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
                     .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "Client ID must be set in configuration"));
             String clientSecret = Optional.ofNullable(StringUtils.trimToNull(almSettingDto.getDecryptedClientSecret(settings.getEncryption())))
                     .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "Client Secret must be set in configuration"));
-            return new BitbucketCloudClient(new BitbucketCloudConfiguration(appId, almRepo, clientId, clientSecret), createObjectMapper(), createBaseClientBuilder(okHttpClientBuilderSupplier));
+            String bearerToken = BitbucketCloudClient.negotiateBearerToken(clientId, clientSecret, objectMapper, clientBuilder.build());
+            return new BitbucketCloudClient(objectMapper, createAuthorisingClient(clientBuilder, bearerToken), new BitbucketConfiguration(appId, almRepo));
         } else {
             String almSlug = Optional.ofNullable(StringUtils.trimToNull(projectAlmSettingDto.getAlmSlug()))
                     .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.PROJECT, "ALM slug must be set in configuration"));
@@ -76,7 +79,7 @@ public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
                     .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "URL must be set in configuration"));
             String personalAccessToken = Optional.ofNullable(StringUtils.trimToNull(almSettingDto.getDecryptedPersonalAccessToken(settings.getEncryption())))
                     .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.PROJECT, "Personal access token must be set in configuration"));
-            return new BitbucketServerClient(new BitbucketServerConfiguration(almRepo, almSlug, url, personalAccessToken), createObjectMapper(), createBaseClientBuilder(okHttpClientBuilderSupplier));
+            return new BitbucketServerClient(new BitbucketServerConfiguration(almRepo, almSlug, url), objectMapper, createAuthorisingClient(clientBuilder, personalAccessToken));
         }
     }
 
@@ -86,9 +89,19 @@ public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
-    private static OkHttpClient.Builder createBaseClientBuilder(Supplier<OkHttpClient.Builder> builderSupplier) {
+    private static OkHttpClient.Builder createBaseClientBuilder(HttpClientBuilderFactory httpClientBuilderFactory) {
         HttpLoggingInterceptor httpLoggingInterceptor = new HttpLoggingInterceptor(LOGGER::debug);
         httpLoggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
-        return builderSupplier.get().addInterceptor(httpLoggingInterceptor);
+        return httpClientBuilderFactory.createClientBuilder().addInterceptor(httpLoggingInterceptor);
+    }
+
+    private static OkHttpClient createAuthorisingClient(OkHttpClient.Builder clientBuilder, String bearerToken) {
+        return clientBuilder.addInterceptor(chain -> {
+                    Request newRequest = chain.request().newBuilder()
+                            .addHeader("Authorization", format("Bearer %s", bearerToken))
+                            .addHeader("Accept", "application/json")
+                            .build();
+                    return chain.proceed(newRequest);
+                }).build();
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/HttpClientBuilderFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/HttpClientBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Michael Clarke
+ * Copyright (C) 2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,23 +16,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-package com.github.mc1arke.sonarqube.plugin.ce;
+package com.github.mc1arke.sonarqube.plugin.almclient.bitbucket;
 
-import org.junit.Test;
+import okhttp3.OkHttpClient;
+import org.sonar.api.ce.ComputeEngineSide;
+import org.sonar.api.server.ServerSide;
 
-import java.util.List;
+@ServerSide
+@ComputeEngineSide
+public class HttpClientBuilderFactory {
 
-import static org.junit.Assert.assertEquals;
-
-/**
- * @author Michael Clarke
- */
-public class CommunityReportAnalysisComponentProviderTest {
-
-    @Test
-    public void testGetComponents() {
-        List<Object> result = new CommunityReportAnalysisComponentProvider().getComponents();
-        assertEquals(14, result.size());
-        assertEquals(CommunityBranchLoaderDelegate.class, result.get(0));
+    public OkHttpClient.Builder createClientBuilder() {
+        return new OkHttpClient.Builder();
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/model/ReportStatus.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/model/ReportStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Michael Clarke
+ * Copyright (C) 2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,23 +16,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-package com.github.mc1arke.sonarqube.plugin.ce;
+package com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model;
 
-import org.junit.Test;
-
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-
-/**
- * @author Michael Clarke
- */
-public class CommunityReportAnalysisComponentProviderTest {
-
-    @Test
-    public void testGetComponents() {
-        List<Object> result = new CommunityReportAnalysisComponentProvider().getComponents();
-        assertEquals(14, result.size());
-        assertEquals(CommunityBranchLoaderDelegate.class, result.get(0));
-    }
+public enum ReportStatus {
+    PASSED, FAILED
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/model/server/BitbucketServerConfiguration.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/model/server/BitbucketServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Michael Clarke
+ * Copyright (C) 2021-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,19 +23,13 @@ import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.BitbucketCo
 public class BitbucketServerConfiguration extends BitbucketConfiguration {
 
     private final String url;
-    private final String personalAccessToken;
 
-    public BitbucketServerConfiguration(String almRepo, String almSlug, String url, String personalAccessToken) {
+    public BitbucketServerConfiguration(String almRepo, String almSlug, String url) {
         super(almRepo, almSlug);
         this.url = url;
-        this.personalAccessToken = personalAccessToken;
     }
 
     public String getUrl() {
         return url;
-    }
-
-    public String getPersonalAccessToken() {
-        return personalAccessToken;
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2019-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,6 +21,7 @@ package com.github.mc1arke.sonarqube.plugin.ce;
 import com.github.mc1arke.sonarqube.plugin.almclient.DefaultLinkHeaderReader;
 import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.DefaultAzureDevopsClientFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.DefaultBitbucketClientFactory;
+import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.HttpClientBuilderFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.DefaultGithubClientFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.RestApplicationAuthenticationProvider;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.DefaultGitlabClientFactory;
@@ -45,7 +46,7 @@ public class CommunityReportAnalysisComponentProvider implements ReportAnalysisC
         return Arrays.asList(CommunityBranchLoaderDelegate.class, PullRequestPostAnalysisTask.class,
                              PostAnalysisIssueVisitor.class, DefaultLinkHeaderReader.class,
                              DefaultGithubClientFactory.class, RestApplicationAuthenticationProvider.class, GithubPullRequestDecorator.class,
-                             DefaultBitbucketClientFactory.class, BitbucketPullRequestDecorator.class,
+                             HttpClientBuilderFactory.class, DefaultBitbucketClientFactory.class, BitbucketPullRequestDecorator.class,
                              DefaultGitlabClientFactory.class, GitlabMergeRequestDecorator.class,
                              DefaultAzureDevopsClientFactory.class, AzureDevOpsPullRequestDecorator.class);
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -68,6 +68,9 @@ import java.util.stream.Collectors;
 public class AnalysisDetails {
 
     private static final List<String> CLOSED_ISSUE_STATUS = Arrays.asList(Issue.STATUS_CLOSED, Issue.STATUS_RESOLVED);
+    private static final List<String> OPEN_ISSUE_STATUSES =
+            Issue.STATUSES.stream().filter(s -> !CLOSED_ISSUE_STATUS.contains(s))
+                    .collect(Collectors.toList());
 
     private static final List<BigDecimal> COVERAGE_LEVELS =
             Arrays.asList(BigDecimal.valueOf(100), BigDecimal.valueOf(90), BigDecimal.valueOf(60),
@@ -397,6 +400,15 @@ public class AnalysisDetails {
 
     public Optional<BigDecimal> getCoverage(){
         return findMeasure(CoreMetrics.COVERAGE_KEY).map(Measure::getDoubleValue).map(BigDecimal::new);
+    }
+
+    public List<PostAnalysisIssueVisitor.ComponentIssue> getScmReportableIssues() {
+        return postAnalysisIssueVisitor.getIssues().stream()
+                .filter(i -> getSCMPathForIssue(i).isPresent())
+                .filter(i -> i.getComponent().getType() == Component.Type.FILE)
+                .filter(i -> i.getIssue().resolution() == null)
+                .filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().status()))
+                .collect(Collectors.toList());
     }
 
     public static class BranchDetails {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2019-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.annotation.CheckForNull;
 
@@ -38,7 +39,9 @@ public class PostAnalysisIssueVisitor extends IssueVisitor {
 
     @Override
     public void onIssue(Component component, DefaultIssue defaultIssue) {
-        collectedIssues.add(new ComponentIssue(component, defaultIssue));
+        collectedIssues.add(new ComponentIssue(component, Optional.ofNullable(defaultIssue)
+                .map(LightIssue::new)
+                .orElse(null)));
     }
 
     public List<ComponentIssue> getIssues() {
@@ -50,11 +53,10 @@ public class PostAnalysisIssueVisitor extends IssueVisitor {
         private final Component component;
         private final LightIssue issue;
 
-        ComponentIssue(Component component, DefaultIssue issue) {
+        ComponentIssue(Component component, LightIssue issue) {
             super();
             this.component = component;
-            this.issue = (issue != null) ? new LightIssue(issue) : null;
-            // the null test is to please PostAnalysisIssueVisitorTest.checkAllIssuesCollected()
+            this.issue = issue;
         }
 
         public Component getComponent() {
@@ -85,7 +87,7 @@ public class PostAnalysisIssueVisitor extends IssueVisitor {
         private final DbIssues.Locations locations;
         private final RuleKey ruleKey;
 
-        private LightIssue(DefaultIssue issue) {
+        LightIssue(DefaultIssue issue) {
             this.effortInMinutes = issue.effortInMinutes();
             this.key = issue.key();
             this.line = issue.getLine();

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Mathias Åhsberg, Michael Clarke
+ * Copyright (C) 2020-2022 Mathias Åhsberg, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,6 +26,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.CodeInsight
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.CodeInsightsReport;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.DataValue;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.ReportData;
+import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.ReportStatus;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
@@ -37,7 +38,6 @@ import org.sonar.api.rule.Severity;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonar.ce.task.projectanalysis.component.Component;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
@@ -63,10 +63,6 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
 
     private static final DecorationResult DEFAULT_DECORATION_RESULT = DecorationResult.builder().build();
 
-    private static final List<String> OPEN_ISSUE_STATUSES =
-            Issue.STATUSES.stream().filter(s -> !Issue.STATUS_CLOSED.equals(s) && !Issue.STATUS_RESOLVED.equals(s))
-                    .collect(Collectors.toList());
-
     private final BitbucketClientFactory bitbucketClientFactory;
 
     public BitbucketPullRequestDecorator(BitbucketClientFactory bitbucketClientFactory) {
@@ -82,22 +78,18 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                 return DEFAULT_DECORATION_RESULT;
             }
 
-            String project = client.resolveProject(almSettingDto, projectAlmSettingDto);
-            String repo = client.resolveRepository(almSettingDto, projectAlmSettingDto);
-
             CodeInsightsReport codeInsightsReport = client.createCodeInsightsReport(
                     toReport(client, analysisDetails),
                     reportDescription(analysisDetails),
                     analysisDetails.getAnalysisDate().toInstant(),
                     analysisDetails.getDashboardUrl(),
                     format("%s/common/icon.png", analysisDetails.getBaseImageUrl()),
-                    analysisDetails.getQualityGateStatus()
+                    analysisDetails.getQualityGateStatus() == QualityGate.Status.OK ? ReportStatus.PASSED : ReportStatus.FAILED
             );
 
-            client.uploadReport(project, repo,
-                    analysisDetails.getCommitSha(), codeInsightsReport);
+            client.uploadReport(analysisDetails.getCommitSha(), codeInsightsReport);
 
-            updateAnnotations(client, project, repo, analysisDetails);
+            updateAnnotations(client, analysisDetails);
         } catch (IOException e) {
             LOGGER.error("Could not decorate pull request for project {}", analysisDetails.getAnalysisProjectKey(), e);
         }
@@ -124,17 +116,14 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
         return reportData;
     }
 
-    private void updateAnnotations(BitbucketClient client, String project, String repo, AnalysisDetails analysisDetails) throws IOException {
+    private void updateAnnotations(BitbucketClient client, AnalysisDetails analysisDetails) throws IOException {
         final AtomicInteger chunkCounter = new AtomicInteger(0);
 
-        client.deleteAnnotations(project, repo, analysisDetails.getCommitSha());
+        client.deleteAnnotations(analysisDetails.getCommitSha());
 
         AnnotationUploadLimit uploadLimit = client.getAnnotationUploadLimit();
 
-        Map<Integer, Set<CodeInsightsAnnotation>> annotationChunks = analysisDetails.getPostAnalysisIssueVisitor().getIssues().stream()
-                .filter(i -> i.getComponent().getReportAttributes().getScmPath().isPresent())
-                .filter(i -> i.getComponent().getType() == Component.Type.FILE)
-                .filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().status()))
+        Map<Integer, Set<CodeInsightsAnnotation>> annotationChunks = analysisDetails.getScmReportableIssues().stream()
                 .filter(i -> !(i.getIssue().type() == RuleType.SECURITY_HOTSPOT && Issue.SECURITY_HOTSPOT_RESOLUTIONS
                     .contains(i.getIssue().resolution())))
                 .sorted(Comparator.comparing(a -> Severity.ALL.indexOf(a.getIssue().severity())))
@@ -158,7 +147,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                     break;
                 }
 
-                client.uploadAnnotations(project, repo, analysisDetails.getCommitSha(), annotations);
+                client.uploadAnnotations(analysisDetails.getCommitSha(), annotations);
             } catch (BitbucketException e) {
                 if (e.isError(BitbucketException.PAYLOAD_TOO_LARGE)) {
                     LOGGER.warn("The annotations will be truncated since the maximum number of annotations for this report has been reached.");
@@ -174,7 +163,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
         return (chunkCounter * uploadLimit.getAnnotationBatchSize()) > uploadLimit.getTotalAllowedAnnotations();
     }
 
-    private String toBitbucketSeverity(String severity) {
+    private static String toBitbucketSeverity(String severity) {
         if (severity == null) {
             return "LOW";
         }
@@ -189,7 +178,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
         }
     }
 
-    private String toBitbucketType(RuleType sonarqubeType) {
+    private static String toBitbucketType(RuleType sonarqubeType) {
         switch (sonarqubeType) {
             case SECURITY_HOTSPOT:
             case VULNERABILITY:
@@ -203,24 +192,24 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
         }
     }
 
-    private ReportData securityReport(Long vulnerabilities, Long hotspots) {
+    private static ReportData securityReport(Long vulnerabilities, Long hotspots) {
         String vulnerabilityDescription = vulnerabilities == 1 ? "Vulnerability" : "Vulnerabilities";
         String hotspotDescription = hotspots == 1 ? "Hotspot" : "Hotspots";
         String security = format("%d %s (and %d %s)", vulnerabilities, vulnerabilityDescription, hotspots, hotspotDescription);
         return new ReportData("Security", new DataValue.Text(security));
     }
 
-    private ReportData reliabilityReport(Long bugs) {
+    private static ReportData reliabilityReport(Long bugs) {
         String description = bugs == 1 ? "Bug" : "Bugs";
         return new ReportData("Reliability", new DataValue.Text(format("%d %s", bugs, description)));
     }
 
-    private ReportData maintainabilityReport(Long codeSmells) {
+    private static ReportData maintainabilityReport(Long codeSmells) {
         String description = codeSmells == 1 ? "Code Smell" : "Code Smells";
         return new ReportData("Maintainability", new DataValue.Text(format("%d %s", codeSmells, description)));
     }
 
-    private String reportDescription(AnalysisDetails details) {
+    private static String reportDescription(AnalysisDetails details) {
         String header = details.getQualityGateStatus() == QualityGate.Status.OK ? "Quality Gate passed" : "Quality Gate failed";
         String body = details.findFailedConditions().stream()
                 .map(AnalysisDetails::format)
@@ -229,7 +218,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
         return format("%s%n%s", header, body);
     }
 
-    private BigDecimal newCoverage(AnalysisDetails details) {
+    private static BigDecimal newCoverage(AnalysisDetails details) {
         return details.findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)
                 .filter(condition -> condition.getStatus() != QualityGate.EvaluationStatus.NO_VALUE)
                 .map(QualityGate.Condition::getValue)
@@ -237,7 +226,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                 .orElse(BigDecimal.ZERO);
     }
 
-    private BigDecimal newDuplication(AnalysisDetails details) {
+    private static BigDecimal newDuplication(AnalysisDetails details) {
         return details.findQualityGateCondition(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY)
                 .filter(condition -> condition.getStatus() != QualityGate.EvaluationStatus.NO_VALUE)
                 .map(QualityGate.Condition::getValue)

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/validator/BitbucketValidator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/validator/BitbucketValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Michael Clarke
+ * Copyright (C) 2021-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -56,7 +56,7 @@ public class BitbucketValidator implements Validator {
             throw new InvalidConfigurationException(InvalidConfigurationException.Scope.PROJECT, "Could not create Bitbucket client - " + ex.getMessage(), ex);
         }
         try {
-            bitbucketClient.retrieveRepository(bitbucketClient.resolveProject(almSettingDto, projectAlmSettingDto), bitbucketClient.resolveRepository(almSettingDto, projectAlmSettingDto));
+            bitbucketClient.retrieveRepository();
         } catch (IOException | RuntimeException ex) {
             throw new InvalidConfigurationException(InvalidConfigurationException.Scope.PROJECT, "Could not retrieve repository details from Bitbucket - " + ex.getMessage(), ex);
         }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -118,7 +118,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(22, argumentCaptor.getAllValues().size());
+        assertEquals(23, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Michael Clarke
+ * Copyright (C) 2021-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -24,6 +24,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.AnnotationU
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.CodeInsightsAnnotation;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.CodeInsightsReport;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.DataValue;
+import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.ReportStatus;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.server.Annotation;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.server.BitbucketServerConfiguration;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.server.CreateReportRequest;
@@ -43,7 +44,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.sonar.api.ce.posttask.QualityGate;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -74,7 +74,7 @@ public class BitbucketServerClientUnitTest {
     @Before
     public void before() {
         BitbucketServerConfiguration
-                config = new BitbucketServerConfiguration("repo", "slug", "https://my-server.org", "token");
+                config = new BitbucketServerConfiguration("repository", "slug", "https://my-server.org");
         underTest = new BitbucketServerClient(config, mapper, client);
     }
 
@@ -240,13 +240,13 @@ public class BitbucketServerClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when
-        underTest.uploadReport("project", "repository", "commit", report);
+        underTest.uploadReport("commit", report);
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("PUT", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube", request.url().toString());
     }
 
     @Test
@@ -264,7 +264,7 @@ public class BitbucketServerClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when,then
-        assertThatThrownBy(() -> underTest.uploadReport("project", "repository", "commit", report))
+        assertThatThrownBy(() -> underTest.uploadReport("commit", report))
                 .isInstanceOf(BitbucketException.class);
     }
 
@@ -295,7 +295,7 @@ public class BitbucketServerClientUnitTest {
 
 
         // when,then
-        assertThatThrownBy(() -> underTest.uploadReport("project", "repository", "commit", report))
+        assertThatThrownBy(() -> underTest.uploadReport("commit", report))
                 .isInstanceOf(BitbucketException.class)
                 .hasMessage("error!")
                 .extracting(e -> ((BitbucketException) e).isError(400))
@@ -323,13 +323,13 @@ public class BitbucketServerClientUnitTest {
         when(response.isSuccessful()).thenReturn(true);
 
         // when
-        underTest.uploadAnnotations("project", "repository", "commit", annotations);
+        underTest.uploadAnnotations("commit", annotations);
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("POST", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
 
         try (Buffer bodyContent = new Buffer()) {
             request.body().writeTo(bodyContent);
@@ -343,7 +343,7 @@ public class BitbucketServerClientUnitTest {
         Set<CodeInsightsAnnotation> annotations = Sets.newHashSet();
 
         // when
-        underTest.uploadAnnotations("project", "repository", "commit", annotations);
+        underTest.uploadAnnotations("commit", annotations);
 
         // then
         verify(client, never()).newCall(any());
@@ -361,13 +361,13 @@ public class BitbucketServerClientUnitTest {
         when(response.isSuccessful()).thenReturn(true);
 
         // when
-        underTest.deleteAnnotations("project", "repository", "commit");
+        underTest.deleteAnnotations("commit");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("DELETE", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
     }
 
     @Test
@@ -413,7 +413,7 @@ public class BitbucketServerClientUnitTest {
         // given
 
         // when
-        CodeInsightsReport result = underTest.createCodeInsightsReport(new ArrayList<>(), "reportDescription", Instant.now(), "dashboardUrl", "logoUrl", QualityGate.Status.ERROR);
+        CodeInsightsReport result = underTest.createCodeInsightsReport(new ArrayList<>(), "reportDescription", Instant.now(), "dashboardUrl", "logoUrl", ReportStatus.FAILED);
 
         // then
         assertTrue(result instanceof CreateReportRequest);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/HttpClientBuilderFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/HttpClientBuilderFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Michael Clarke
+ * Copyright (C) 2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,26 +16,21 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-package com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.cloud;
+package com.github.mc1arke.sonarqube.plugin.almclient.bitbucket;
 
-import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.BitbucketConfiguration;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
 
-public class BitbucketCloudConfiguration extends BitbucketConfiguration {
+import static org.assertj.core.api.Assertions.assertThat;
 
-    private final String clientId;
-    private final String secret;
+class HttpClientBuilderFactoryTest {
 
-    public BitbucketCloudConfiguration(String repository, String project, String clientId, String secret) {
-        super(repository, project);
-        this.clientId = clientId;
-        this.secret = secret;
-    }
+    @Test
+    void verifyNotSameInstanceReturnedByFactory() {
+        HttpClientBuilderFactory underTest = new HttpClientBuilderFactory();
+        OkHttpClient.Builder builder1 = underTest.createClientBuilder();
+        OkHttpClient.Builder builder2 = underTest.createClientBuilder();
 
-    public String getClientId() {
-        return clientId;
-    }
-
-    public String getSecret() {
-        return secret;
+        assertThat(builder1).isNotSameAs(builder2);
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2019-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -57,7 +57,7 @@ public class PostAnalysisIssueVisitorTest {
         for (int i = 0; i < 100; i++) {
             DefaultIssue issue = (i == 10 ? null : mock(DefaultIssue.class));
             Component component = (i == 5 ? null : mock(Component.class));
-            expected.add(new PostAnalysisIssueVisitor.ComponentIssue(component, issue));
+            expected.add(new PostAnalysisIssueVisitor.ComponentIssue(component, null == issue ? null : new PostAnalysisIssueVisitor.LightIssue(issue)));
 
             testCase.onIssue(component, issue);
         }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/validator/BitbucketValidatorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/validator/BitbucketValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Michael Clarke
+ * Copyright (C) 2021-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -72,7 +72,7 @@ class BitbucketValidatorTest {
     void testInvalidConfigurationExceptionThrownIfRetrieveRepositoryFails() throws IOException {
         BitbucketValidator underTest = new BitbucketValidator(bitbucketClientFactory);
         BitbucketClient bitbucketClient = mock(BitbucketClient.class);
-        when(bitbucketClient.retrieveRepository(any(), any())).thenThrow(new IOException("dummy"));
+        when(bitbucketClient.retrieveRepository()).thenThrow(new IOException("dummy"));
         when(bitbucketClientFactory.createClient(any(), any())).thenReturn(bitbucketClient);
         assertThatThrownBy(() -> underTest.validate(projectAlmSettingDto, almSettingDto))
                 .isInstanceOf(InvalidConfigurationException.class)


### PR DESCRIPTION
The Bitbucket clients require different properties to be used from the
relevant configuration DTOs depending on whether Bitbucket cloud or
server are being used, with the management of the property retrieval
being delegated to the relevant client implementation. However, this
requires each client to reference DTO classes from Sonarqube core, where
the clients should really only interact with their own models.

As the work on retrieving the relevant details has already been
performed in the `DefaultBitbucketClientFactory`, the logic for
performing the retrieval has been removed from each client
implementations, and the calculated values are passed into the
constructor for each client instead. This does make each client instance
constrained to a single  repository, but given the way the clients are
used within the decorators and validators, this isn't an issue.
The client API has therefore been altered to remove the references to
project and repository in any method signatures since the client now
retrieves this internally from the client configuration.

The clients have also been altered now to depend directly on the status
from the Quality Gate, with a new enum being used by the client to
indicate the report status, and the decorator performing the mapping
between the Quality Gate and report status.

Finally, to allow for the `DefaultBitbucketClientFactory` to have a
single constructor rather than a test-specific constructor, the facility
for creating an Http Client has been moved into an
`HttpClientBuilderFactory` and this new class configured for injection
in both the Compute Engine and server components.