### PR TITLE
Move report generation out of AnalysisDetails

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
@@ -34,6 +34,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket.BitbucketPul
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.github.GithubPullRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabMergeRequestDecorator;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report.ReportGenerator;
 import org.sonar.ce.task.projectanalysis.container.ReportAnalysisComponentProvider;
 
 import java.util.Arrays;
@@ -47,7 +48,7 @@ public class CommunityReportAnalysisComponentProvider implements ReportAnalysisC
     @Override
     public List<Object> getComponents() {
         return Arrays.asList(CommunityBranchLoaderDelegate.class, PullRequestPostAnalysisTask.class,
-                             PostAnalysisIssueVisitor.class, DefaultLinkHeaderReader.class,
+                             PostAnalysisIssueVisitor.class, DefaultLinkHeaderReader.class, ReportGenerator.class,
                              MarkdownFormatterFactory.class, DefaultGraphqlProvider.class, DefaultUrlConnectionProvider.class,
                              DefaultGithubClientFactory.class, RestApplicationAuthenticationProvider.class, GithubPullRequestDecorator.class,
                              HttpClientBuilderFactory.class, DefaultBitbucketClientFactory.class, BitbucketPullRequestDecorator.class,

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetails.java
@@ -19,481 +19,101 @@
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
 
 
-import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Document;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Heading;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Image;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Link;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.ListItem;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Node;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Paragraph;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Text;
-import org.apache.commons.lang.StringUtils;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.sonar.api.ce.posttask.Analysis;
+import org.sonar.api.ce.posttask.PostProjectAnalysisTask;
 import org.sonar.api.ce.posttask.Project;
 import org.sonar.api.ce.posttask.QualityGate;
-import org.sonar.api.ce.posttask.QualityGate.EvaluationStatus;
-import org.sonar.api.ce.posttask.ScannerContext;
-import org.sonar.api.config.Configuration;
 import org.sonar.api.issue.Issue;
-import org.sonar.api.measures.CoreMetrics;
-import org.sonar.api.measures.Metric;
-import org.sonar.api.rules.RuleType;
 import org.sonar.ce.task.projectanalysis.component.Component;
-import org.sonar.ce.task.projectanalysis.component.TreeRootHolder;
-import org.sonar.ce.task.projectanalysis.measure.Measure;
-import org.sonar.ce.task.projectanalysis.measure.MeasureRepository;
-import org.sonar.ce.task.projectanalysis.metric.MetricRepository;
-import org.sonar.server.measure.Rating;
 
-import java.io.UnsupportedEncodingException;
-import java.math.BigDecimal;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class AnalysisDetails {
 
-    private static final List<String> CLOSED_ISSUE_STATUS = Arrays.asList(Issue.STATUS_CLOSED, Issue.STATUS_RESOLVED);
     private static final List<String> OPEN_ISSUE_STATUSES =
-            Issue.STATUSES.stream().filter(s -> !CLOSED_ISSUE_STATUS.contains(s))
+            Issue.STATUSES.stream().filter(s -> !Issue.STATUS_CLOSED.equals(s) && !Issue.STATUS_RESOLVED.equals(s))
                     .collect(Collectors.toList());
 
-    private static final List<BigDecimal> COVERAGE_LEVELS =
-            Arrays.asList(BigDecimal.valueOf(100), BigDecimal.valueOf(90), BigDecimal.valueOf(60),
-                          BigDecimal.valueOf(50), BigDecimal.valueOf(40), BigDecimal.valueOf(25));
-    private static final List<DuplicationMapping> DUPLICATION_LEVELS =
-            Arrays.asList(new DuplicationMapping(BigDecimal.valueOf(3), "3"),
-                          new DuplicationMapping(BigDecimal.valueOf(5), "5"),
-                          new DuplicationMapping(BigDecimal.TEN, "10"),
-                          new DuplicationMapping(BigDecimal.valueOf(20), "20"));
-
-    private final String publicRootURL;
-    private final BranchDetails branchDetails;
-    private final MeasuresHolder measuresHolder;
-    private final PostAnalysisIssueVisitor postAnalysisIssueVisitor;
+    private final String pullRequestId;
+    private final String commitId;
+    private final List<PostAnalysisIssueVisitor.ComponentIssue> issues;
     private final QualityGate qualityGate;
-    private final Analysis analysis;
-    private final Project project;
-    private final ScannerContext scannerContext;
-    private final Configuration configuration;
+    private final PostProjectAnalysisTask.ProjectAnalysis projectAnalysis;
 
-    AnalysisDetails(BranchDetails branchDetails, PostAnalysisIssueVisitor postAnalysisIssueVisitor,
-                    QualityGate qualityGate, MeasuresHolder measuresHolder, Analysis analysis, Project project,
-                    Configuration configuration, String publicRootURL, ScannerContext scannerContext) {
+    AnalysisDetails(String pullRequestId, String commitId, List<PostAnalysisIssueVisitor.ComponentIssue> issues,
+                    QualityGate qualityGate, PostProjectAnalysisTask.ProjectAnalysis projectAnalysis) {
         super();
-        this.publicRootURL = publicRootURL;
-        this.branchDetails = branchDetails;
-        this.measuresHolder = measuresHolder;
-        this.postAnalysisIssueVisitor = postAnalysisIssueVisitor;
+        this.pullRequestId = pullRequestId;
+        this.commitId = commitId;
+        this.issues = issues;
         this.qualityGate = qualityGate;
-        this.analysis = analysis;
-        this.project = project;
-        this.scannerContext = scannerContext;
-        this.configuration = configuration;
+        this.projectAnalysis = projectAnalysis;
     }
 
-    public String getBranchName() {
-        return branchDetails.getBranchName();
+    public String getPullRequestId() {
+        return pullRequestId;
     }
 
     public String getCommitSha() {
-        return branchDetails.getCommitId();
-    }
-
-    public String getDashboardUrl() {
-        return publicRootURL + "/dashboard?id=" + encode(project.getKey()) + "&pullRequest=" + branchDetails.getBranchName();
-    }
-
-    public String getIssueUrl(PostAnalysisIssueVisitor.LightIssue issue) {
-        if (issue.type() == RuleType.SECURITY_HOTSPOT) {
-            return String.format("%s/security_hotspots?id=%s&pullRequest=%s&hotspots=%s", publicRootURL, encode(project.getKey()), branchDetails.getBranchName(), issue.key());
-        } else {
-            return String.format("%s/project/issues?id=%s&pullRequest=%s&issues=%s&open=%s", publicRootURL, encode(project.getKey()), branchDetails.getBranchName(), issue.key(), issue.key());
-        }
-    }
-
-    public Optional<ProjectIssueIdentifier> parseIssueIdFromUrl(String issueUrl) {
-        URI url = URI.create(issueUrl);
-        List<NameValuePair> parameters = URLEncodedUtils.parse(url, StandardCharsets.UTF_8);
-        Optional<String> optionalProjectId = parameters.stream()
-                .filter(parameter -> "id".equals(parameter.getName()))
-                .map(NameValuePair::getValue)
-                .findFirst();
-
-        if (optionalProjectId.isEmpty()) {
-            return Optional.empty();
-        }
-
-        String projectId = optionalProjectId.get();
-
-        if (url.getPath().endsWith("/dashboard")) {
-            return Optional.of(new ProjectIssueIdentifier(projectId, "decorator-summary-comment"));
-        } else if (url.getPath().endsWith("security_hotspots")) {
-            return parameters.stream()
-                    .filter(parameter -> "hotspots".equals(parameter.getName()))
-                    .map(NameValuePair::getValue)
-                    .findFirst()
-                    .map(issueId -> new ProjectIssueIdentifier(projectId, issueId));
-        } else {
-            return parameters.stream()
-                    .filter(parameter -> "issues".equals(parameter.getName()))
-                    .map(NameValuePair::getValue)
-                    .findFirst()
-                    .map(issueId -> new ProjectIssueIdentifier(projectId, issueId));
-        }
+        return commitId;
     }
 
     public QualityGate.Status getQualityGateStatus() {
         return qualityGate.getStatus();
     }
 
-    public String getRuleUrlWithRuleKey(String ruleKey) {
-        return publicRootURL + "/coding_rules?open=" + encode(ruleKey) + "&rule_key=" + encode(ruleKey);
-    }
-
-    public Optional<String> getScannerProperty(String propertyName) {
-        return Optional.ofNullable(scannerContext.getProperties().get(propertyName));
-    }
-
-    public String createAnalysisSummary(FormatterFactory formatterFactory) {
-
-        BigDecimal newCoverage = getNewCoverage().orElse(null);
-        BigDecimal coverage = getCoverage().orElse(null);
-
-        BigDecimal newDuplications = findQualityGateCondition(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY)
-                .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
-                .map(QualityGate.Condition::getValue)
-                .map(BigDecimal::new)
-                .orElse(null);
-
-        double duplications =
-                findMeasure(CoreMetrics.DUPLICATED_LINES_DENSITY_KEY).map(Measure::getDoubleValue).orElse(0D);
-
-        NumberFormat decimalFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
-
-        Map<RuleType, Long> issueCounts = countRuleByType();
-        long issueTotal = issueCounts.values().stream().mapToLong(l -> l).sum();
-
-        List<QualityGate.Condition> failedConditions = findFailedConditions();
-
-        String baseImageUrl = getBaseImageUrl();
-
-        Document document = new Document(new Paragraph((QualityGate.Status.OK == getQualityGateStatus() ?
-                                                        new Image("Passed", baseImageUrl +
-                                                                            "/checks/QualityGateBadge/passed.svg?sanitize=true") :
-                                                        new Image("Failed", baseImageUrl +
-                                                                            "/checks/QualityGateBadge/failed.svg?sanitize=true"))),
-                                         failedConditions.isEmpty() ? new Text("") :
-                                         new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
-                                                 com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,
-                                                 failedConditions.stream().map(c -> new ListItem(new Text(format(c))))
-                                                         .toArray(ListItem[]::new)),
-                                         new Heading(1, new Text("Analysis Details")), new Heading(2, new Text(
-                issueTotal + " Issue" + (issueCounts.values().stream().mapToLong(l -> l).sum() == 1 ? "" : "s"))),
-                                         new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
-                                                 com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,
-                                                 new ListItem(new Image("Bug",
-                                                                        baseImageUrl + "/common/bug.svg?sanitize=true"),
-                                                              new Text(" "), new Text(
-                                                         pluralOf(issueCounts.get(RuleType.BUG), "Bug", "Bugs"))),
-                                                 new ListItem(new Image("Vulnerability", baseImageUrl +
-                                                                                         "/common/vulnerability.svg?sanitize=true"),
-                                                              new Text(" "), new Text(pluralOf(
-                                                         issueCounts.get(RuleType.VULNERABILITY) +
-                                                         issueCounts.get(RuleType.SECURITY_HOTSPOT), "Vulnerability",
-                                                         "Vulnerabilities"))), new ListItem(new Image("Code Smell",
-                                                                                                      baseImageUrl +
-                                                                                                      "/common/code_smell.svg?sanitize=true"),
-                                                                                            new Text(" "), new Text(
-                                                 pluralOf(issueCounts.get(RuleType.CODE_SMELL), "Code Smell",
-                                                          "Code Smells")))),
-                                         new Heading(2, new Text("Coverage and Duplications")),
-                                         new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
-                                                 com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,
-                                                 new ListItem(createCoverageImage(newCoverage, baseImageUrl),
-                                                              new Text(" "), new Text(
-                                                         Optional.ofNullable(newCoverage).map(decimalFormat::format)
-                                                                 .map(i -> i + "% Coverage")
-                                                                 .orElse("No coverage information") + " (" +
-                                                         decimalFormat.format(Optional.ofNullable(coverage).orElse(BigDecimal.valueOf(0))) + "% Estimated after merge)")),
-                                                 new ListItem(createDuplicateImage(newDuplications, baseImageUrl),
-                                                              new Text(" "), new Text(
-                                                         Optional.ofNullable(newDuplications).map(decimalFormat::format)
-                                                                 .map(i -> i + "% Duplicated Code")
-                                                                 .orElse("No duplication information") + " (" +
-                                                         decimalFormat.format(duplications) +
-                                                         "% Estimated after merge)"))),
-                                         new Paragraph(new Text(String.format("**Project ID:** %s", project.getKey()))),
-                                         new Paragraph(new Link(getDashboardUrl(), new Text("View in SonarQube"))));
-
-        return formatterFactory.documentFormatter().format(document);
-    }
-
-    public String createAnalysisIssueSummary(PostAnalysisIssueVisitor.ComponentIssue componentIssue, FormatterFactory formatterFactory) {
-        final PostAnalysisIssueVisitor.LightIssue issue = componentIssue.getIssue();
-
-        String baseImageUrl = getBaseImageUrl();
-
-        Long effort = issue.effortInMinutes();
-        Node effortNode = (null == effort ? new Text("") : new Paragraph(new Text(String.format("**Duration (min):** %s", effort))));
-
-        String resolution = issue.resolution();
-        Node resolutionNode = (StringUtils.isBlank(resolution) ? new Text("") : new Paragraph(new Text(String.format("**Resolution:** %s ", resolution))));
-
-        Document document = new Document(
-                new Paragraph(new Text(String.format("**Type:** %s ", issue.type().name())), new Image(issue.type().name(), String.format("%s/checks/IssueType/%s.svg?sanitize=true", baseImageUrl, issue.type().name().toLowerCase()))),
-                new Paragraph(new Text(String.format("**Severity:** %s ", issue.severity())), new Image(issue.severity(), String.format("%s/checks/Severity/%s.svg?sanitize=true", baseImageUrl, issue.severity().toLowerCase()))),
-                new Paragraph(new Text(String.format("**Message:** %s", issue.getMessage()))),
-                effortNode,
-                resolutionNode,
-                new Paragraph(new Text(String.format("**Project ID:** %s **Issue ID:** %s", project.getKey(), issue.key()))),
-                new Paragraph(new Link(getIssueUrl(issue), new Text("View in SonarQube")))
-        );
-        return formatterFactory.documentFormatter().format(document);
-    }
-
-    public String getBaseImageUrl() {
-        return configuration.get(CommunityBranchPlugin.IMAGE_URL_BASE)
-                .orElse(publicRootURL + "/static/communityBranchPlugin")
-                .replaceAll("/*$", "");
-    }
-
-    public Optional<String> getSCMPathForIssue(PostAnalysisIssueVisitor.ComponentIssue componentIssue) {
-        Component component = componentIssue.getComponent();
-        if (Component.Type.FILE.equals(component.getType())) {
-            return component.getReportAttributes().getScmPath();
-        }
-        return Optional.empty();
-    }
-
-    public PostAnalysisIssueVisitor getPostAnalysisIssueVisitor() {
-        return postAnalysisIssueVisitor;
-    }
-
-    private static String encode(String original) {
-        try {
-            return URLEncoder.encode(original, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException("Standard charset not found in JVM", e);
-        }
-    }
-
-    private static Image createCoverageImage(BigDecimal coverage, String baseImageUrl) {
-        if (null == coverage) {
-            return new Image("No coverage information",
-                             baseImageUrl + "/checks/CoverageChart/NoCoverageInfo.svg?sanitize=true");
-        }
-        BigDecimal matchedLevel = BigDecimal.ZERO;
-        for (BigDecimal level : COVERAGE_LEVELS) {
-            if (coverage.compareTo(level) >= 0) {
-                matchedLevel = level;
-                break;
-            }
-        }
-        return new Image(matchedLevel + " percent coverage",
-                         baseImageUrl + "/checks/CoverageChart/" + matchedLevel + ".svg?sanitize=true");
-    }
-
-    private static Image createDuplicateImage(BigDecimal duplications, String baseImageUrl) {
-        if (null == duplications) {
-            return new Image("No duplication information",
-                             baseImageUrl + "/checks/Duplications/NoDuplicationInfo.svg?sanitize=true");
-        }
-        String matchedLevel = "20plus";
-        for (DuplicationMapping level : DUPLICATION_LEVELS) {
-            if (level.getDuplicationLevel().compareTo(duplications) >= 0) {
-                matchedLevel = level.getImageName();
-                break;
-            }
-        }
-        return new Image(matchedLevel + " percent duplication",
-                         baseImageUrl + "/checks/Duplications/" + matchedLevel + ".svg?sanitize=true");
-    }
-
-
-    public Date getAnalysisDate() {
-        return analysis.getDate();
-    }
-
-    public String getAnalysisId() {
-        return analysis.getAnalysisUuid();
-    }
-
-    public String getAnalysisProjectKey() {
-        return project.getKey();
-    }
-
-    public String getAnalysisProjectName() {
-        return project.getName();
-    }
-
-    public List<QualityGate.Condition> findFailedConditions() {
-        return qualityGate.getConditions().stream().filter(c -> c.getStatus() == QualityGate.EvaluationStatus.ERROR)
+    public List<QualityGate.Condition> findFailedQualityGateConditions() {
+        return qualityGate.getConditions().stream()
+                .filter(c -> c.getStatus() == QualityGate.EvaluationStatus.ERROR)
                 .collect(Collectors.toList());
     }
 
-    public Optional<Measure> findMeasure(String metricKey) {
-        return measuresHolder.getMeasureRepository().getRawMeasure(measuresHolder.getTreeRootHolder().getRoot(),
-                                                                   measuresHolder.getMetricRepository()
-                                                                           .getByKey(metricKey));
+    public Optional<String> getScannerProperty(String propertyName) {
+        return Optional.ofNullable(projectAnalysis.getScannerContext().getProperties().get(propertyName));
     }
 
-    public Optional<QualityGate.Condition> findQualityGateCondition(String metricKey) {
-        return qualityGate.getConditions().stream().filter(c -> metricKey.equals(c.getMetricKey())).findFirst();
+    public Date getAnalysisDate() {
+        return getAnalysis().getDate();
     }
 
-    public Map<RuleType, Long> countRuleByType() {
-        return Arrays.stream(RuleType.values()).collect(Collectors.toMap(k -> k,
-                                                                         k -> postAnalysisIssueVisitor.getIssues()
-                                                                                 .stream()
-                                                                                 .map(PostAnalysisIssueVisitor.ComponentIssue::getIssue)
-                                                                                 .filter(i -> !CLOSED_ISSUE_STATUS
-                                                                                         .contains(i.status()))
-                                                                                 .filter(i -> k == i.type()).count()));
+    public String getAnalysisId() {
+        return getAnalysis().getAnalysisUuid();
     }
 
-    private static String pluralOf(long value, String singleLabel, String multiLabel) {
-        return value + " " + (1 == value ? singleLabel : multiLabel);
+    public String getAnalysisProjectKey() {
+        return getProject().getKey();
     }
 
-
-    public static String format(QualityGate.Condition condition) {
-        Metric<?> metric = CoreMetrics.getMetric(condition.getMetricKey());
-        if (metric.getType() == Metric.ValueType.RATING) {
-            return String
-                    .format("%s %s (%s %s)", Rating.valueOf(Integer.parseInt(condition.getValue())), metric.getName(),
-                            condition.getOperator() == QualityGate.Operator.GREATER_THAN ? "is worse than" :
-                            "is better than", Rating.valueOf(Integer.parseInt(condition.getErrorThreshold())));
-        } else if (metric.getType() == Metric.ValueType.PERCENT) {
-            NumberFormat numberFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
-            return String.format("%s%% %s (%s %s%%)", numberFormat.format(new BigDecimal(condition.getValue())),
-                                 metric.getName(),
-                                 condition.getOperator() == QualityGate.Operator.GREATER_THAN ? "is greater than" :
-                                 "is less than", numberFormat.format(new BigDecimal(condition.getErrorThreshold())));
-        } else {
-            return String.format("%s %s (%s %s)", condition.getValue(), metric.getName(),
-                                 condition.getOperator() == QualityGate.Operator.GREATER_THAN ? "is greater than" :
-                                 "is less than", condition.getErrorThreshold());
-        }
+    public String getAnalysisProjectName() {
+        return getProject().getName();
     }
 
-    public Optional<BigDecimal> getNewCoverage(){
-        return findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)
-                .filter(condition -> condition.getStatus() != EvaluationStatus.NO_VALUE)
-                .map(QualityGate.Condition::getValue)
-                .map(BigDecimal::new);
-    }
-
-    public Optional<BigDecimal> getCoverage(){
-        return findMeasure(CoreMetrics.COVERAGE_KEY).map(Measure::getDoubleValue).map(BigDecimal::new);
+    public List<PostAnalysisIssueVisitor.ComponentIssue> getIssues() {
+        return issues;
     }
 
     public List<PostAnalysisIssueVisitor.ComponentIssue> getScmReportableIssues() {
-        return postAnalysisIssueVisitor.getIssues().stream()
-                .filter(i -> getSCMPathForIssue(i).isPresent())
+        return getIssues().stream()
+                .filter(i -> i.getComponent().getReportAttributes().getScmPath().isPresent())
                 .filter(i -> i.getComponent().getType() == Component.Type.FILE)
                 .filter(i -> i.getIssue().resolution() == null)
                 .filter(i -> OPEN_ISSUE_STATUSES.contains(i.getIssue().status()))
                 .collect(Collectors.toList());
     }
 
-    public static class BranchDetails {
-
-        private final String branchName;
-        private final String commitId;
-
-        BranchDetails(String branchName, String commitId) {
-            this.branchName = branchName;
-            this.commitId = commitId;
-        }
-
-        public String getBranchName() {
-            return branchName;
-        }
-
-        public String getCommitId() {
-            return commitId;
-        }
-
+    public Optional<QualityGate.Condition> findQualityGateCondition(String metricKey) {
+        return qualityGate.getConditions().stream().filter(c -> metricKey.equals(c.getMetricKey())).findFirst();
     }
 
-    public static class MeasuresHolder {
-
-        private final MetricRepository metricRepository;
-        private final MeasureRepository measureRepository;
-        private final TreeRootHolder treeRootHolder;
-
-        MeasuresHolder(MetricRepository metricRepository, MeasureRepository measureRepository,
-                       TreeRootHolder treeRootHolder) {
-            this.metricRepository = metricRepository;
-            this.measureRepository = measureRepository;
-            this.treeRootHolder = treeRootHolder;
-        }
-
-        public MetricRepository getMetricRepository() {
-            return metricRepository;
-        }
-
-        public MeasureRepository getMeasureRepository() {
-            return measureRepository;
-        }
-
-        public TreeRootHolder getTreeRootHolder() {
-            return treeRootHolder;
-        }
-
+    private Analysis getAnalysis() {
+        return projectAnalysis.getAnalysis().orElseThrow();
     }
 
-    private static class DuplicationMapping {
-
-        private final BigDecimal duplicationLevel;
-        private final String imageName;
-
-        DuplicationMapping(BigDecimal duplicationLevel, String imageName) {
-            this.duplicationLevel = duplicationLevel;
-            this.imageName = imageName;
-        }
-
-        private BigDecimal getDuplicationLevel() {
-            return duplicationLevel;
-        }
-
-        private String getImageName() {
-            return imageName;
-        }
-    }
-
-    public static class ProjectIssueIdentifier {
-
-        private final String projectKey;
-        private final String issueKey;
-
-        public ProjectIssueIdentifier(String projectKey, String issueKey) {
-            this.projectKey = projectKey;
-            this.issueKey = issueKey;
-        }
-
-        public String getProjectKey() {
-            return projectKey;
-        }
-
-        public String getIssueKey() {
-            return issueKey;
-        }
+    private Project getProject() {
+        return projectAnalysis.getProject();
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitor.java
@@ -25,13 +25,12 @@ import org.sonar.ce.task.projectanalysis.issue.IssueVisitor;
 import org.sonar.core.issue.DefaultIssue;
 import org.sonar.db.protobuf.DbIssues;
 
+import javax.annotation.CheckForNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
-import javax.annotation.CheckForNull;
 
 public class PostAnalysisIssueVisitor extends IssueVisitor {
 
@@ -39,9 +38,7 @@ public class PostAnalysisIssueVisitor extends IssueVisitor {
 
     @Override
     public void onIssue(Component component, DefaultIssue defaultIssue) {
-        collectedIssues.add(new ComponentIssue(component, Optional.ofNullable(defaultIssue)
-                .map(LightIssue::new)
-                .orElse(null)));
+        collectedIssues.add(new ComponentIssue(component, new LightIssue(defaultIssue)));
     }
 
     public List<ComponentIssue> getIssues() {
@@ -65,6 +62,13 @@ public class PostAnalysisIssueVisitor extends IssueVisitor {
 
         public LightIssue getIssue() {
             return issue;
+        }
+
+        public Optional<String> getScmPath() {
+            if (Component.Type.FILE == component.getType()) {
+                return component.getReportAttributes().getScmPath();
+            }
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisIssueSummary.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisIssueSummary.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Document;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Image;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Link;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Node;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Paragraph;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Text;
+import org.apache.commons.lang.StringUtils;
+
+public final class AnalysisIssueSummary {
+
+    private final String typeImageUrl;
+    private final String severityImageUrl;
+    private final String issueUrl;
+    private final String issueKey;
+    private final String projectKey;
+    private final Long effortInMinutes;
+    private final String type;
+    private final String message;
+    private final String severity;
+    private final String resolution;
+
+    private AnalysisIssueSummary(Builder builder) {
+        this.typeImageUrl = builder.typeImageUrl;
+        this.severityImageUrl = builder.severityImageUrl;
+        this.issueUrl = builder.issueUrl;
+        this.issueKey = builder.issueKey;
+        this.projectKey = builder.projectKey;
+        this.effortInMinutes = builder.effortInMinutes;
+        this.type = builder.type;
+        this.message = builder.message;
+        this.severity = builder.severity;
+        this.resolution = builder.resolution;
+    }
+
+    public String getTypeImageUrl() {
+        return typeImageUrl;
+    }
+
+    public String getSeverityImageUrl() {
+        return severityImageUrl;
+    }
+
+    public String getIssueUrl() {
+        return issueUrl;
+    }
+
+    public String getIssueKey() {
+        return issueKey;
+    }
+
+    public String getProjectKey() {
+        return projectKey;
+    }
+
+    public Long getEffortInMinutes() {
+        return effortInMinutes;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getSeverity() {
+        return severity;
+    }
+
+    public String getResolution() {
+        return resolution;
+    }
+
+    public String format(FormatterFactory formatterFactory) {
+        Long effort = getEffortInMinutes();
+        Node effortNode = (null == effort ? new Text("") : new Paragraph(new Text(String.format("**Duration (min):** %s", effort))));
+
+        Node resolutionNode = (StringUtils.isBlank(getResolution()) ? new Text("") : new Paragraph(new Text(String.format("**Resolution:** %s", getResolution()))));
+
+        Document document = new Document(
+                new Paragraph(new Text(String.format("**Type:** %s ", getType())), new Image(getType(), getTypeImageUrl())),
+                new Paragraph(new Text(String.format("**Severity:** %s ", getSeverity())), new Image(getSeverity(), getSeverityImageUrl())),
+                new Paragraph(new Text(String.format("**Message:** %s", getMessage()))),
+                effortNode,
+                resolutionNode,
+                new Paragraph(new Text(String.format("**Project ID:** %s **Issue ID:** %s", getProjectKey(), getIssueKey()))),
+                new Paragraph(new Link(getIssueUrl(), new Text("View in SonarQube")))
+        );
+
+        return formatterFactory.documentFormatter().format(document);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String typeImageUrl;
+        private String severityImageUrl;
+        private String issueUrl;
+        private String issueKey;
+        private String projectKey;
+        private Long effortInMinutes;
+        private String type;
+        private String message;
+        private String severity;
+        private String resolution;
+
+        private Builder() {
+            super();
+        }
+
+        public Builder withTypeImageUrl(String typeImageUrl) {
+            this.typeImageUrl = typeImageUrl;
+            return this;
+        }
+
+        public Builder withSeverityImageUrl(String severityImageUrl) {
+            this.severityImageUrl = severityImageUrl;
+            return this;
+        }
+
+        public Builder withIssueUrl(String issueUrl) {
+            this.issueUrl = issueUrl;
+            return this;
+        }
+
+        public Builder withIssueKey(String issueKey) {
+            this.issueKey = issueKey;
+            return this;
+        }
+
+        public Builder withProjectKey(String projectKey) {
+            this.projectKey = projectKey;
+            return this;
+        }
+
+        public Builder withEffortInMinutes(Long effortInMinutes) {
+            this.effortInMinutes = effortInMinutes;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder withSeverity(String severity) {
+            this.severity = severity;
+            return this;
+        }
+
+        public Builder withResolution(String resolution) {
+            this.resolution = resolution;
+            return this;
+        }
+
+        public AnalysisIssueSummary build() {
+            return new AnalysisIssueSummary(this);
+        }
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Document;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Heading;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Image;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Link;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.ListItem;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Paragraph;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Text;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+public final class AnalysisSummary {
+
+    private final String summaryImageUrl;
+    private final String projectKey;
+
+    private final String statusDescription;
+    private final String statusImageUrl;
+    private final List<String> failedQualityGateConditions;
+    private final String dashboardUrl;
+
+    private final BigDecimal newCoverage;
+    private final BigDecimal coverage;
+    private final String coverageImageUrl;
+
+    private final BigDecimal newDuplications;
+    private final BigDecimal duplications;
+    private final String duplicationsImageUrl;
+
+    private final long totalIssueCount;
+
+    private final long bugCount;
+    private final String bugImageUrl;
+
+    private final long securityHotspotCount;
+    private final long vulnerabilityCount;
+    private final String vulnerabilityImageUrl;
+
+    private final long codeSmellCount;
+    private final String codeSmellImageUrl;
+
+    private AnalysisSummary(Builder builder) {
+        this.summaryImageUrl = builder.summaryImageUrl;
+        this.projectKey = builder.projectKey;
+        this.statusDescription = builder.statusDescription;
+        this.statusImageUrl = builder.statusImageUrl;
+        this.failedQualityGateConditions = builder.failedQualityGateConditions;
+        this.dashboardUrl = builder.dashboardUrl;
+        this.newCoverage = builder.newCoverage;
+        this.coverage = builder.coverage;
+        this.coverageImageUrl = builder.coverageImageUrl;
+        this.newDuplications = builder.newDuplications;
+        this.duplications = builder.duplications;
+        this.duplicationsImageUrl = builder.duplicationsImageUrl;
+        this.totalIssueCount = builder.totalIssueCount;
+        this.bugCount = builder.bugCount;
+        this.bugImageUrl = builder.bugImageUrl;
+        this.securityHotspotCount = builder.securityHotspotCount;
+        this.vulnerabilityCount = builder.vulnerabilityCount;
+        this.vulnerabilityImageUrl = builder.vulnerabilityImageUrl;
+        this.codeSmellCount = builder.codeSmellCount;
+        this.codeSmellImageUrl = builder.codeSmellImageUrl;
+    }
+
+    public String getSummaryImageUrl() {
+        return summaryImageUrl;
+    }
+
+    public String getProjectKey() {
+        return projectKey;
+    }
+
+    public String getStatusDescription() {
+        return statusDescription;
+    }
+
+    public String getStatusImageUrl() {
+        return statusImageUrl;
+    }
+
+    public List<String> getFailedQualityGateConditions() {
+        return failedQualityGateConditions;
+    }
+
+    public String getDashboardUrl() {
+        return dashboardUrl;
+    }
+
+    public BigDecimal getNewCoverage() {
+        return newCoverage;
+    }
+
+    public BigDecimal getCoverage() {
+        return coverage;
+    }
+
+    public String getCoverageImageUrl() {
+        return coverageImageUrl;
+    }
+
+    public BigDecimal getNewDuplications() {
+        return newDuplications;
+    }
+
+    public BigDecimal getDuplications() {
+        return duplications;
+    }
+
+    public String getDuplicationsImageUrl() {
+        return duplicationsImageUrl;
+    }
+
+    public long getTotalIssueCount() {
+        return totalIssueCount;
+    }
+
+    public long getBugCount() {
+        return bugCount;
+    }
+
+    public String getBugImageUrl() {
+        return bugImageUrl;
+    }
+
+    public long getSecurityHotspotCount() {
+        return securityHotspotCount;
+    }
+
+    public long getVulnerabilityCount() {
+        return vulnerabilityCount;
+    }
+
+    public String getVulnerabilityImageUrl() {
+        return vulnerabilityImageUrl;
+    }
+
+    public long getCodeSmellCount() {
+        return codeSmellCount;
+    }
+
+    public String getCodeSmellImageUrl() {
+        return codeSmellImageUrl;
+    }
+
+    public String format(FormatterFactory formatterFactory) {
+        NumberFormat decimalFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+
+        List<String> failedConditions = getFailedQualityGateConditions();
+
+        Document document = new Document(new Paragraph(new Image(getStatusDescription(), getStatusImageUrl())),
+                failedConditions.isEmpty() ? new Text("") :
+                        new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
+                                com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,
+                                failedConditions.stream()
+                                        .map(Text::new)
+                                        .map(ListItem::new)
+                                        .toArray(ListItem[]::new)),
+                new Heading(1, new Text("Analysis Details")),
+                new Heading(2, new Text(pluralOf(getTotalIssueCount(), "Issue", "Issues"))),
+                new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
+                        com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,
+                        new ListItem(new Image("Bug", getBugImageUrl()),
+                                new Text(" "),
+                                new Text(pluralOf(getBugCount(), "Bug", "Bugs"))),
+                        new ListItem(new Image("Vulnerability", getVulnerabilityImageUrl()),
+                                new Text(" "),
+                                new Text(pluralOf(getVulnerabilityCount() + getSecurityHotspotCount(), "Vulnerability", "Vulnerabilities"))),
+                        new ListItem(new Image("Code Smell", getCodeSmellImageUrl()),
+                                new Text(" "),
+                                new Text(pluralOf(getCodeSmellCount(), "Code Smell", "Code Smells")))),
+                new Heading(2, new Text("Coverage and Duplications")),
+                new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
+                        com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,
+                        new ListItem(new Image("Coverage", getCoverageImageUrl()),
+                                new Text(" "), new Text(
+                                Optional.ofNullable(getNewCoverage())
+                                        .map(decimalFormat::format)
+                                        .map(i -> i + "% Coverage")
+                                        .orElse("No coverage information") + " (" +
+                                        decimalFormat.format(Optional.ofNullable(getCoverage()).orElse(BigDecimal.valueOf(0))) + "% Estimated after merge)")),
+                        new ListItem(new Image("Duplications", getDuplicationsImageUrl()),
+                                new Text(" "),
+                                new Text(Optional.ofNullable(getNewDuplications())
+                                        .map(decimalFormat::format)
+                                        .map(i -> i + "% Duplicated Code")
+                                        .orElse("No duplication information") + " (" + decimalFormat.format(getDuplications()) + "% Estimated after merge)"))),
+                new Paragraph(new Text(String.format("**Project ID:** %s", getProjectKey()))),
+                new Paragraph(new Link(getDashboardUrl(), new Text("View in SonarQube"))));
+
+        return formatterFactory.documentFormatter().format(document);
+    }
+
+    private static String pluralOf(long value, String singleLabel, String multiLabel) {
+        return value + " " + (1 == value ? singleLabel : multiLabel);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String summaryImageUrl;
+        private String projectKey;
+
+        private String statusDescription;
+        private String statusImageUrl;
+        private List<String> failedQualityGateConditions;
+        private String dashboardUrl;
+
+        private BigDecimal newCoverage;
+        private BigDecimal coverage;
+        private String coverageImageUrl;
+
+        private BigDecimal newDuplications;
+        private BigDecimal duplications;
+        private String duplicationsImageUrl;
+
+        private long totalIssueCount;
+
+        private long bugCount;
+        private String bugImageUrl;
+
+        private long securityHotspotCount;
+        private long vulnerabilityCount;
+        private String vulnerabilityImageUrl;
+
+        private long codeSmellCount;
+        private String codeSmellImageUrl;
+
+        private Builder() {
+            super();
+        }
+
+        public Builder withSummaryImageUrl(String summaryImageUrl) {
+            this.summaryImageUrl = summaryImageUrl;
+            return this;
+        }
+
+        public Builder withProjectKey(String projectKey) {
+            this.projectKey = projectKey;
+            return this;
+        }
+
+        public Builder withStatusDescription(String statusDescription) {
+            this.statusDescription = statusDescription;
+            return this;
+        }
+
+        public Builder withStatusImageUrl(String statusImageUrl) {
+            this.statusImageUrl = statusImageUrl;
+            return this;
+        }
+
+        public Builder withFailedQualityGateConditions(List<String> failedQualityGateConditions) {
+            this.failedQualityGateConditions = failedQualityGateConditions;
+            return this;
+        }
+
+        public Builder withDashboardUrl(String dashboardUrl) {
+            this.dashboardUrl = dashboardUrl;
+            return this;
+        }
+
+        public Builder withNewCoverage(BigDecimal newCoverage) {
+            this.newCoverage = newCoverage;
+            return this;
+        }
+
+        public Builder withCoverage(BigDecimal coverage) {
+            this.coverage = coverage;
+            return this;
+        }
+
+        public Builder withCoverageImageUrl(String coverageImageUrl) {
+            this.coverageImageUrl = coverageImageUrl;
+            return this;
+        }
+
+        public Builder withNewDuplications(BigDecimal newDuplications) {
+            this.newDuplications = newDuplications;
+            return this;
+        }
+
+        public Builder withDuplications(BigDecimal duplications) {
+            this.duplications = duplications;
+            return this;
+        }
+
+        public Builder withDuplicationsImageUrl(String duplicationsImageUrl) {
+            this.duplicationsImageUrl = duplicationsImageUrl;
+            return this;
+        }
+
+        public Builder withTotalIssueCount(long totalIssueCount) {
+            this.totalIssueCount = totalIssueCount;
+            return this;
+        }
+
+        public Builder withBugCount(long bugCount) {
+            this.bugCount = bugCount;
+            return this;
+        }
+
+        public Builder withBugImageUrl(String bugImageUrl) {
+            this.bugImageUrl = bugImageUrl;
+            return this;
+        }
+
+        public Builder withSecurityHotspotCount(long securityHotspotCount) {
+            this.securityHotspotCount = securityHotspotCount;
+            return this;
+        }
+
+        public Builder withVulnerabilityCount(long vulnerabilityCount) {
+            this.vulnerabilityCount = vulnerabilityCount;
+            return this;
+        }
+
+        public Builder withVulnerabilityImageUrl(String vulnerabilityImageUrl) {
+            this.vulnerabilityImageUrl = vulnerabilityImageUrl;
+            return this;
+        }
+
+        public Builder withCodeSmellCount(long codeSmellCount) {
+            this.codeSmellCount = codeSmellCount;
+            return this;
+        }
+
+        public Builder withCodeSmellImageUrl(String codeSmellImageUrl) {
+            this.codeSmellImageUrl = codeSmellImageUrl;
+            return this;
+        }
+
+        public AnalysisSummary build() {
+            return new AnalysisSummary(this);
+        }
+    }
+
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/ReportGenerator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/ReportGenerator.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report;
+
+import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
+import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.Metric;
+import org.sonar.api.platform.Server;
+import org.sonar.api.rules.RuleType;
+import org.sonar.ce.task.projectanalysis.component.TreeRootHolder;
+import org.sonar.ce.task.projectanalysis.measure.Measure;
+import org.sonar.ce.task.projectanalysis.measure.MeasureRepository;
+import org.sonar.ce.task.projectanalysis.metric.MetricRepository;
+import org.sonar.server.measure.Rating;
+
+import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class ReportGenerator {
+
+    private static final List<String> CLOSED_ISSUE_STATUS = Arrays.asList(Issue.STATUS_CLOSED, Issue.STATUS_RESOLVED);
+
+    private static final List<BigDecimal> COVERAGE_LEVELS = List.of(BigDecimal.valueOf(100),
+                    BigDecimal.valueOf(90),
+                    BigDecimal.valueOf(60),
+                    BigDecimal.valueOf(50),
+                    BigDecimal.valueOf(40),
+                    BigDecimal.valueOf(25));
+
+    private static final List<DuplicationMapping> DUPLICATION_LEVELS = List.of(new DuplicationMapping(BigDecimal.valueOf(3), "3"),
+                    new DuplicationMapping(BigDecimal.valueOf(5), "5"),
+                    new DuplicationMapping(BigDecimal.TEN, "10"),
+                    new DuplicationMapping(BigDecimal.valueOf(20), "20"));
+
+    private final Server server;
+    private final Configuration configuration;
+    private final MeasureRepository measureRepository;
+    private final MetricRepository metricRepository;
+    private final TreeRootHolder treeRootHolder;
+
+    public ReportGenerator(Server server, Configuration configuration, MeasureRepository measureRepository, MetricRepository metricRepository, TreeRootHolder treeRootHolder) {
+        this.server = server;
+        this.configuration = configuration;
+        this.measureRepository = measureRepository;
+        this.metricRepository = metricRepository;
+        this.treeRootHolder = treeRootHolder;
+    }
+
+    public AnalysisIssueSummary createAnalysisIssueSummary(PostAnalysisIssueVisitor.ComponentIssue componentIssue, AnalysisDetails analysisDetails) {
+        final PostAnalysisIssueVisitor.LightIssue issue = componentIssue.getIssue();
+
+        String baseImageUrl = getBaseImageUrl();
+
+        return AnalysisIssueSummary.builder()
+                .withEffortInMinutes(issue.effortInMinutes())
+                .withIssueKey(issue.key())
+                .withIssueUrl(getIssueUrl(issue, analysisDetails))
+                .withMessage(issue.getMessage())
+                .withProjectKey(analysisDetails.getAnalysisProjectKey())
+                .withResolution(issue.resolution())
+                .withSeverity(issue.severity())
+                .withSeverityImageUrl(String.format("%s/checks/Severity/%s.svg?sanitize=true", baseImageUrl, issue.severity().toLowerCase()))
+                .withType(issue.type().name())
+                .withTypeImageUrl(String.format("%s/checks/IssueType/%s.svg?sanitize=true", baseImageUrl, issue.type().name().toLowerCase()))
+                .build();
+    }
+
+    public AnalysisSummary createAnalysisSummary(AnalysisDetails analysisDetails) {
+        BigDecimal newCoverage = analysisDetails.findQualityGateCondition(CoreMetrics.NEW_COVERAGE_KEY)
+                .filter(condition -> condition.getStatus() != QualityGate.EvaluationStatus.NO_VALUE)
+                .map(QualityGate.Condition::getValue)
+                .map(BigDecimal::new)
+                .orElse(null);
+
+        BigDecimal coverage = findMeasure(CoreMetrics.COVERAGE_KEY)
+                .map(Measure::getDoubleValue)
+                .map(BigDecimal::new)
+                .orElse(null);
+
+        BigDecimal newDuplications = analysisDetails.findQualityGateCondition(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY)
+                .filter(condition -> condition.getStatus() != QualityGate.EvaluationStatus.NO_VALUE)
+                .map(QualityGate.Condition::getValue)
+                .map(BigDecimal::new)
+                .orElse(null);
+
+        BigDecimal duplications = findMeasure(CoreMetrics.DUPLICATED_LINES_DENSITY_KEY)
+                .map(Measure::getDoubleValue)
+                .map(BigDecimal::valueOf)
+                .orElse(null);
+
+        Map<RuleType, Long> issueCounts = countRuleByType(analysisDetails.getIssues());
+        long issueTotal = issueCounts.values().stream().mapToLong(l -> l).sum();
+
+        List<QualityGate.Condition> failedConditions = analysisDetails.findFailedQualityGateConditions();
+
+        String baseImageUrl = getBaseImageUrl();
+
+        return AnalysisSummary.builder()
+                .withProjectKey(analysisDetails.getAnalysisProjectKey())
+                .withSummaryImageUrl(baseImageUrl + "/common/icon.png")
+                .withBugCount(issueCounts.get(RuleType.BUG))
+                .withBugImageUrl(baseImageUrl + "/common/bug.svg?sanitize=true")
+                .withCodeSmellCount(issueCounts.get(RuleType.CODE_SMELL))
+                .withCodeSmellImageUrl(baseImageUrl + "/common/code_smell.svg?sanitize=true")
+                .withCoverage(coverage)
+                .withNewCoverage(newCoverage)
+                .withCoverageImageUrl(createCoverageImage(newCoverage, baseImageUrl))
+                .withDashboardUrl(getDashboardUrl(analysisDetails))
+                .withDuplications(duplications)
+                .withDuplicationsImageUrl(createDuplicateImage(newDuplications, baseImageUrl))
+                .withNewDuplications(newDuplications)
+                .withFailedQualityGateConditions(failedConditions.stream()
+                        .map(ReportGenerator::formatQualityGateCondition)
+                        .collect(Collectors.toList()))
+                .withStatusDescription(QualityGate.Status.OK == analysisDetails.getQualityGateStatus() ? "Passed" : "Failed")
+                .withStatusImageUrl(QualityGate.Status.OK == analysisDetails.getQualityGateStatus()
+                        ? baseImageUrl + "/checks/QualityGateBadge/passed.svg?sanitize=true"
+                        : baseImageUrl + "/checks/QualityGateBadge/failed.svg?sanitize=true")
+                .withTotalIssueCount(issueTotal)
+                .withVulnerabilityCount(issueCounts.get(RuleType.VULNERABILITY))
+                .withSecurityHotspotCount(issueCounts.get(RuleType.SECURITY_HOTSPOT))
+                .withVulnerabilityImageUrl(baseImageUrl + "/common/vulnerability.svg?sanitize=true")
+                .build();
+    }
+
+    private String getBaseImageUrl() {
+        return configuration.get(CommunityBranchPlugin.IMAGE_URL_BASE)
+                .orElse(server.getPublicRootUrl() + "/static/communityBranchPlugin")
+                .replaceAll("/*$", "");
+    }
+
+    private String getIssueUrl(PostAnalysisIssueVisitor.LightIssue issue, AnalysisDetails analysisDetails) {
+        if (issue.type() == RuleType.SECURITY_HOTSPOT) {
+            return String.format("%s/security_hotspots?id=%s&pullRequest=%s&hotspots=%s", server.getPublicRootUrl(), URLEncoder.encode(analysisDetails.getAnalysisProjectKey(), StandardCharsets.UTF_8), analysisDetails.getPullRequestId(), issue.key());
+        } else {
+            return String.format("%s/project/issues?id=%s&pullRequest=%s&issues=%s&open=%s", server.getPublicRootUrl(), URLEncoder.encode(analysisDetails.getAnalysisProjectKey(), StandardCharsets.UTF_8), analysisDetails.getPullRequestId(), issue.key(), issue.key());
+        }
+    }
+
+    private Optional<Measure> findMeasure(String metricKey) {
+        return measureRepository.getRawMeasure(treeRootHolder.getRoot(), metricRepository.getByKey(metricKey));
+    }
+
+    private String getDashboardUrl(AnalysisDetails analysisDetails) {
+        return server.getPublicRootUrl() + "/dashboard?id=" + URLEncoder.encode(analysisDetails.getAnalysisProjectKey(), StandardCharsets.UTF_8) + "&pullRequest=" + analysisDetails.getPullRequestId();
+    }
+
+    private static String createCoverageImage(BigDecimal coverage, String baseImageUrl) {
+        if (null == coverage) {
+            return baseImageUrl + "/checks/CoverageChart/NoCoverageInfo.svg?sanitize=true";
+        }
+        BigDecimal matchedLevel = BigDecimal.ZERO;
+        for (BigDecimal level : COVERAGE_LEVELS) {
+            if (coverage.compareTo(level) >= 0) {
+                matchedLevel = level;
+                break;
+            }
+        }
+        return baseImageUrl + "/checks/CoverageChart/" + matchedLevel + ".svg?sanitize=true";
+    }
+
+    private static String createDuplicateImage(BigDecimal duplications, String baseImageUrl) {
+        if (null == duplications) {
+            return baseImageUrl + "/checks/Duplications/NoDuplicationInfo.svg?sanitize=true";
+        }
+        String matchedLevel = "20plus";
+        for (DuplicationMapping level : DUPLICATION_LEVELS) {
+            if (level.getDuplicationLevel().compareTo(duplications) >= 0) {
+                matchedLevel = level.getImageName();
+                break;
+            }
+        }
+        return baseImageUrl + "/checks/Duplications/" + matchedLevel + ".svg?sanitize=true";
+    }
+
+    private static String formatQualityGateCondition(QualityGate.Condition condition) {
+        Metric<?> metric = CoreMetrics.getMetric(condition.getMetricKey());
+        if (metric.getType() == Metric.ValueType.RATING) {
+            return String
+                    .format("%s %s (%s %s)", Rating.valueOf(Integer.parseInt(condition.getValue())), metric.getName(),
+                            condition.getOperator() == QualityGate.Operator.GREATER_THAN ? "is worse than" :
+                                    "is better than", Rating.valueOf(Integer.parseInt(condition.getErrorThreshold())));
+        } else if (metric.getType() == Metric.ValueType.PERCENT) {
+            NumberFormat numberFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+            return String.format("%s%% %s (%s %s%%)", numberFormat.format(new BigDecimal(condition.getValue())),
+                    metric.getName(),
+                    condition.getOperator() == QualityGate.Operator.GREATER_THAN ? "is greater than" :
+                            "is less than", numberFormat.format(new BigDecimal(condition.getErrorThreshold())));
+        } else {
+            return String.format("%s %s (%s %s)", condition.getValue(), metric.getName(),
+                    condition.getOperator() == QualityGate.Operator.GREATER_THAN ? "is greater than" :
+                            "is less than", condition.getErrorThreshold());
+        }
+    }
+
+    private static Map<RuleType, Long> countRuleByType(List<PostAnalysisIssueVisitor.ComponentIssue> issues) {
+        return Arrays.stream(RuleType.values()).collect(Collectors.toMap(k -> k,
+                k -> issues.stream()
+                        .map(PostAnalysisIssueVisitor.ComponentIssue::getIssue)
+                        .filter(i -> !CLOSED_ISSUE_STATUS.contains(i.status()))
+                        .filter(i -> k == i.type())
+                        .count()));
+    }
+
+    private static class DuplicationMapping {
+
+        private final BigDecimal duplicationLevel;
+        private final String imageName;
+
+        DuplicationMapping(BigDecimal duplicationLevel, String imageName) {
+            this.duplicationLevel = duplicationLevel;
+            this.imageName = imageName;
+        }
+
+        private BigDecimal getDuplicationLevel() {
+            return duplicationLevel;
+        }
+
+        private String getImageName() {
+            return imageName;
+        }
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
@@ -345,7 +345,7 @@ class GraphqlGithubClientTest {
 
         AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
         when(analysisDetails.getScmReportableIssues()).thenReturn(issues);
-        when(analysisDetails.getBranchName()).thenReturn("13579");
+        when(analysisDetails.getPullRequestId()).thenReturn("13579");
         when(analysisDetails.getAnalysisProjectKey()).thenReturn("projectKey");
         when(analysisDetails.getAnalysisDate()).thenReturn(new Date());
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProviderTest.java
@@ -32,7 +32,7 @@ public class CommunityReportAnalysisComponentProviderTest {
     @Test
     public void testGetComponents() {
         List<Object> result = new CommunityReportAnalysisComponentProvider().getComponents();
-        assertEquals(17, result.size());
+        assertEquals(18, result.size());
         assertEquals(CommunityBranchLoaderDelegate.class, result.get(0));
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
@@ -18,902 +18,105 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
 
-import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Document;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Formatter;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Heading;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Image;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Link;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.ListItem;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Paragraph;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Text;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.Test;
 import org.sonar.api.ce.posttask.Analysis;
+import org.sonar.api.ce.posttask.PostProjectAnalysisTask;
 import org.sonar.api.ce.posttask.Project;
 import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.ce.posttask.ScannerContext;
-import org.sonar.api.config.Configuration;
 import org.sonar.api.issue.Issue;
-import org.sonar.api.measures.CoreMetrics;
-import org.sonar.api.rules.RuleType;
 import org.sonar.ce.task.projectanalysis.component.Component;
 import org.sonar.ce.task.projectanalysis.component.ReportAttributes;
-import org.sonar.ce.task.projectanalysis.component.TreeRootHolder;
-import org.sonar.ce.task.projectanalysis.measure.Measure;
-import org.sonar.ce.task.projectanalysis.measure.MeasureRepository;
-import org.sonar.ce.task.projectanalysis.metric.Metric;
-import org.sonar.ce.task.projectanalysis.metric.MetricRepository;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AnalysisDetailsTest {
+class AnalysisDetailsTest {
 
     @Test
-    public void testGetBranchName() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        doReturn("branchName").when(branchDetails).getBranchName();
-
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
-        QualityGate qualityGate = mock(QualityGate.class);
-        Analysis analysis = mock(Analysis.class);
-        Project project = mock(Project.class);
-        Configuration configuration = mock(Configuration.class);
-        ScannerContext scannerContext = mock(ScannerContext.class);
-
-        AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, null, scannerContext);
-
-        assertEquals("branchName", testCase.getBranchName());
-    }
-
-    @Test
-    public void testGetCommitSha() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        doReturn("commitId").when(branchDetails).getCommitId();
-
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
-        QualityGate qualityGate = mock(QualityGate.class);
-        Analysis analysis = mock(Analysis.class);
-        Project project = mock(Project.class);
-        ScannerContext scannerContext = mock(ScannerContext.class);
-        Configuration configuration = mock(Configuration.class);
-
-        AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, null, scannerContext);
-
-        assertEquals("commitId", testCase.getCommitSha());
-    }
-
-    @Test
-    public void testGetQualityGateStatus() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
+    void shouldReturnStatusFromQualityGate() {
         QualityGate qualityGate = mock(QualityGate.class);
         doReturn(QualityGate.Status.ERROR).when(qualityGate).getStatus();
-        Analysis analysis = mock(Analysis.class);
-        Project project = mock(Project.class);
-        ScannerContext scannerContext = mock(ScannerContext.class);
-        Configuration configuration = mock(Configuration.class);
+        PostProjectAnalysisTask.ProjectAnalysis projectAnalysis = mock(PostProjectAnalysisTask.ProjectAnalysis.class);
 
         AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, null, scannerContext);
+                new AnalysisDetails("pullRequestKey", "commitHash", new ArrayList<>(), qualityGate, projectAnalysis);
 
         assertEquals(QualityGate.Status.ERROR, testCase.getQualityGateStatus());
     }
 
     @Test
-    public void testGetAnalysisDate() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
+    void shouldGetDateFromAnalysis() {
         QualityGate qualityGate = mock(QualityGate.class);
         Analysis analysis = mock(Analysis.class);
+        PostProjectAnalysisTask.ProjectAnalysis projectAnalysis = mock(PostProjectAnalysisTask.ProjectAnalysis.class);
+        doReturn(Optional.of(analysis)).when(projectAnalysis).getAnalysis();
         doReturn(new Date()).when(analysis).getDate();
-        Project project = mock(Project.class);
-        ScannerContext scannerContext = mock(ScannerContext.class);
-        Configuration configuration = mock(Configuration.class);
 
         AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, null, scannerContext);
+                new AnalysisDetails("pullRequestKey", "commitHash", new ArrayList<>(), qualityGate, projectAnalysis);
 
         assertEquals(analysis.getDate(), testCase.getAnalysisDate());
     }
 
     @Test
-    public void testGetAnalysisId() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
+    void shouldGetIdFromAnalysis() {
         QualityGate qualityGate = mock(QualityGate.class);
         Analysis analysis = mock(Analysis.class);
+        PostProjectAnalysisTask.ProjectAnalysis projectAnalysis = mock(PostProjectAnalysisTask.ProjectAnalysis.class);
+        doReturn(Optional.of(analysis)).when(projectAnalysis).getAnalysis();
         doReturn("Analysis ID").when(analysis).getAnalysisUuid();
-        Project project = mock(Project.class);
-        ScannerContext scannerContext = mock(ScannerContext.class);
-        Configuration configuration = mock(Configuration.class);
 
         AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, null, scannerContext);
+                new AnalysisDetails("pullRequestKey", "commitHash", new ArrayList<>(), qualityGate, projectAnalysis);
 
         assertEquals("Analysis ID", testCase.getAnalysisId());
     }
 
     @Test
-    public void testGetAnalysisProjectKey() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
+    void shouldGetProjectKeyFromUnderlyingProject() {
         QualityGate qualityGate = mock(QualityGate.class);
-        Analysis analysis = mock(Analysis.class);
+        PostProjectAnalysisTask.ProjectAnalysis projectAnalysis = mock(PostProjectAnalysisTask.ProjectAnalysis.class);
         Project project = mock(Project.class);
-        doReturn("Project Key").when(project).getKey();
-        ScannerContext scannerContext = mock(ScannerContext.class);
-        Configuration configuration = mock(Configuration.class);
+        when(project.getKey()).thenReturn("Project Key");
+        when(projectAnalysis.getProject()).thenReturn(project);
 
         AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, null, scannerContext);
+                new AnalysisDetails("pullRequestKey", "commitHash", new ArrayList<>(), qualityGate, projectAnalysis);
 
         assertEquals("Project Key", testCase.getAnalysisProjectKey());
     }
 
     @Test
-    public void testCreateAnalysisSummary() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        doReturn("5").when(branchDetails).getBranchName();
-
-        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        doReturn(treeRootHolder).when(measuresHolder).getTreeRootHolder();
-
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
-        PostAnalysisIssueVisitor.LightIssue issue1 = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        doReturn(Issue.STATUS_CLOSED).when(issue1).status();
-
-        PostAnalysisIssueVisitor.LightIssue issue2 = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        doReturn(Issue.STATUS_OPEN).when(issue2).status();
-        doReturn(RuleType.BUG).when(issue2).type();
-
-        PostAnalysisIssueVisitor.LightIssue issue3 = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        doReturn(Issue.STATUS_OPEN).when(issue3).status();
-        doReturn(RuleType.SECURITY_HOTSPOT).when(issue3).type();
-
-        PostAnalysisIssueVisitor.LightIssue issue4 = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        doReturn(Issue.STATUS_OPEN).when(issue4).status();
-        doReturn(RuleType.CODE_SMELL).when(issue4).type();
-
-        PostAnalysisIssueVisitor.LightIssue issue5 = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        doReturn(Issue.STATUS_OPEN).when(issue5).status();
-        doReturn(RuleType.VULNERABILITY).when(issue5).type();
-
-        PostAnalysisIssueVisitor.LightIssue issue6 = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        doReturn(Issue.STATUS_OPEN).when(issue6).status();
-        doReturn(RuleType.BUG).when(issue6).type();
-
-        doReturn(Stream.of(issue1, issue2, issue3, issue4, issue5, issue6).map(i -> {
-            PostAnalysisIssueVisitor.ComponentIssue componentIssue =
-                    mock(PostAnalysisIssueVisitor.ComponentIssue.class);
-            doReturn(i).when(componentIssue).getIssue();
-            return componentIssue;
-        }).collect(Collectors.toList())).when(postAnalysisIssueVisitor).getIssues();
-
-        QualityGate.Condition condition1 = mock(QualityGate.Condition.class);
-        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition1).getStatus();
-        doReturn(CoreMetrics.LINES_TO_COVER.getKey()).when(condition1).getMetricKey();
-        doReturn("12").when(condition1).getValue();
-        doReturn(QualityGate.Operator.LESS_THAN).when(condition1).getOperator();
-        doReturn("20").when(condition1).getErrorThreshold();
-
-        QualityGate.Condition condition2 = mock(QualityGate.Condition.class);
-        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition2).getStatus();
-        doReturn(CoreMetrics.CODE_SMELLS.getKey()).when(condition2).getMetricKey();
-        doReturn("2").when(condition2).getValue();
-        doReturn(QualityGate.Operator.GREATER_THAN).when(condition2).getOperator();
-        doReturn("0").when(condition2).getErrorThreshold();
-
-        QualityGate.Condition condition3 = mock(QualityGate.Condition.class);
-        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition3).getStatus();
-        doReturn(CoreMetrics.LINE_COVERAGE.getKey()).when(condition3).getMetricKey();
-        doReturn("68").when(condition3).getValue();
-        doReturn(QualityGate.Operator.LESS_THAN).when(condition3).getOperator();
-        doReturn("80").when(condition3).getErrorThreshold();
-
-        QualityGate.Condition condition4 = mock(QualityGate.Condition.class);
-        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition4).getStatus();
-        doReturn(CoreMetrics.NEW_SECURITY_RATING.getKey()).when(condition4).getMetricKey();
-        doReturn("5").when(condition4).getValue();
-        doReturn(QualityGate.Operator.GREATER_THAN).when(condition4).getOperator();
-        doReturn("4").when(condition4).getErrorThreshold();
-
-        QualityGate.Condition condition5 = mock(QualityGate.Condition.class);
-        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition5).getStatus();
-        doReturn(CoreMetrics.RELIABILITY_RATING.getKey()).when(condition5).getMetricKey();
-        doReturn("1").when(condition5).getValue();
-        doReturn(QualityGate.Operator.LESS_THAN).when(condition5).getOperator();
-        doReturn("3").when(condition5).getErrorThreshold();
-
-        QualityGate.Condition condition6 = mock(QualityGate.Condition.class);
-        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition6).getStatus();
-        doReturn(CoreMetrics.BRANCH_COVERAGE.getKey()).when(condition6).getMetricKey();
-        doReturn("16").when(condition6).getValue();
-        doReturn(QualityGate.Operator.GREATER_THAN).when(condition6).getOperator();
-        doReturn("15").when(condition6).getErrorThreshold();
-
-        QualityGate.Condition condition7 = mock(QualityGate.Condition.class);
-        doReturn(QualityGate.EvaluationStatus.OK).when(condition7).getStatus();
-        doReturn(CoreMetrics.NEW_BUGS.getKey()).when(condition7).getMetricKey();
-        doReturn("0").when(condition7).getValue();
-        doReturn(QualityGate.Operator.LESS_THAN).when(condition7).getOperator();
-        doReturn("1").when(condition7).getErrorThreshold();
-
+    void shouldGetProjectNameFromUnderlyingProject() {
         QualityGate qualityGate = mock(QualityGate.class);
-        doReturn(Arrays.asList(condition1, condition2, condition3, condition4, condition5, condition6, condition7))
-                .when(qualityGate).getConditions();
-
-        Analysis analysis = mock(Analysis.class);
+        PostProjectAnalysisTask.ProjectAnalysis projectAnalysis = mock(PostProjectAnalysisTask.ProjectAnalysis.class);
         Project project = mock(Project.class);
-        doReturn("Project Key").when(project).getKey();
-
-        Component rootComponent = mock(Component.class);
-        doReturn(rootComponent).when(treeRootHolder).getRoot();
-
-        MeasureRepository measureRepository = mock(MeasureRepository.class);
-        doReturn(Optional.of(Measure.newMeasureBuilder().create(12.3, 2, "data"))).when(measureRepository)
-                .getRawMeasure(eq(rootComponent), any(Metric.class));
-        doReturn(measureRepository).when(measuresHolder).getMeasureRepository();
-
-        MetricRepository metricRepository = mock(MetricRepository.class);
-        doReturn(mock(Metric.class)).when(metricRepository).getByKey(anyString());
-        doReturn(metricRepository).when(measuresHolder).getMetricRepository();
-
-        ScannerContext scannerContext = mock(ScannerContext.class);
-        Configuration configuration = mock(Configuration.class);
+        when(project.getName()).thenReturn("Project Name");
+        when(projectAnalysis.getProject()).thenReturn(project);
 
         AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, "http://localhost:9000", scannerContext);
+                new AnalysisDetails("pullRequestKey", "commitHash", new ArrayList<>(), qualityGate, projectAnalysis);
 
-        Formatter<Document> formatter = mock(Formatter.class);
-        doReturn("formatted content").when(formatter).format(any());
-        FormatterFactory formatterFactory = mock(FormatterFactory.class);
-        doReturn(formatter).when(formatterFactory).documentFormatter();
-
-        assertEquals("formatted content", testCase.createAnalysisSummary(formatterFactory));
-
-        ArgumentCaptor<Document> documentArgumentCaptor = ArgumentCaptor.forClass(Document.class);
-        verify(formatter).format(documentArgumentCaptor.capture());
-
-        Document expectedDocument = new Document(new Paragraph(new Image("Failed",
-                                                                         "http://localhost:9000/static/communityBranchPlugin/checks/QualityGateBadge/failed.svg?sanitize=true")),
-                                                 new List(List.Style.BULLET,
-                                                          new ListItem(new Text("12 Lines to Cover (is less than 20)")),
-                                                          new ListItem(new Text("2 Code Smells (is greater than 0)")),
-                                                          new ListItem(new Text(
-                                                                  "68.00% Line Coverage (is less than 80.00%)")),
-                                                          new ListItem(new Text(
-                                                                  "E Security Rating on New Code (is worse than D)")),
-                                                          new ListItem(
-                                                                  new Text("A Reliability Rating (is better than C)")),
-                                                          new ListItem(new Text(
-                                                                  "16.00% Condition Coverage (is greater than 15.00%)"))),
-                                                 new Heading(1, new Text("Analysis Details")),
-                                                 new Heading(2, new Text("5 Issues")), new List(List.Style.BULLET,
-                                                                                                new ListItem(
-                                                                                                        new Image("Bug",
-                                                                                                                  "http://localhost:9000/static/communityBranchPlugin/common/bug.svg?sanitize=true"),
-                                                                                                        new Text(" "),
-                                                                                                        new Text(
-                                                                                                                "2 Bugs")),
-                                                                                                new ListItem(new Image(
-                                                                                                        "Vulnerability",
-                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/vulnerability.svg?sanitize=true"),
-                                                                                                             new Text(
-                                                                                                                     " "),
-                                                                                                             new Text(
-                                                                                                                     "2 Vulnerabilities")),
-                                                                                                new ListItem(new Image(
-                                                                                                        "Code Smell",
-                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/code_smell.svg?sanitize=true"),
-                                                                                                             new Text(
-                                                                                                                     " "),
-                                                                                                             new Text(
-                                                                                                                     "1 Code Smell"))),
-                                                 new Heading(2, new Text("Coverage and Duplications")),
-                                                 new List(List.Style.BULLET, new ListItem(
-                                                         new Image("No coverage information",
-                                                                   "http://localhost:9000/static/communityBranchPlugin/checks/CoverageChart/NoCoverageInfo.svg?sanitize=true"),
-                                                         new Text(" "), new Text(
-                                                         "No coverage information (12.30% Estimated after merge)")),
-                                                          new ListItem(new Image("No duplication information",
-                                                                                 "http://localhost:9000/static/communityBranchPlugin/checks/Duplications/NoDuplicationInfo.svg?sanitize=true"),
-                                                                       new Text(" "), new Text(
-                                                                  "No duplication information (12.30% Estimated after merge)"))),
-                                                 new Paragraph(new Text("**Project ID:** Project Key")),
-                                                 new Paragraph(new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube"))));
-
-        assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
-
-    }
-
-
-    @Test
-    public void testCreateAnalysisSummary2() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        doReturn("5").when(branchDetails).getBranchName();
-
-        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        doReturn(treeRootHolder).when(measuresHolder).getTreeRootHolder();
-
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
-        doReturn(new ArrayList<>()).when(postAnalysisIssueVisitor).getIssues();
-
-        QualityGate.Condition duplicationsCondition = mock(QualityGate.Condition.class);
-        doReturn("18").when(duplicationsCondition).getValue();
-        doReturn(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY).when(duplicationsCondition).getMetricKey();
-
-
-        QualityGate.Condition coverageCondition = mock(QualityGate.Condition.class);
-        doReturn("33").when(coverageCondition).getValue();
-        doReturn(CoreMetrics.NEW_COVERAGE_KEY).when(coverageCondition).getMetricKey();
-
-        QualityGate qualityGate = mock(QualityGate.class);
-        doReturn(QualityGate.Status.OK).when(qualityGate).getStatus();
-        doReturn(Arrays.asList(coverageCondition, duplicationsCondition)).when(qualityGate).getConditions();
-
-        Analysis analysis = mock(Analysis.class);
-        Project project = mock(Project.class);
-        doReturn("Project Key").when(project).getKey();
-
-        Component rootComponent = mock(Component.class);
-        doReturn(rootComponent).when(treeRootHolder).getRoot();
-
-        MeasureRepository measureRepository = mock(MeasureRepository.class);
-        doReturn(Optional.of(Measure.newMeasureBuilder().create(21.782, 2, "data"))).when(measureRepository)
-                .getRawMeasure(eq(rootComponent), any(Metric.class));
-        doReturn(measureRepository).when(measuresHolder).getMeasureRepository();
-
-        MetricRepository metricRepository = mock(MetricRepository.class);
-        doReturn(mock(Metric.class)).when(metricRepository).getByKey(anyString());
-        doReturn(metricRepository).when(measuresHolder).getMetricRepository();
-
-        ScannerContext scannerContext = mock(ScannerContext.class);
-
-        Configuration configuration = mock(Configuration.class);
-
-        AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, "http://localhost:9000", scannerContext);
-
-        Formatter<Document> formatter = mock(Formatter.class);
-        doReturn("formatted content").when(formatter).format(any());
-        FormatterFactory formatterFactory = mock(FormatterFactory.class);
-        doReturn(formatter).when(formatterFactory).documentFormatter();
-
-        assertEquals("formatted content", testCase.createAnalysisSummary(formatterFactory));
-
-        ArgumentCaptor<Document> documentArgumentCaptor = ArgumentCaptor.forClass(Document.class);
-        verify(formatter).format(documentArgumentCaptor.capture());
-
-        Document expectedDocument = new Document(new Paragraph(new Image("Passed",
-                                                                         "http://localhost:9000/static/communityBranchPlugin/checks/QualityGateBadge/passed.svg?sanitize=true")),
-                                                 new Text(""), new Heading(1, new Text("Analysis Details")),
-                                                 new Heading(2, new Text("0 Issues")), new List(List.Style.BULLET,
-                                                                                                new ListItem(
-                                                                                                        new Image("Bug",
-                                                                                                                  "http://localhost:9000/static/communityBranchPlugin/common/bug.svg?sanitize=true"),
-                                                                                                        new Text(" "),
-                                                                                                        new Text(
-                                                                                                                "0 Bugs")),
-                                                                                                new ListItem(new Image(
-                                                                                                        "Vulnerability",
-                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/vulnerability.svg?sanitize=true"),
-                                                                                                             new Text(
-                                                                                                                     " "),
-                                                                                                             new Text(
-                                                                                                                     "0 Vulnerabilities")),
-                                                                                                new ListItem(new Image(
-                                                                                                        "Code Smell",
-                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/code_smell.svg?sanitize=true"),
-                                                                                                             new Text(
-                                                                                                                     " "),
-                                                                                                             new Text(
-                                                                                                                     "0 Code Smells"))),
-                                                 new Heading(2, new Text("Coverage and Duplications")),
-                                                 new List(List.Style.BULLET, new ListItem(
-                                                         new Image("25 percent coverage",
-                                                                   "http://localhost:9000/static/communityBranchPlugin/checks/CoverageChart/25.svg?sanitize=true"),
-                                                         new Text(" "),
-                                                         new Text("33.00% Coverage (21.78% Estimated after merge)")),
-                                                          new ListItem(new Image("20 percent duplication",
-                                                                                 "http://localhost:9000/static/communityBranchPlugin/checks/Duplications/20.svg?sanitize=true"),
-                                                                       new Text(" "), new Text(
-                                                                  "18.00% Duplicated Code (21.78% Estimated after merge)"))),
-                                                 new Paragraph(new Text("**Project ID:** Project Key")),
-                                                 new Paragraph(new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube"))));
-
-        assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
-
+        assertEquals("Project Name", testCase.getAnalysisProjectName());
     }
 
     @Test
-    public void testCreateAnalysisSummary3() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        doReturn("5").when(branchDetails).getBranchName();
-
-        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        doReturn(treeRootHolder).when(measuresHolder).getTreeRootHolder();
-
-        PostAnalysisIssueVisitor.LightIssue issue = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        doReturn(Issue.STATUS_OPEN).when(issue).status();
-        doReturn(RuleType.BUG).when(issue).type();
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
-
-        PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
-        doReturn(issue).when(componentIssue).getIssue();
-        doReturn(Collections.singletonList(componentIssue)).when(postAnalysisIssueVisitor).getIssues();
-
-        QualityGate.Condition duplicationsCondition = mock(QualityGate.Condition.class);
-        doReturn("10").when(duplicationsCondition).getValue();
-        doReturn(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY).when(duplicationsCondition).getMetricKey();
-
-
-        QualityGate.Condition coverageCondition = mock(QualityGate.Condition.class);
-        doReturn("25").when(coverageCondition).getValue();
-        doReturn(CoreMetrics.NEW_COVERAGE_KEY).when(coverageCondition).getMetricKey();
-
-        QualityGate qualityGate = mock(QualityGate.class);
-        doReturn(QualityGate.Status.OK).when(qualityGate).getStatus();
-        doReturn(Arrays.asList(coverageCondition, duplicationsCondition)).when(qualityGate).getConditions();
-
-        Analysis analysis = mock(Analysis.class);
-        Project project = mock(Project.class);
-        doReturn("Project Key").when(project).getKey();
-
-        Component rootComponent = mock(Component.class);
-        doReturn(rootComponent).when(treeRootHolder).getRoot();
-
-        MeasureRepository measureRepository = mock(MeasureRepository.class);
-        doReturn(Optional.of(Measure.newMeasureBuilder().create(21.782, 2, "data"))).when(measureRepository)
-                .getRawMeasure(eq(rootComponent), any(Metric.class));
-        doReturn(measureRepository).when(measuresHolder).getMeasureRepository();
-
-        MetricRepository metricRepository = mock(MetricRepository.class);
-        doReturn(mock(Metric.class)).when(metricRepository).getByKey(anyString());
-        doReturn(metricRepository).when(measuresHolder).getMetricRepository();
-
-        ScannerContext scannerContext = mock(ScannerContext.class);
-
-        Configuration configuration = mock(Configuration.class);
-        doReturn(Optional.of("http://host.name/path")).when(configuration)
-                .get(eq(CommunityBranchPlugin.IMAGE_URL_BASE));
-
-        AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, "http://localhost:9000", scannerContext);
-
-        Formatter<Document> formatter = mock(Formatter.class);
-        doReturn("formatted content").when(formatter).format(any());
-        FormatterFactory formatterFactory = mock(FormatterFactory.class);
-        doReturn(formatter).when(formatterFactory).documentFormatter();
-
-        assertEquals("formatted content", testCase.createAnalysisSummary(formatterFactory));
-
-        ArgumentCaptor<Document> documentArgumentCaptor = ArgumentCaptor.forClass(Document.class);
-        verify(formatter).format(documentArgumentCaptor.capture());
-
-        Document expectedDocument = new Document(new Paragraph(
-                new Image("Passed", "http://host.name/path/checks/QualityGateBadge/passed.svg?sanitize=true")),
-                                                 new Text(""), new Heading(1, new Text("Analysis Details")),
-                                                 new Heading(2, new Text("1 Issue")), new List(List.Style.BULLET,
-                                                                                               new ListItem(
-                                                                                                       new Image("Bug",
-                                                                                                                 "http://host.name/path/common/bug.svg?sanitize=true"),
-                                                                                                       new Text(" "),
-                                                                                                       new Text(
-                                                                                                               "1 Bug")),
-                                                                                               new ListItem(new Image(
-                                                                                                       "Vulnerability",
-                                                                                                       "http://host.name/path/common/vulnerability.svg?sanitize=true"),
-                                                                                                            new Text(
-                                                                                                                    " "),
-                                                                                                            new Text(
-                                                                                                                    "0 Vulnerabilities")),
-                                                                                               new ListItem(new Image(
-                                                                                                       "Code Smell",
-                                                                                                       "http://host.name/path/common/code_smell.svg?sanitize=true"),
-                                                                                                            new Text(
-                                                                                                                    " "),
-                                                                                                            new Text(
-                                                                                                                    "0 Code Smells"))),
-                                                 new Heading(2, new Text("Coverage and Duplications")),
-                                                 new List(List.Style.BULLET, new ListItem(
-                                                         new Image("25 percent coverage",
-                                                                   "http://host.name/path/checks/CoverageChart/25.svg?sanitize=true"),
-                                                         new Text(" "),
-                                                         new Text("25.00% Coverage (21.78% Estimated after merge)")),
-                                                          new ListItem(new Image("10 percent duplication",
-                                                                                 "http://host.name/path/checks/Duplications/10.svg?sanitize=true"),
-                                                                       new Text(" "), new Text(
-                                                                  "10.00% Duplicated Code (21.78% Estimated after merge)"))),
-                                                 new Paragraph(new Text("**Project ID:** Project Key")),
-                                                 new Paragraph(new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube"))));
-
-        assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
-
-    }
-
-    @Test
-    public void testCreateAnalysisSummary4() {
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        doReturn("5").when(branchDetails).getBranchName();
-
-        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
-        AnalysisDetails.MeasuresHolder measuresHolder = mock(AnalysisDetails.MeasuresHolder.class);
-        doReturn(treeRootHolder).when(measuresHolder).getTreeRootHolder();
-
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
-        doReturn(new ArrayList<>()).when(postAnalysisIssueVisitor).getIssues();
-
-        QualityGate.Condition duplicationsCondition = mock(QualityGate.Condition.class);
-        doReturn("30").when(duplicationsCondition).getValue();
-        doReturn(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY_KEY).when(duplicationsCondition).getMetricKey();
-
-
-        QualityGate.Condition coverageCondition = mock(QualityGate.Condition.class);
-        doReturn("0").when(coverageCondition).getValue();
-        doReturn(CoreMetrics.NEW_COVERAGE_KEY).when(coverageCondition).getMetricKey();
-
-        QualityGate qualityGate = mock(QualityGate.class);
-        doReturn(QualityGate.Status.OK).when(qualityGate).getStatus();
-        doReturn(Arrays.asList(coverageCondition, duplicationsCondition)).when(qualityGate).getConditions();
-
-        Analysis analysis = mock(Analysis.class);
-        Project project = mock(Project.class);
-        doReturn("Project Key").when(project).getKey();
-
-        Component rootComponent = mock(Component.class);
-        doReturn(rootComponent).when(treeRootHolder).getRoot();
-
-        MeasureRepository measureRepository = mock(MeasureRepository.class);
-        doReturn(Optional.of(Measure.newMeasureBuilder().create(21.782, 2, "data"))).when(measureRepository)
-                .getRawMeasure(eq(rootComponent), any(Metric.class));
-        doReturn(measureRepository).when(measuresHolder).getMeasureRepository();
-
-        MetricRepository metricRepository = mock(MetricRepository.class);
-        doReturn(mock(Metric.class)).when(metricRepository).getByKey(anyString());
-        doReturn(metricRepository).when(measuresHolder).getMetricRepository();
-
-        ScannerContext scannerContext = mock(ScannerContext.class);
-        Configuration configuration = mock(Configuration.class);
-
-        AnalysisDetails testCase =
-                new AnalysisDetails(branchDetails, postAnalysisIssueVisitor, qualityGate, measuresHolder, analysis,
-                                    project, configuration, "http://localhost:9000", scannerContext);
-
-        Formatter<Document> formatter = mock(Formatter.class);
-        doReturn("formatted content").when(formatter).format(any());
-        FormatterFactory formatterFactory = mock(FormatterFactory.class);
-        doReturn(formatter).when(formatterFactory).documentFormatter();
-
-        assertEquals("formatted content", testCase.createAnalysisSummary(formatterFactory));
-
-        ArgumentCaptor<Document> documentArgumentCaptor = ArgumentCaptor.forClass(Document.class);
-        verify(formatter).format(documentArgumentCaptor.capture());
-
-        Document expectedDocument = new Document(new Paragraph(new Image("Passed",
-                                                                         "http://localhost:9000/static/communityBranchPlugin/checks/QualityGateBadge/passed.svg?sanitize=true")),
-                                                 new Text(""), new Heading(1, new Text("Analysis Details")),
-                                                 new Heading(2, new Text("0 Issues")), new List(List.Style.BULLET,
-                                                                                                new ListItem(
-                                                                                                        new Image("Bug",
-                                                                                                                  "http://localhost:9000/static/communityBranchPlugin/common/bug.svg?sanitize=true"),
-                                                                                                        new Text(" "),
-                                                                                                        new Text(
-                                                                                                                "0 Bugs")),
-                                                                                                new ListItem(new Image(
-                                                                                                        "Vulnerability",
-                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/vulnerability.svg?sanitize=true"),
-                                                                                                             new Text(
-                                                                                                                     " "),
-                                                                                                             new Text(
-                                                                                                                     "0 Vulnerabilities")),
-                                                                                                new ListItem(new Image(
-                                                                                                        "Code Smell",
-                                                                                                        "http://localhost:9000/static/communityBranchPlugin/common/code_smell.svg?sanitize=true"),
-                                                                                                             new Text(
-                                                                                                                     " "),
-                                                                                                             new Text(
-                                                                                                                     "0 Code Smells"))),
-                                                 new Heading(2, new Text("Coverage and Duplications")),
-                                                 new List(List.Style.BULLET, new ListItem(
-                                                         new Image("0 percent coverage",
-                                                                   "http://localhost:9000/static/communityBranchPlugin/checks/CoverageChart/0.svg?sanitize=true"),
-                                                         new Text(" "),
-                                                         new Text("0.00% Coverage (21.78% Estimated after merge)")),
-                                                          new ListItem(new Image("20plus percent duplication",
-                                                                                 "http://localhost:9000/static/communityBranchPlugin/checks/Duplications/20plus.svg?sanitize=true"),
-                                                                       new Text(" "), new Text(
-                                                                  "30.00% Duplicated Code (21.78% Estimated after merge)"))),
-                                                 new Paragraph(new Text("**Project ID:** Project Key")),
-                                                 new Paragraph(new Link("http://localhost:9000/dashboard?id=Project+Key&pullRequest=5", new Text("View in SonarQube"))));
-
-        assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
-
-    }
-
-    @Test
-    public void testCorrectMeasuresRepositoryReturned() {
-        MeasureRepository measureRepository = mock(MeasureRepository.class);
-        MetricRepository metricRepository = mock(MetricRepository.class);
-        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
-
-        AnalysisDetails.MeasuresHolder testCase =
-                new AnalysisDetails.MeasuresHolder(metricRepository, measureRepository, treeRootHolder);
-
-        assertEquals(measureRepository, testCase.getMeasureRepository());
-    }
-
-    @Test
-    public void testCorrectMetricsRepositoryReturned() {
-        MeasureRepository measureRepository = mock(MeasureRepository.class);
-        MetricRepository metricRepository = mock(MetricRepository.class);
-        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
-
-        AnalysisDetails.MeasuresHolder testCase =
-                new AnalysisDetails.MeasuresHolder(metricRepository, measureRepository, treeRootHolder);
-
-        assertEquals(metricRepository, testCase.getMetricRepository());
-    }
-
-    @Test
-    public void testCorrectTreeRootHolderReturned() {
-        MeasureRepository measureRepository = mock(MeasureRepository.class);
-        MetricRepository metricRepository = mock(MetricRepository.class);
-        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
-
-        AnalysisDetails.MeasuresHolder testCase =
-                new AnalysisDetails.MeasuresHolder(metricRepository, measureRepository, treeRootHolder);
-
-        assertEquals(treeRootHolder, testCase.getTreeRootHolder());
-    }
-
-    @Test
-    public void testCorrectPostAnalysisIssueVisitorReturned() {
-        PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
-        AnalysisDetails analysisDetails =
-                new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), postAnalysisIssueVisitor,
-                                    mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class),
-                                    mock(Analysis.class), mock(Project.class), mock(Configuration.class), null,
-                                    mock(ScannerContext.class));
-        assertSame(postAnalysisIssueVisitor, analysisDetails.getPostAnalysisIssueVisitor());
-    }
-
-    @Test
-    public void testCorrectBranchDetailsReturned() {
-        AnalysisDetails.BranchDetails branchDetails = new AnalysisDetails.BranchDetails("branchName", "commitId");
-        assertEquals("branchName", branchDetails.getBranchName());
-        assertEquals("commitId", branchDetails.getCommitId());
-    }
-
-    @Test
-    public void testGetBaseImageUrlFromConfig() {
-        Configuration configuration = mock(Configuration.class);
-        doReturn(Optional.of("http://host.name/path")).when(configuration)
-                .get(eq(CommunityBranchPlugin.IMAGE_URL_BASE));
-
-        AnalysisDetails analysisDetails =
-                new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
-                        mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class),
-                        mock(Analysis.class), mock(Project.class), configuration, "http://localhost:9000", mock(ScannerContext.class));
-
-        assertEquals("http://host.name/path", analysisDetails.getBaseImageUrl());
-    }
-
-    @Test
-    public void testGetBaseImageUrlFromConfigWithTrailingSlash() {
-        Configuration configuration = mock(Configuration.class);
-        doReturn(Optional.of("http://host.name/path/")).when(configuration)
-                .get(eq(CommunityBranchPlugin.IMAGE_URL_BASE));
-
-        AnalysisDetails analysisDetails =
-                new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
-                        mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class),
-                        mock(Analysis.class), mock(Project.class), configuration, "http://localhost:9000", mock(ScannerContext.class));
-
-        assertEquals("http://host.name/path", analysisDetails.getBaseImageUrl());
-    }
-
-    @Test
-    public void testGetBaseImageUrlFromRootUrl() {
-        AnalysisDetails analysisDetails =
-                new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
-                        mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class),
-                        mock(Analysis.class), mock(Project.class), mock(Configuration.class), "http://localhost:9000", mock(ScannerContext.class));
-
-        assertEquals("http://localhost:9000/static/communityBranchPlugin", analysisDetails.getBaseImageUrl());
-    }
-
-    @Test
-    public void testGetIssueUrlBug() {
-        Project project = mock(Project.class);
-        doReturn("projectKey").when(project).getKey();
-
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        doReturn("123").when(branchDetails).getBranchName();
-
-        AnalysisDetails analysisDetails =
-                new AnalysisDetails(branchDetails, mock(PostAnalysisIssueVisitor.class),
-                        mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class),
-                        mock(Analysis.class), project, mock(Configuration.class), "http://localhost:9000", mock(ScannerContext.class));
-
-        PostAnalysisIssueVisitor.LightIssue lightIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        when(lightIssue.key()).thenReturn("issueKey");
-        when(lightIssue.type()).thenReturn(RuleType.BUG);
-
-        assertEquals("http://localhost:9000/project/issues?id=projectKey&pullRequest=123&issues=issueKey&open=issueKey", analysisDetails.getIssueUrl(lightIssue));
-    }
-
-    @Test
-    public void testGetIssueUrlSecurityHotspot() {
-        Project project = mock(Project.class);
-        doReturn("projectKey").when(project).getKey();
-
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        doReturn("123").when(branchDetails).getBranchName();
-
-        AnalysisDetails analysisDetails =
-                new AnalysisDetails(branchDetails, mock(PostAnalysisIssueVisitor.class),
-                        mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class),
-                        mock(Analysis.class), project, mock(Configuration.class), "http://localhost:9000", mock(ScannerContext.class));
-
-        PostAnalysisIssueVisitor.LightIssue lightIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        when(lightIssue.key()).thenReturn("secondIssueKey");
-        when(lightIssue.type()).thenReturn(RuleType.SECURITY_HOTSPOT);
-
-        assertEquals("http://localhost:9000/security_hotspots?id=projectKey&pullRequest=123&hotspots=secondIssueKey", analysisDetails.getIssueUrl(lightIssue));
-    }
-
-    @Test
-    public void testGetRuleUrlWithRuleKey() {
-        AnalysisDetails analysisDetails =
-                new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
-                        mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class),
-                        mock(Analysis.class), mock(Project.class), mock(Configuration.class), "http://localhost:9000", mock(ScannerContext.class));
-
-        assertEquals("http://localhost:9000/coding_rules?open=ruleKey&rule_key=ruleKey", analysisDetails.getRuleUrlWithRuleKey("ruleKey"));
-    }
-
-    @Test
-    public void testCreateAnalysisIssueSummary() {
-        FormatterFactory formatterFactory = mock(FormatterFactory.class);
-        PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
-
-        AnalysisDetails.BranchDetails branchDetails = mock(AnalysisDetails.BranchDetails.class);
-        when(branchDetails.getBranchName()).thenReturn("branchName");
-
-        PostAnalysisIssueVisitor.LightIssue lightIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
-        when(lightIssue.type()).thenReturn(RuleType.BUG);
-        when(lightIssue.getMessage()).thenReturn("message");
-        when(lightIssue.severity()).thenReturn("severity");
-        when(lightIssue.key()).thenReturn("issueKey");
-        when(lightIssue.effortInMinutes()).thenReturn(123L);
-        when(componentIssue.getIssue()).thenReturn(lightIssue);
-
-        Project project = mock(Project.class);
-        when(project.getKey()).thenReturn("projectKey");
-
-        Formatter<Document> documentFormatter = mock(Formatter.class);
-        when(formatterFactory.documentFormatter()).thenReturn(documentFormatter);
-
-        AnalysisDetails analysisDetails =
-                new AnalysisDetails(branchDetails, mock(PostAnalysisIssueVisitor.class),
-                        mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class),
-                        mock(Analysis.class), project, mock(Configuration.class), "http://localhost:9000", mock(ScannerContext.class));
-
-        ArgumentCaptor<Document> documentArgumentCaptor = ArgumentCaptor.forClass(Document.class);
-        analysisDetails.createAnalysisIssueSummary(componentIssue, formatterFactory);
-        verify(documentFormatter).format(documentArgumentCaptor.capture());
-
-        assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(
-                new Document(
-                        new Paragraph(
-                                new Text("**Type:** BUG "),
-                                new Image("BUG", "http://localhost:9000/static/communityBranchPlugin/checks/IssueType/bug.svg?sanitize=true")
-                        ),
-                        new Paragraph(
-                                new Text("**Severity:** severity "),
-                                new Image("severity", "http://localhost:9000/static/communityBranchPlugin/checks/Severity/severity.svg?sanitize=true")
-                        ),
-                        new Paragraph(new Text("**Message:** message")),
-                        new Paragraph(new Text("**Duration (min):** 123")),
-                        new Text(""),
-                        new Paragraph(new Text("**Project ID:** projectKey **Issue ID:** issueKey")),
-                        new Paragraph(new Link("http://localhost:9000/project/issues?id=projectKey&pullRequest=branchName&issues=issueKey&open=issueKey", new Text("View in SonarQube")))
-                )
-        );
-    }
-
-    @Test
-    public void testFakeIdReturnedForSummaryComment() {
-        AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
-                mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
-                mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("https://sonarqube.dummy/path/dashboard?id=project&pullRequest=123"))
-                .get()
-                .usingRecursiveComparison()
-                .isEqualTo(new AnalysisDetails.ProjectIssueIdentifier("project", "decorator-summary-comment"));
-    }
-
-    @Test
-    public void testIssueIdReturnedForHotspotUrl() {
-        AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
-                mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
-                mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/security_hotspots?id=projectIdentifier&hotspots=A1B2-Z9Y8X7"))
-                .get()
-                .usingRecursiveComparison()
-                .isEqualTo(new AnalysisDetails.ProjectIssueIdentifier("projectIdentifier", "A1B2-Z9Y8X7"));
-    }
-
-    @Test
-    public void testNoIssueIdReturnedForHotspotUrlWithoutId() {
-        AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
-                mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
-                mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/security_hotspots?id=projectId&other_parameter=ABC"))
-                .isEmpty();
-    }
-
-    @Test
-    public void testIssueIdReturnedForIssueUrl() {
-        AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
-                mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
-                mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/issue?id=projectId&issues=XXX-YYY-ZZZ"))
-                .get()
-                .usingRecursiveComparison()
-                .isEqualTo(new AnalysisDetails.ProjectIssueIdentifier("projectId", "XXX-YYY-ZZZ"));
-    }
-
-    @Test
-    public void testNoIssueIdReturnedForIssueUrlWithoutId() {
-        AnalysisDetails analysisDetails = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), mock(PostAnalysisIssueVisitor.class),
-                mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
-                mock(Configuration.class),"", mock(ScannerContext.class));
-        assertThat(analysisDetails.parseIssueIdFromUrl("http://subdomain.sonarqube.dummy/path/issue?id=projectId&other_parameter=123")).isEmpty();
-    }
-    
-    @Test
-    public void shouldOnlyReturnNonClosedFileIssuesWithScmInfo() {
+    void shouldOnlyReturnNonClosedFileIssuesWithScmInfo() {
         PostAnalysisIssueVisitor.LightIssue lightIssue1 = mock(PostAnalysisIssueVisitor.LightIssue.class);
         when(lightIssue1.status()).thenReturn(Issue.STATUS_OPEN);
         Component component1 = mock(Component.class);
@@ -953,10 +156,81 @@ public class AnalysisDetailsTest {
         PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
         when(postAnalysisIssueVisitor.getIssues()).thenReturn(Arrays.asList(componentIssue1, componentIssue2, componentIssue3, componentIssue4));
         
-        AnalysisDetails underTest = new AnalysisDetails(mock(AnalysisDetails.BranchDetails.class), postAnalysisIssueVisitor,
-                mock(QualityGate.class), mock(AnalysisDetails.MeasuresHolder.class), mock(Analysis.class), mock(Project.class),
-                mock(Configuration.class),"", mock(ScannerContext.class));
+        AnalysisDetails underTest = new AnalysisDetails("pullRequest", "commmitId",
+                Arrays.asList(componentIssue1, componentIssue2, componentIssue3, componentIssue4),
+                mock(QualityGate.class), mock(PostProjectAnalysisTask.ProjectAnalysis.class));
         
         assertThat(underTest.getScmReportableIssues()).containsOnly(componentIssue1);
+    }
+
+    @Test
+    void shouldOnlyReturnQualityGateConditionsInErrorState() {
+        QualityGate qualityGate = mock(QualityGate.class);
+
+        QualityGate.Condition condition1 = mock(QualityGate.Condition.class);
+        when(condition1.getStatus()).thenReturn(QualityGate.EvaluationStatus.OK);
+        QualityGate.Condition condition2 = mock(QualityGate.Condition.class);
+        when(condition2.getStatus()).thenReturn(QualityGate.EvaluationStatus.ERROR);
+        QualityGate.Condition condition3 = mock(QualityGate.Condition.class);
+        when(condition3.getStatus()).thenReturn(QualityGate.EvaluationStatus.NO_VALUE);
+        QualityGate.Condition condition4 = mock(QualityGate.Condition.class);
+        when(condition4.getStatus()).thenReturn(QualityGate.EvaluationStatus.WARN);
+        QualityGate.Condition condition5 = mock(QualityGate.Condition.class);
+        when(condition5.getStatus()).thenReturn(QualityGate.EvaluationStatus.ERROR);
+
+        when(qualityGate.getConditions()).thenReturn(List.of(condition1, condition2, condition3, condition4, condition5));
+
+        AnalysisDetails underTest = new AnalysisDetails("pullRequest", "commit", List.of(), qualityGate, mock(PostProjectAnalysisTask.ProjectAnalysis.class));
+
+        assertThat(underTest.findFailedQualityGateConditions()).isEqualTo(List.of(condition2, condition5));
+    }
+
+    @Test
+    void shouldFilterOnQualityGateConditionName() {
+        QualityGate qualityGate = mock(QualityGate.class);
+
+        List<QualityGate.Condition> conditions = IntStream.range(0, 10).mapToObj(i -> {
+            QualityGate.Condition condition = mock(QualityGate.Condition.class);
+            when(condition.getMetricKey()).thenReturn("key" + i);
+            return condition;
+        }).collect(Collectors.toList());
+
+        when(qualityGate.getConditions()).thenReturn(conditions);
+
+        AnalysisDetails underTest = new AnalysisDetails("pullRequest", "commit", List.of(), qualityGate, mock(PostProjectAnalysisTask.ProjectAnalysis.class));
+
+        assertThat(underTest.findQualityGateCondition("key2")).contains(conditions.get(2));
+    }
+
+    @Test
+    void shouldRetrievePropertyFromScannerProperties() {
+        Map<String, String> scannerProperties = mock(Map.class);
+        when(scannerProperties.get(anyString())).thenReturn("world");
+
+        ScannerContext scannerContext = mock(ScannerContext.class);
+        when(scannerContext.getProperties()).thenReturn(scannerProperties);
+        PostProjectAnalysisTask.ProjectAnalysis projectAnalysis = mock(PostProjectAnalysisTask.ProjectAnalysis.class);
+        when(projectAnalysis.getScannerContext()).thenReturn(scannerContext);
+
+        AnalysisDetails underTest = new AnalysisDetails("PullRequest", "Commit", List.of(), mock(QualityGate.class), projectAnalysis);
+
+        assertThat(underTest.getScannerProperty("hello")).contains("world");
+
+        verify(scannerProperties).get("hello");
+    }
+
+    @Test
+    void shouldReturnPullRequestId() {
+        AnalysisDetails underTest = new AnalysisDetails("pull-request-id", "commit-id", List.of(), mock(QualityGate.class), mock(PostProjectAnalysisTask.ProjectAnalysis.class));
+
+        assertThat(underTest.getPullRequestId()).isEqualTo("pull-request-id");
+    }
+
+
+    @Test
+    void shouldReturnCommitSha() {
+        AnalysisDetails underTest = new AnalysisDetails("pull-request-id", "commit-id", List.of(), mock(QualityGate.class), mock(PostProjectAnalysisTask.ProjectAnalysis.class));
+
+        assertThat(underTest.getCommitSha()).isEqualTo("commit-id");
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PostAnalysisIssueVisitorTest.java
@@ -22,11 +22,13 @@ import org.junit.Test;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rules.RuleType;
 import org.sonar.ce.task.projectanalysis.component.Component;
+import org.sonar.ce.task.projectanalysis.component.ReportAttributes;
 import org.sonar.core.issue.DefaultIssue;
 import org.sonar.db.protobuf.DbIssues;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -35,6 +37,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class PostAnalysisIssueVisitorTest {
 
@@ -55,9 +58,9 @@ public class PostAnalysisIssueVisitorTest {
 
         List<PostAnalysisIssueVisitor.ComponentIssue> expected = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
-            DefaultIssue issue = (i == 10 ? null : mock(DefaultIssue.class));
-            Component component = (i == 5 ? null : mock(Component.class));
-            expected.add(new PostAnalysisIssueVisitor.ComponentIssue(component, null == issue ? null : new PostAnalysisIssueVisitor.LightIssue(issue)));
+            DefaultIssue issue = mock(DefaultIssue.class);
+            Component component = mock(Component.class);
+            expected.add(new PostAnalysisIssueVisitor.ComponentIssue(component, new PostAnalysisIssueVisitor.LightIssue(issue)));
 
             testCase.onIssue(component, issue);
         }
@@ -89,10 +92,11 @@ public class PostAnalysisIssueVisitorTest {
     public void testLightIssueMapping() {
         // mock a DefaultIssue
         DefaultIssue defaultIssue = exampleDefaultIssue();
+        Component component = mock(Component.class);
 
         // map the DefaultIssue into a LightIssue (using PostAnalysisIssueVisitor to workaround private constructor)
         PostAnalysisIssueVisitor visitor = new PostAnalysisIssueVisitor();
-        visitor.onIssue(null, defaultIssue);
+        visitor.onIssue(component, defaultIssue);
         PostAnalysisIssueVisitor.LightIssue lightIssue = visitor.getIssues().get(0).getIssue();
 
         // check values equality, twice (see below)
@@ -127,11 +131,12 @@ public class PostAnalysisIssueVisitorTest {
     @Test
     public void testEqualLightIssues() {
         DefaultIssue defaultIssue = exampleDefaultIssue();
+        Component component = mock(Component.class);
 
         // map the DefaultIssue into two equal LightIssues
         PostAnalysisIssueVisitor visitor = new PostAnalysisIssueVisitor();
-        visitor.onIssue(null, defaultIssue);
-        visitor.onIssue(null, defaultIssue);
+        visitor.onIssue(component, defaultIssue);
+        visitor.onIssue(component, defaultIssue);
         PostAnalysisIssueVisitor.LightIssue lightIssue1 = visitor.getIssues().get(0).getIssue();
         PostAnalysisIssueVisitor.LightIssue lightIssue2 = visitor.getIssues().get(1).getIssue();
 
@@ -147,15 +152,16 @@ public class PostAnalysisIssueVisitorTest {
     @Test
     public void testDifferentLightIssues() {
         DefaultIssue defaultIssue = exampleDefaultIssue();
+        Component component = mock(Component.class);
 
         // map the DefaultIssue into a first LightIssue
         PostAnalysisIssueVisitor visitor = new PostAnalysisIssueVisitor();
-        visitor.onIssue(null, defaultIssue);
+        visitor.onIssue(component, defaultIssue);
         PostAnalysisIssueVisitor.LightIssue lightIssue1 = visitor.getIssues().get(0).getIssue();
 
-        // map a slightly different DefaultIssue into an other LightIssue
+        // map a slightly different DefaultIssue into another LightIssue
         doReturn("another message").when(defaultIssue).getMessage();
-        visitor.onIssue(null, defaultIssue);
+        visitor.onIssue(component, defaultIssue);
         PostAnalysisIssueVisitor.LightIssue lightIssue2 = visitor.getIssues().get(1).getIssue();
 
         // assert difference
@@ -167,5 +173,48 @@ public class PostAnalysisIssueVisitorTest {
         assertNotEquals(lightIssue1, null);
         
     }
+
+    @Test
+    public void shouldReturnScmInfoForFileComponent() {
+        Component component = mock(Component.class);
+        when(component.getType()).thenReturn(Component.Type.FILE);
+        ReportAttributes reportAttributes = mock(ReportAttributes.class);
+        when(reportAttributes.getScmPath()).thenReturn(Optional.of("path"));
+        when(component.getReportAttributes()).thenReturn(reportAttributes);
+
+        PostAnalysisIssueVisitor.LightIssue issue = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        PostAnalysisIssueVisitor.ComponentIssue underTest = new PostAnalysisIssueVisitor.ComponentIssue(component, issue);
+
+        assertThat(underTest.getScmPath()).contains("path");
+    }
+
+    @Test
+    public void shouldReturnNoScmInfoForNonFileComponent() {
+        Component component = mock(Component.class);
+        when(component.getType()).thenReturn(Component.Type.PROJECT);
+        ReportAttributes reportAttributes = mock(ReportAttributes.class);
+        when(reportAttributes.getScmPath()).thenReturn(Optional.of("path"));
+        when(component.getReportAttributes()).thenReturn(reportAttributes);
+
+        PostAnalysisIssueVisitor.LightIssue issue = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        PostAnalysisIssueVisitor.ComponentIssue underTest = new PostAnalysisIssueVisitor.ComponentIssue(component, issue);
+
+        assertThat(underTest.getScmPath()).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnNoScmInfoForFileComponentWithNoInfo() {
+        Component component = mock(Component.class);
+        when(component.getType()).thenReturn(Component.Type.FILE);
+        ReportAttributes reportAttributes = mock(ReportAttributes.class);
+        when(reportAttributes.getScmPath()).thenReturn(Optional.empty());
+        when(component.getReportAttributes()).thenReturn(reportAttributes);
+
+        PostAnalysisIssueVisitor.LightIssue issue = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        PostAnalysisIssueVisitor.ComponentIssue underTest = new PostAnalysisIssueVisitor.ComponentIssue(component, issue);
+
+        assertThat(underTest.getScmPath()).isEmpty();
+    }
+
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTaskTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Michael Clarke
+ * Copyright (C) 2020-2022 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,8 +18,8 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.sonar.api.ce.posttask.Analysis;
 import org.sonar.api.ce.posttask.Branch;
@@ -27,11 +27,6 @@ import org.sonar.api.ce.posttask.PostProjectAnalysisTask;
 import org.sonar.api.ce.posttask.Project;
 import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.ce.posttask.ScannerContext;
-import org.sonar.api.config.Configuration;
-import org.sonar.api.platform.Server;
-import org.sonar.ce.task.projectanalysis.component.TreeRootHolder;
-import org.sonar.ce.task.projectanalysis.measure.MeasureRepository;
-import org.sonar.ce.task.projectanalysis.metric.MetricRepository;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.alm.setting.ALM;
@@ -62,42 +57,36 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class PullRequestPostAnalysisTaskTest {
+class PullRequestPostAnalysisTaskTest {
 
-    private PostProjectAnalysisTask.ProjectAnalysis projectAnalysis = mock(PostProjectAnalysisTask.ProjectAnalysis.class);
-    private Branch branch = mock(Branch.class);
-    private ScannerContext scannerContext = mock(ScannerContext.class);
+    private final PostProjectAnalysisTask.ProjectAnalysis projectAnalysis = mock(PostProjectAnalysisTask.ProjectAnalysis.class);
+    private final Branch branch = mock(Branch.class);
+    private final ScannerContext scannerContext = mock(ScannerContext.class);
 
-    private Server server = mock(Server.class);
-    private List<PullRequestBuildStatusDecorator> pullRequestBuildStatusDecorators = new ArrayList<>();
-    private PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
-    private MetricRepository metricRepository = mock(MetricRepository.class);
-    private MeasureRepository measureRepository = mock(MeasureRepository.class);
-    private TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
-    private PostProjectAnalysisTask.Context context = mock(PostProjectAnalysisTask.Context.class);
-    private DbClient dbClient = mock(DbClient.class);
-    private Project project = mock(Project.class);
-    private Configuration configuration = mock(Configuration.class);
+    private final List<PullRequestBuildStatusDecorator> pullRequestBuildStatusDecorators = new ArrayList<>();
+    private final PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
+    private final PostProjectAnalysisTask.Context context = mock(PostProjectAnalysisTask.Context.class);
+    private final DbClient dbClient = mock(DbClient.class);
+    private final Project project = mock(Project.class);
+    private final List<PostAnalysisIssueVisitor.ComponentIssue> componentIssues = List.of(mock(PostAnalysisIssueVisitor.ComponentIssue.class));
 
-    private PullRequestPostAnalysisTask testCase =
-            new PullRequestPostAnalysisTask(server, pullRequestBuildStatusDecorators,
-                    postAnalysisIssueVisitor, metricRepository, measureRepository,
-                    treeRootHolder, configuration, dbClient);
+    private final PullRequestPostAnalysisTask testCase =
+            new PullRequestPostAnalysisTask(pullRequestBuildStatusDecorators,
+                    postAnalysisIssueVisitor, dbClient);
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         doReturn(Optional.of(branch)).when(projectAnalysis).getBranch();
         doReturn(scannerContext).when(projectAnalysis).getScannerContext();
         doReturn(new HashMap<>()).when(scannerContext).getProperties();
         doReturn(projectAnalysis).when(context).getProjectAnalysis();
         doReturn(project).when(projectAnalysis).getProject();
         doReturn("uuid").when(project).getUuid();
-
-
+        doReturn(componentIssues).when(postAnalysisIssueVisitor).getIssues();
     }
 
     @Test
-    public void testFinishedNonPullRequest() {
+    void testFinishedNonPullRequest() {
         doReturn(Branch.Type.BRANCH).when(branch).getType();
 
         testCase.finished(context);
@@ -107,7 +96,7 @@ public class PullRequestPostAnalysisTaskTest {
     }
 
     @Test
-    public void testFinishedNoBranchName() {
+    void testFinishedNoBranchName() {
         doReturn(Branch.Type.PULL_REQUEST).when(branch).getType();
         doReturn(Optional.empty()).when(branch).getName();
 
@@ -117,7 +106,7 @@ public class PullRequestPostAnalysisTaskTest {
     }
 
     @Test
-    public void testFinishedNoProviderSet() {
+    void testFinishedNoProviderSet() {
         doReturn(Branch.Type.PULL_REQUEST).when(branch).getType();
         doReturn(Optional.of("branchName")).when(branch).getName();
 
@@ -145,7 +134,7 @@ public class PullRequestPostAnalysisTaskTest {
     }
 
     @Test
-    public void testFinishedNoProviderMatchingName() {
+    void testFinishedNoProviderMatchingName() {
         doReturn(Branch.Type.PULL_REQUEST).when(branch).getType();
         doReturn(Optional.of("branchName")).when(branch).getName();
 
@@ -181,7 +170,7 @@ public class PullRequestPostAnalysisTaskTest {
     }
 
     @Test
-    public void testFinishedNoAnalysis() {
+    void testFinishedNoAnalysis() {
         doReturn(Branch.Type.PULL_REQUEST).when(branch).getType();
         doReturn(Optional.of("pull-request")).when(branch).getName();
 
@@ -219,7 +208,7 @@ public class PullRequestPostAnalysisTaskTest {
 
 
     @Test
-    public void testFinishedAnalysisWithNoRevision() {
+    void testFinishedAnalysisWithNoRevision() {
         doReturn(Branch.Type.PULL_REQUEST).when(branch).getType();
         doReturn(Optional.of("pull-request")).when(branch).getName();
 
@@ -259,7 +248,7 @@ public class PullRequestPostAnalysisTaskTest {
     }
 
     @Test
-    public void testFinishedAnalysisWithNoQualityGate() {
+    void testFinishedAnalysisWithNoQualityGate() {
         doReturn(Branch.Type.PULL_REQUEST).when(branch).getType();
         doReturn(Optional.of("pull-request")).when(branch).getName();
 
@@ -302,7 +291,7 @@ public class PullRequestPostAnalysisTaskTest {
     }
 
     @Test
-    public void testFinishedAnalysisDecorationRequest() {
+    void testFinishedAnalysisDecorationRequest() {
         doReturn(Branch.Type.PULL_REQUEST).when(branch).getType();
         doReturn(Optional.of("pull-request")).when(branch).getName();
 
@@ -357,16 +346,12 @@ public class PullRequestPostAnalysisTaskTest {
         verify(decorator2).decorateQualityGateStatus(analysisDetailsArgumentCaptor.capture(), eq(almSettingDto), eq(projectAlmSettingDto));
 
         AnalysisDetails analysisDetails =
-                new AnalysisDetails(new AnalysisDetails.BranchDetails("pull-request", "revision"),
-                                    postAnalysisIssueVisitor, qualityGate,
-                                    new AnalysisDetails.MeasuresHolder(metricRepository, measureRepository,
-                                                                       treeRootHolder), analysis, project,
-                                    configuration ,null, scannerContext);
+                new AnalysisDetails("pull-request", "revision", componentIssues, qualityGate, projectAnalysis);
         assertThat(analysisDetailsArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(analysisDetails);
     }
 
     @Test
-    public void testFinishedAnalysisDecorationRequestPullRequestLinkSaved() {
+    void testFinishedAnalysisDecorationRequestPullRequestLinkSaved() {
         doReturn(Branch.Type.PULL_REQUEST).when(branch).getType();
         doReturn(Optional.of("pull-request")).when(branch).getName();
 
@@ -404,10 +389,10 @@ public class PullRequestPostAnalysisTaskTest {
         doReturn(DbProjectBranches.PullRequestData.newBuilder().build()).when(branchDto).getPullRequestData();
 
         ProjectAlmSettingDao projectAlmSettingDao = mock(ProjectAlmSettingDao.class);
-        doReturn(Optional.of(projectAlmSettingDto)).when(projectAlmSettingDao).selectByProject(eq(dbSession), eq("uuid"));
+        doReturn(Optional.of(projectAlmSettingDto)).when(projectAlmSettingDao).selectByProject(dbSession, "uuid");
         doReturn("setting-uuid").when(projectAlmSettingDto).getAlmSettingUuid();
         AlmSettingDao almSettingDao = mock(AlmSettingDao.class);
-        doReturn(Optional.of(almSettingDto)).when(almSettingDao).selectByUuid(eq(dbSession), eq("setting-uuid"));
+        doReturn(Optional.of(almSettingDto)).when(almSettingDao).selectByUuid(dbSession, "setting-uuid");
 
         doReturn(projectAlmSettingDao).when(dbClient).projectAlmSettingDao();
         doReturn(almSettingDao).when(dbClient).almSettingDao();
@@ -417,9 +402,9 @@ public class PullRequestPostAnalysisTaskTest {
         ArgumentCaptor<AnalysisDetails> analysisDetailsArgumentCaptor = ArgumentCaptor.forClass(AnalysisDetails.class);
         verify(projectAnalysis).getAnalysis();
         verify(projectAnalysis).getQualityGate();
-        verify(dbClient, times(2)).openSession(eq(false));
+        verify(dbClient, times(2)).openSession(false);
         verify(dbClient).branchDao();
-        verify(branchDao).selectByPullRequestKey(eq(dbSession), eq("uuid"), eq("pull-request"));
+        verify(branchDao).selectByPullRequestKey(dbSession, "uuid", "pull-request");
         verify(decorator2).decorateQualityGateStatus(analysisDetailsArgumentCaptor.capture(), eq(almSettingDto), eq(projectAlmSettingDto));
 
         ArgumentCaptor<DbProjectBranches.PullRequestData> pullRequestDataArgumentCaptor = ArgumentCaptor.forClass(
@@ -428,19 +413,16 @@ public class PullRequestPostAnalysisTaskTest {
         assertThat(pullRequestDataArgumentCaptor.getValue().getUrl()).isEqualTo("pullRequestUrl");
 
         verify(dbSession).commit();
-        verify(branchDao).upsert(eq(dbSession), eq(branchDto));
+        verify(branchDao).upsert(dbSession, branchDto);
 
         AnalysisDetails analysisDetails =
-                new AnalysisDetails(new AnalysisDetails.BranchDetails("pull-request", "revision"),
-                                    postAnalysisIssueVisitor, qualityGate,
-                                    new AnalysisDetails.MeasuresHolder(metricRepository, measureRepository,
-                                                                       treeRootHolder), analysis, project,
-                                    configuration ,null, scannerContext);
+                new AnalysisDetails("pull-request", "revision",
+                                    componentIssues, qualityGate, projectAnalysis);
         assertThat(analysisDetailsArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(analysisDetails);
     }
 
     @Test
-    public void testFinishedAnalysisDecorationRequestPullRequestLinkNotSavedIfBranchDtoMissing() {
+    void testFinishedAnalysisDecorationRequestPullRequestLinkNotSavedIfBranchDtoMissing() {
         doReturn(Branch.Type.PULL_REQUEST).when(branch).getType();
         doReturn(Optional.of("pull-request")).when(branch).getName();
 
@@ -497,9 +479,9 @@ public class PullRequestPostAnalysisTaskTest {
 
         verify(projectAnalysis).getAnalysis();
         verify(projectAnalysis).getQualityGate();
-        verify(dbClient, times(2)).openSession(eq(false));
+        verify(dbClient, times(2)).openSession(false);
         verify(dbClient).branchDao();
-        verify(branchDao).selectByPullRequestKey(eq(dbSession), eq("uuid"), eq("pull-request"));
+        verify(branchDao).selectByPullRequestKey(dbSession, "uuid", "pull-request");
         verify(decorator1).decorateQualityGateStatus(analysisDetailsArgumentCaptor.capture(),
                                                      almSettingDtoArgumentCaptor.capture(),
                                                      projectAlmSettingDtoArgumentCaptor.capture());
@@ -511,16 +493,13 @@ public class PullRequestPostAnalysisTaskTest {
         verify(branchDao, never()).upsert(any(), any());
 
         AnalysisDetails analysisDetails =
-                new AnalysisDetails(new AnalysisDetails.BranchDetails("pull-request", "revision"),
-                                    postAnalysisIssueVisitor, qualityGate,
-                                    new AnalysisDetails.MeasuresHolder(metricRepository, measureRepository,
-                                                                       treeRootHolder), analysis, project,
-                                    configuration ,null, scannerContext);
+                new AnalysisDetails("pull-request", "revision",
+                                    componentIssues, qualityGate, projectAnalysis);
         assertThat(analysisDetailsArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(analysisDetails);
     }
 
     @Test
-    public void testCorrectDescriptionReturnedForTask() {
+    void testCorrectDescriptionReturnedForTask() {
         assertThat(testCase.getDescription()).isEqualTo("Pull Request Decoration");
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorTest.java
@@ -20,9 +20,6 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab;
 
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.GitlabClient;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.GitlabClientFactory;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
-import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.Commit;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.CommitNote;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.DiffRefs;
@@ -32,13 +29,18 @@ import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.MergeRequestNo
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.Note;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.PipelineStatus;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.User;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.MarkdownFormatterFactory;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report.AnalysisIssueSummary;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report.AnalysisSummary;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report.ReportGenerator;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.issue.Issue;
-import org.sonar.api.platform.Server;
 import org.sonar.ce.task.projectanalysis.component.Component;
 import org.sonar.ce.task.projectanalysis.scm.Changeset;
 import org.sonar.ce.task.projectanalysis.scm.ScmInfo;
@@ -86,25 +88,30 @@ public class GitlabMergeRequestDecoratorTest {
 
     private final GitlabClient gitlabClient = mock(GitlabClient.class);
     private final GitlabClientFactory gitlabClientFactory = mock(GitlabClientFactory.class);
-    private final Server server = mock(Server.class);
     private final ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
     private final AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
     private final AlmSettingDto almSettingDto = mock(AlmSettingDto.class);
     private final ProjectAlmSettingDto projectAlmSettingDto = mock(ProjectAlmSettingDto.class);
     private final MergeRequest mergeRequest = mock(MergeRequest.class);
     private final User sonarqubeUser = mock(User.class);
-    private final PostAnalysisIssueVisitor postAnalysisIssueVisitor = mock(PostAnalysisIssueVisitor.class);
     private final DiffRefs diffRefs = mock(DiffRefs.class);
+    private final ReportGenerator reportGenerator = mock(ReportGenerator.class);
     private final MarkdownFormatterFactory markdownFormatterFactory = mock(MarkdownFormatterFactory.class);
+    private final AnalysisSummary analysisSummary = mock(AnalysisSummary.class);
 
-    private final GitlabMergeRequestDecorator underTest = new GitlabMergeRequestDecorator(server, scmInfoRepository, gitlabClientFactory, markdownFormatterFactory);
+    private final GitlabMergeRequestDecorator underTest = new GitlabMergeRequestDecorator(scmInfoRepository, gitlabClientFactory, reportGenerator, markdownFormatterFactory);
 
     @Before
     public void setUp() throws IOException {
+        when(analysisSummary.format(any())).thenReturn("Summary Comment");
+        when(reportGenerator.createAnalysisSummary(any())).thenReturn(analysisSummary);
+        AnalysisIssueSummary analysisIssueSummary = mock(AnalysisIssueSummary.class);
+        when(analysisIssueSummary.format(any())).thenReturn("Issue Summary");
+        when(reportGenerator.createAnalysisIssueSummary(any(), any())).thenReturn(analysisIssueSummary);
         when(gitlabClientFactory.createClient(any(), any())).thenReturn(gitlabClient);
         when(almSettingDto.getUrl()).thenReturn("http://gitlab.dummy");
         when(projectAlmSettingDto.getAlmRepo()).thenReturn(PROJECT_PATH);
-        when(analysisDetails.getBranchName()).thenReturn(Long.toString(MERGE_REQUEST_IID));
+        when(analysisDetails.getPullRequestId()).thenReturn(Long.toString(MERGE_REQUEST_IID));
         when(mergeRequest.getIid()).thenReturn(MERGE_REQUEST_IID);
         when(mergeRequest.getSourceProjectId()).thenReturn(PROJECT_ID);
         when(mergeRequest.getDiffRefs()).thenReturn(diffRefs);
@@ -118,10 +125,9 @@ public class GitlabMergeRequestDecoratorTest {
                 .collect(Collectors.toList()));
         when(sonarqubeUser.getUsername()).thenReturn(SONARQUBE_USERNAME);
         when(gitlabClient.getCurrentUser()).thenReturn(sonarqubeUser);
-        when(analysisDetails.getPostAnalysisIssueVisitor()).thenReturn(postAnalysisIssueVisitor);
         when(analysisDetails.getAnalysisProjectKey()).thenReturn(PROJECT_KEY);
         when(analysisDetails.getAnalysisId()).thenReturn(ANALYSIS_UUID);
-        when(postAnalysisIssueVisitor.getIssues()).thenReturn(new ArrayList<>());
+        when(analysisDetails.getScmReportableIssues()).thenReturn(new ArrayList<>());
     }
 
     @Test
@@ -131,7 +137,7 @@ public class GitlabMergeRequestDecoratorTest {
 
     @Test
     public void shouldThrowErrorWhenPullRequestKeyNotNumeric() {
-        when(analysisDetails.getBranchName()).thenReturn("non-MR-IID");
+        when(analysisDetails.getPullRequestId()).thenReturn("non-MR-IID");
 
         assertThatThrownBy(() -> underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto))
                 .isInstanceOf(IllegalStateException.class)
@@ -248,7 +254,7 @@ public class GitlabMergeRequestDecoratorTest {
 
         Note note = mock(Note.class);
         when(note.getAuthor()).thenReturn(sonarqubeUser);
-        when(note.getBody()).thenReturn("[View in SonarQube](url)");
+        when(note.getBody()).thenReturn("[View in SonarQube](http://host.domain/issue?issues=issueId&id=" + PROJECT_KEY + ")");
         when(note.isResolvable()).thenReturn(true);
 
         Note note2 = mock(Note.class);
@@ -261,7 +267,6 @@ public class GitlabMergeRequestDecoratorTest {
         when(discussion.getId()).thenReturn("discussionId2");
         when(discussion.getNotes()).thenReturn(Arrays.asList(note, note2));
 
-        when(analysisDetails.parseIssueIdFromUrl("url")).thenReturn(Optional.of(new AnalysisDetails.ProjectIssueIdentifier(PROJECT_KEY, "issueId")));
         when(gitlabClient.getMergeRequestDiscussions(anyLong(), anyLong())).thenReturn(Collections.singletonList(discussion));
 
         underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
@@ -339,7 +344,7 @@ public class GitlabMergeRequestDecoratorTest {
 
         Note note = mock(Note.class);
         when(note.getAuthor()).thenReturn(sonarqubeUser);
-        when(note.getBody()).thenReturn("Sonarqube reported issue\n[View in SonarQube](https://dummy.url.with.subdomain/path/to/sonarqube?paramters=many&values=complex%20and+encoded)");
+        when(note.getBody()).thenReturn("Sonarqube reported issue\n[View in SonarQube](https://dummy.url.with.subdomain/path/to/sonarqube?paramters=many&values=complex%20and+encoded&issues=new-issue&id=" + PROJECT_KEY + ")");
         when(note.isResolvable()).thenReturn(true);
 
         Note note2 = mock(Note.class);
@@ -351,7 +356,6 @@ public class GitlabMergeRequestDecoratorTest {
         when(discussion.getId()).thenReturn("discussionId5");
         when(discussion.getNotes()).thenReturn(Arrays.asList(note, note2));
 
-        when(analysisDetails.parseIssueIdFromUrl("https://dummy.url.with.subdomain/path/to/sonarqube?paramters=many&values=complex%20and+encoded")).thenReturn(Optional.of(new AnalysisDetails.ProjectIssueIdentifier(PROJECT_KEY, "new-issue")));
         when(gitlabClient.getMergeRequestDiscussions(anyLong(), anyLong())).thenReturn(Collections.singletonList(discussion));
 
         underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
@@ -372,7 +376,7 @@ public class GitlabMergeRequestDecoratorTest {
 
         Note note = mock(Note.class);
         when(note.getAuthor()).thenReturn(sonarqubeUser);
-        when(note.getBody()).thenReturn("Sonarqube reported issue\n[View in SonarQube](https://dummy.url.with.subdomain/path/to/sonarqube?paramters=many&values=complex%20and+encoded)");
+        when(note.getBody()).thenReturn("Sonarqube reported issue\n[View in SonarQube](https://dummy.url.with.subdomain/path/to/sonarqube?paramters=many&values=complex%20and+encoded&issues=issuedId&id=" + PROJECT_KEY + ")");
         when(note.isResolvable()).thenReturn(true);
 
         Note note2 = mock(Note.class);
@@ -384,7 +388,6 @@ public class GitlabMergeRequestDecoratorTest {
         when(discussion.getId()).thenReturn("discussionId5");
         when(discussion.getNotes()).thenReturn(Arrays.asList(note, note2));
 
-        when(analysisDetails.parseIssueIdFromUrl("https://dummy.url.with.subdomain/path/to/sonarqube?paramters=many&values=complex%20and+encoded")).thenReturn(Optional.of(new AnalysisDetails.ProjectIssueIdentifier(PROJECT_KEY, "issueId")));
         when(gitlabClient.getMergeRequestDiscussions(anyLong(), anyLong())).thenReturn(Collections.singletonList(discussion));
         doThrow(new IOException("dummy")).when(gitlabClient).addMergeRequestDiscussionNote(anyLong(), anyLong(), any(), any());
 
@@ -422,7 +425,6 @@ public class GitlabMergeRequestDecoratorTest {
         when(discussion.getId()).thenReturn("discussionId6");
         when(discussion.getNotes()).thenReturn(Arrays.asList(note, note2, note3));
 
-        when(analysisDetails.parseIssueIdFromUrl("url")).thenReturn(Optional.of(new AnalysisDetails.ProjectIssueIdentifier(PROJECT_KEY, "issueId")));
         when(gitlabClient.getMergeRequestDiscussions(anyLong(), anyLong())).thenReturn(Collections.singletonList(discussion));
 
         underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
@@ -452,7 +454,6 @@ public class GitlabMergeRequestDecoratorTest {
         when(discussion.getId()).thenReturn("discussionId6");
         when(discussion.getNotes()).thenReturn(Arrays.asList(note, note2, note3));
 
-        when(analysisDetails.parseIssueIdFromUrl("url")).thenReturn(Optional.of(new AnalysisDetails.ProjectIssueIdentifier("otherProjectKey", "issueId")));
         when(gitlabClient.getMergeRequestDiscussions(anyLong(), anyLong())).thenReturn(Collections.singletonList(discussion));
 
         underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
@@ -473,11 +474,10 @@ public class GitlabMergeRequestDecoratorTest {
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue.getIssue()).thenReturn(lightIssue);
         when(componentIssue.getComponent()).thenReturn(component);
+        when(componentIssue.getScmPath()).thenReturn(Optional.of("path-to-file"));
 
-        when(postAnalysisIssueVisitor.getIssues()).thenReturn(Collections.singletonList(componentIssue));
+        when(analysisDetails.getScmReportableIssues()).thenReturn(Collections.singletonList(componentIssue));
         when(gitlabClient.getMergeRequestDiscussions(anyLong(), anyLong())).thenReturn(new ArrayList<>());
-        when(analysisDetails.createAnalysisIssueSummary(eq(componentIssue), any())).thenReturn("Issue Summary");
-        when(analysisDetails.getSCMPathForIssue(componentIssue)).thenReturn(Optional.of("path-to-file"));
 
         Changeset changeset = mock(Changeset.class);
         when(changeset.getRevision()).thenReturn("DEF");
@@ -499,7 +499,9 @@ public class GitlabMergeRequestDecoratorTest {
         ArgumentCaptor<MergeRequestNote> mergeRequestNoteArgumentCaptor = ArgumentCaptor.forClass(MergeRequestNote.class);
         verify(gitlabClient).addMergeRequestDiscussion(eq(PROJECT_ID), eq(MERGE_REQUEST_IID), mergeRequestNoteArgumentCaptor.capture());
 
-        assertThat(mergeRequestNoteArgumentCaptor.getValue()).isEqualToComparingFieldByField(new CommitNote("Issue Summary", BASE_SHA, START_SHA, HEAD_SHA, "path-to-file", "path-to-file", 999));
+        assertThat(mergeRequestNoteArgumentCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(new CommitNote("Issue Summary", BASE_SHA, START_SHA, HEAD_SHA, "path-to-file", "path-to-file", 999));
     }
 
     @Test
@@ -514,11 +516,10 @@ public class GitlabMergeRequestDecoratorTest {
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue.getIssue()).thenReturn(lightIssue);
         when(componentIssue.getComponent()).thenReturn(component);
+        when(componentIssue.getScmPath()).thenReturn(Optional.of("path-to-file"));
 
-        when(postAnalysisIssueVisitor.getIssues()).thenReturn(Collections.singletonList(componentIssue));
+        when(analysisDetails.getScmReportableIssues()).thenReturn(Collections.singletonList(componentIssue));
         when(gitlabClient.getMergeRequestDiscussions(anyLong(), anyLong())).thenReturn(new ArrayList<>());
-        when(analysisDetails.createAnalysisIssueSummary(eq(componentIssue), any())).thenReturn("Issue Summary");
-        when(analysisDetails.getSCMPathForIssue(componentIssue)).thenReturn(Optional.of("path-to-file"));
 
         Changeset changeset = mock(Changeset.class);
         when(changeset.getRevision()).thenReturn("DEF");
@@ -536,7 +537,9 @@ public class GitlabMergeRequestDecoratorTest {
         ArgumentCaptor<MergeRequestNote> mergeRequestNoteArgumentCaptor = ArgumentCaptor.forClass(MergeRequestNote.class);
         verify(gitlabClient, times(2)).addMergeRequestDiscussion(eq(PROJECT_ID), eq(MERGE_REQUEST_IID), mergeRequestNoteArgumentCaptor.capture());
 
-        assertThat(mergeRequestNoteArgumentCaptor.getAllValues().get(0)).isEqualToComparingFieldByField(new CommitNote("Issue Summary", BASE_SHA, START_SHA, HEAD_SHA, "path-to-file", "path-to-file", 999));
+        assertThat(mergeRequestNoteArgumentCaptor.getAllValues().get(0))
+                .usingRecursiveComparison()
+                .isEqualTo(new CommitNote("Issue Summary", BASE_SHA, START_SHA, HEAD_SHA, "path-to-file", "path-to-file", 999));
         assertThat(mergeRequestNoteArgumentCaptor.getAllValues().get(1)).isNotInstanceOf(CommitNote.class);
     }
 
@@ -552,9 +555,10 @@ public class GitlabMergeRequestDecoratorTest {
         PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
         when(componentIssue.getIssue()).thenReturn(lightIssue);
         when(componentIssue.getComponent()).thenReturn(component);
+        when(componentIssue.getScmPath()).thenReturn(Optional.of("path-to-file"));
 
         Note note = mock(Note.class);
-        when(note.getBody()).thenReturn("Reported issue\n[View in SonarQube](url)");
+        when(note.getBody()).thenReturn("Reported issue\n[View in SonarQube](http://domain.url/sonar/issue?issues=issueKey1&id=" + PROJECT_KEY + ")");
         when(note.getAuthor()).thenReturn(sonarqubeUser);
         when(note.isResolvable()).thenReturn(true);
 
@@ -562,11 +566,8 @@ public class GitlabMergeRequestDecoratorTest {
         when(discussion.getId()).thenReturn("discussion-id");
         when(discussion.getNotes()).thenReturn(Collections.singletonList(note));
 
-        when(analysisDetails.parseIssueIdFromUrl("url")).thenReturn(Optional.of(new AnalysisDetails.ProjectIssueIdentifier(PROJECT_KEY, "issueKey1")));
         when(gitlabClient.getMergeRequestDiscussions(anyLong(), anyLong())).thenReturn(Collections.singletonList(discussion));
-        when(postAnalysisIssueVisitor.getIssues()).thenReturn(Collections.singletonList(componentIssue));
-        when(analysisDetails.createAnalysisIssueSummary(eq(componentIssue), any())).thenReturn("Issue Summary");
-        when(analysisDetails.getSCMPathForIssue(componentIssue)).thenReturn(Optional.of("path-to-file"));
+        when(analysisDetails.getScmReportableIssues()).thenReturn(Collections.singletonList(componentIssue));
 
         Changeset changeset = mock(Changeset.class);
         when(changeset.getRevision()).thenReturn("DEF");
@@ -600,9 +601,8 @@ public class GitlabMergeRequestDecoratorTest {
         when(componentIssue.getIssue()).thenReturn(lightIssue);
         when(componentIssue.getComponent()).thenReturn(component);
 
-        when(postAnalysisIssueVisitor.getIssues()).thenReturn(Collections.singletonList(componentIssue));
+        when(analysisDetails.getScmReportableIssues()).thenReturn(Collections.singletonList(componentIssue));
         when(gitlabClient.getMergeRequestDiscussions(anyLong(), anyLong())).thenReturn(new ArrayList<>());
-        when(analysisDetails.createAnalysisIssueSummary(eq(componentIssue), any())).thenReturn("Issue Summary");
 
         underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
 
@@ -619,10 +619,10 @@ public class GitlabMergeRequestDecoratorTest {
     @Test
     public void shouldSubmitSuccessfulPipelineStatusAndResolvedSummaryCommentOnSuccessAnalysis() throws IOException {
         when(analysisDetails.getQualityGateStatus()).thenReturn(QualityGate.Status.OK);
-        when(analysisDetails.createAnalysisSummary(any())).thenReturn("Summary comment");
         when(analysisDetails.getCommitSha()).thenReturn("commitsha");
 
-        when(server.getPublicRootUrl()).thenReturn("https://sonarqube.dummy");
+        when(analysisSummary.format(any())).thenReturn("Summary comment");
+        when(analysisSummary.getDashboardUrl()).thenReturn("https://sonarqube.dummy/dashboard?id=projectKey&pullRequest=123");
 
         Discussion discussion = mock(Discussion.class);
         when(discussion.getId()).thenReturn("dicussion id");
@@ -636,21 +636,24 @@ public class GitlabMergeRequestDecoratorTest {
         ArgumentCaptor<PipelineStatus> pipelineStatusArgumentCaptor = ArgumentCaptor.forClass(PipelineStatus.class);
         verify(gitlabClient).setMergeRequestPipelineStatus(eq(PROJECT_ID), eq("commitsha"), pipelineStatusArgumentCaptor.capture());
 
-        assertThat(mergeRequestNoteArgumentCaptor.getValue()).isEqualToComparingFieldByField(new MergeRequestNote("Summary comment"));
+        assertThat(mergeRequestNoteArgumentCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(new MergeRequestNote("Summary comment"));
         assertThat(pipelineStatusArgumentCaptor.getValue())
-                .isEqualToComparingFieldByField(new PipelineStatus("SonarQube", "SonarQube Status",
+                .usingRecursiveComparison()
+                .isEqualTo(new PipelineStatus("SonarQube", "SonarQube Status",
                         PipelineStatus.State.SUCCESS, "https://sonarqube.dummy/dashboard?id=" + PROJECT_KEY + "&pullRequest=" + MERGE_REQUEST_IID, null, null));
     }
 
     @Test
     public void shouldSubmitFailedPipelineStatusAndUnresolvedSummaryCommentOnFailedAnalysis() throws IOException {
         when(analysisDetails.getQualityGateStatus()).thenReturn(QualityGate.Status.ERROR);
-        when(analysisDetails.createAnalysisSummary(any())).thenReturn("Different Summary comment");
         when(analysisDetails.getCommitSha()).thenReturn("other sha");
-        when(analysisDetails.getCoverage()).thenReturn(Optional.of(BigDecimal.TEN));
         when(analysisDetails.getScannerProperty("com.github.mc1arke.sonarqube.plugin.branch.pullrequest.gitlab.pipelineId")).thenReturn(Optional.of("11"));
 
-        when(server.getPublicRootUrl()).thenReturn("https://sonarqube2.dummy");
+        when(analysisSummary.format(any())).thenReturn("Different Summary comment");
+        when(analysisSummary.getDashboardUrl()).thenReturn("https://sonarqube2.dummy/dashboard?id=projectKey&pullRequest=123");
+        when(analysisSummary.getNewCoverage()).thenReturn(BigDecimal.TEN);
 
         Discussion discussion = mock(Discussion.class);
         when(discussion.getId()).thenReturn("dicussion id 2");
@@ -664,21 +667,24 @@ public class GitlabMergeRequestDecoratorTest {
         ArgumentCaptor<PipelineStatus> pipelineStatusArgumentCaptor = ArgumentCaptor.forClass(PipelineStatus.class);
         verify(gitlabClient).setMergeRequestPipelineStatus(eq(PROJECT_ID), eq("other sha"), pipelineStatusArgumentCaptor.capture());
 
-        assertThat(mergeRequestNoteArgumentCaptor.getValue()).isEqualToComparingFieldByField(new MergeRequestNote("Different Summary comment"));
+        assertThat(mergeRequestNoteArgumentCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(new MergeRequestNote("Different Summary comment"));
         assertThat(pipelineStatusArgumentCaptor.getValue())
-                .isEqualToComparingFieldByField(new PipelineStatus("SonarQube", "SonarQube Status",
+                .usingRecursiveComparison()
+                .isEqualTo(new PipelineStatus("SonarQube", "SonarQube Status",
                         PipelineStatus.State.FAILED, "https://sonarqube2.dummy/dashboard?id=" + PROJECT_KEY + "&pullRequest=" + MERGE_REQUEST_IID, BigDecimal.TEN, 11L));
     }
 
     @Test
     public void shouldThrowErrorWhenSubmitPipelineStatusToGitlabFails() throws IOException {
         when(analysisDetails.getQualityGateStatus()).thenReturn(QualityGate.Status.ERROR);
-        when(analysisDetails.createAnalysisSummary(any())).thenReturn("Different Summary comment");
         when(analysisDetails.getCommitSha()).thenReturn("other sha");
-        when(analysisDetails.getCoverage()).thenReturn(Optional.of(BigDecimal.TEN));
         when(analysisDetails.getScannerProperty("com.github.mc1arke.sonarqube.plugin.branch.pullrequest.gitlab.pipelineId")).thenReturn(Optional.of("11"));
 
-        when(server.getPublicRootUrl()).thenReturn("https://sonarqube2.dummy");
+        when(analysisSummary.format(any())).thenReturn("Different Summary comment");
+        when(analysisSummary.getDashboardUrl()).thenReturn("https://sonarqube2.dummy/dashboard?id=projectKey&pullRequest=123");
+        when(analysisSummary.getNewCoverage()).thenReturn(BigDecimal.TEN);
 
         Discussion discussion = mock(Discussion.class);
         when(discussion.getId()).thenReturn("dicussion id 2");
@@ -695,21 +701,22 @@ public class GitlabMergeRequestDecoratorTest {
         ArgumentCaptor<PipelineStatus> pipelineStatusArgumentCaptor = ArgumentCaptor.forClass(PipelineStatus.class);
         verify(gitlabClient).setMergeRequestPipelineStatus(eq(PROJECT_ID), eq("other sha"), pipelineStatusArgumentCaptor.capture());
 
-        assertThat(mergeRequestNoteArgumentCaptor.getValue()).isEqualToComparingFieldByField(new MergeRequestNote("Different Summary comment"));
+        assertThat(mergeRequestNoteArgumentCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(new MergeRequestNote("Different Summary comment"));
         assertThat(pipelineStatusArgumentCaptor.getValue())
-                .isEqualToComparingFieldByField(new PipelineStatus("SonarQube", "SonarQube Status",
+                .usingRecursiveComparison()
+                .isEqualTo(new PipelineStatus("SonarQube", "SonarQube Status",
                         PipelineStatus.State.FAILED, "https://sonarqube2.dummy/dashboard?id=" + PROJECT_KEY + "&pullRequest=" + MERGE_REQUEST_IID, BigDecimal.TEN, 11L));
     }
 
     @Test
     public void shouldThrowErrorWhenSubmitAnalysisToGitlabFails() throws IOException {
         when(analysisDetails.getQualityGateStatus()).thenReturn(QualityGate.Status.ERROR);
-        when(analysisDetails.createAnalysisSummary(any())).thenReturn("Different Summary comment");
         when(analysisDetails.getCommitSha()).thenReturn("other sha");
-        when(analysisDetails.getCoverage()).thenReturn(Optional.of(BigDecimal.TEN));
         when(analysisDetails.getScannerProperty("com.github.mc1arke.sonarqube.plugin.branch.pullrequest.gitlab.pipelineId")).thenReturn(Optional.of("11"));
 
-        when(server.getPublicRootUrl()).thenReturn("https://sonarqube2.dummy");
+        when(analysisSummary.format(any())).thenReturn("Different Summary comment");
 
         Discussion discussion = mock(Discussion.class);
         when(discussion.getId()).thenReturn("dicussion id 2");
@@ -725,19 +732,23 @@ public class GitlabMergeRequestDecoratorTest {
         verify(gitlabClient, never()).resolveMergeRequestDiscussion(PROJECT_ID, MERGE_REQUEST_IID, discussion.getId());
         verify(gitlabClient, never()).setMergeRequestPipelineStatus(anyLong(), any(), any());
 
-        assertThat(mergeRequestNoteArgumentCaptor.getValue()).isEqualToComparingFieldByField(new MergeRequestNote("Different Summary comment"));
+        assertThat(mergeRequestNoteArgumentCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(new MergeRequestNote("Different Summary comment"));
     }
 
     @Test
     public void shouldReturnWebUrlFromMergeRequestIfScannerPropertyNotSet() {
         assertThat(underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto))
-                .isEqualToComparingFieldByField(DecorationResult.builder().withPullRequestUrl(MERGE_REQUEST_WEB_URL).build());
+                .usingRecursiveComparison()
+                .isEqualTo(DecorationResult.builder().withPullRequestUrl(MERGE_REQUEST_WEB_URL).build());
     }
 
     @Test
     public void shouldReturnWebUrlFromScannerPropertyIfSet() {
         when(analysisDetails.getScannerProperty("sonar.pullrequest.gitlab.projectUrl")).thenReturn(Optional.of(MERGE_REQUEST_WEB_URL + "/additional"));
         assertThat(underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto))
-                .isEqualToComparingFieldByField(DecorationResult.builder().withPullRequestUrl(MERGE_REQUEST_WEB_URL + "/additional/merge_requests/" + MERGE_REQUEST_IID).build());
+                .usingRecursiveComparison()
+                .isEqualTo(DecorationResult.builder().withPullRequestUrl(MERGE_REQUEST_WEB_URL + "/additional/merge_requests/" + MERGE_REQUEST_IID).build());
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisIssueSummaryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisIssueSummaryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Document;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Formatter;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Image;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Link;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Paragraph;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Text;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AnalysisIssueSummaryTest {
+
+    @Test
+    void shouldCreateCorrectOutputDocument() {
+        AnalysisIssueSummary underTest = AnalysisIssueSummary.builder()
+                .withProjectKey("projectKey")
+                .withTypeImageUrl("typeImageUrl")
+                .withType("type")
+                .withSeverityImageUrl("severityImageUrl")
+                .withSeverity("severity")
+                .withResolution("resolution")
+                .withMessage("message")
+                .withIssueUrl("issueUrl")
+                .withIssueKey("issueKey")
+                .withEffortInMinutes(101L)
+                .build();
+
+        FormatterFactory formatterFactory = mock(FormatterFactory.class);
+        Formatter<Document> documentFormatter = mock(Formatter.class);
+        when(documentFormatter.format(any())).thenReturn("output content");
+        when(formatterFactory.documentFormatter()).thenReturn(documentFormatter);
+
+        assertThat(underTest.format(formatterFactory)).isEqualTo("output content");
+
+        ArgumentCaptor<Document> documentArgumentCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(documentFormatter).format(documentArgumentCaptor.capture());
+
+        assertThat(documentArgumentCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    new Document(
+                            new Paragraph(
+                                    new Text("**Type:** type "),
+                                    new Image("type", "typeImageUrl")
+                            ),
+                            new Paragraph(
+                                    new Text("**Severity:** severity "),
+                                    new Image("severity", "severityImageUrl")
+                            ),
+                            new Paragraph(new Text("**Message:** message")),
+                            new Paragraph(new Text("**Duration (min):** 101")),
+                            new Paragraph(new Text("**Resolution:** resolution")),
+                            new Paragraph(new Text("**Project ID:** projectKey **Issue ID:** issueKey")),
+                            new Paragraph(new Link("issueUrl", new Text("View in SonarQube")))
+                )
+        );
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Document;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Formatter;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.FormatterFactory;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Heading;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Image;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Link;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.ListItem;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Paragraph;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.Text;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AnalysisSummaryTest {
+
+    @Test
+    void testCreateAnalysisSummary() {
+        AnalysisSummary underTest = AnalysisSummary.builder()
+                .withNewDuplications(BigDecimal.valueOf(199))
+                .withSummaryImageUrl("summaryImageUrl")
+                .withProjectKey("projectKey")
+                .withBugCount(911)
+                .withBugImageUrl("bugImageUrl")
+                .withCodeSmellCount(1)
+                .withCoverage(BigDecimal.valueOf(303))
+                .withCodeSmellImageUrl("codeSmellImageUrl")
+                .withCoverageImageUrl("codeCoverageImageUrl")
+                .withDashboardUrl("dashboardUrl")
+                .withDuplications(BigDecimal.valueOf(66))
+                .withDuplicationsImageUrl("duplicationsImageUrl")
+                .withFailedQualityGateConditions(java.util.List.of("issuea", "issueb", "issuec"))
+                .withNewCoverage(BigDecimal.valueOf(99))
+                .withSecurityHotspotCount(69)
+                .withStatusDescription("status description")
+                .withStatusImageUrl("statusImageUrl")
+                .withTotalIssueCount(666)
+                .withVulnerabilityCount(96)
+                .withVulnerabilityImageUrl("vulnerabilityImageUrl")
+                .build();
+
+        Formatter<Document> formatter = mock(Formatter.class);
+        doReturn("formatted content").when(formatter).format(any());
+        FormatterFactory formatterFactory = mock(FormatterFactory.class);
+        doReturn(formatter).when(formatterFactory).documentFormatter();
+
+        assertThat(underTest.format(formatterFactory)).isEqualTo("formatted content");
+
+        ArgumentCaptor<Document> documentArgumentCaptor = ArgumentCaptor.forClass(Document.class);
+        verify(formatter).format(documentArgumentCaptor.capture());
+
+        Document expectedDocument = new Document(new Paragraph(new Image("status description", "statusImageUrl")),
+                new List(List.Style.BULLET,
+                        new ListItem(new Text("issuea")),
+                        new ListItem(new Text("issueb")),
+                        new ListItem(new Text("issuec"))),
+                new Heading(1, new Text("Analysis Details")),
+                new Heading(2, new Text("666 Issues")),
+                new List(List.Style.BULLET,
+                    new ListItem(
+                        new Image("Bug","bugImageUrl"),
+                        new Text(" "),
+                        new Text("911 Bugs")),
+                new ListItem(
+                        new Image("Vulnerability","vulnerabilityImageUrl"),
+                        new Text(" "),
+                        new Text("165 Vulnerabilities")),
+                new ListItem(
+                        new Image("Code Smell", "codeSmellImageUrl"),
+                        new Text(" "),
+                        new Text("1 Code Smell"))),
+                new Heading(2, new Text("Coverage and Duplications")),
+                new List(List.Style.BULLET,
+                        new ListItem(
+                            new Image("Coverage", "codeCoverageImageUrl"),
+                            new Text(" "),
+                            new Text("99.00% Coverage (303.00% Estimated after merge)")),
+                        new ListItem(
+                                new Image("Duplications", "duplicationsImageUrl"),
+                                new Text(" "),
+                                new Text("199.00% Duplicated Code (66.00% Estimated after merge)"))),
+                new Paragraph(new Text("**Project ID:** projectKey")),
+                new Paragraph(new Link("dashboardUrl", new Text("View in SonarQube"))));
+
+        assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
+
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/ReportGeneratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/ReportGeneratorTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2022 Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report;
+
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.sonar.api.ce.posttask.Project;
+import org.sonar.api.ce.posttask.QualityGate;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.platform.Server;
+import org.sonar.api.rules.RuleType;
+import org.sonar.ce.task.projectanalysis.component.Component;
+import org.sonar.ce.task.projectanalysis.component.TreeRootHolder;
+import org.sonar.ce.task.projectanalysis.measure.Measure;
+import org.sonar.ce.task.projectanalysis.measure.MeasureRepository;
+import org.sonar.ce.task.projectanalysis.metric.Metric;
+import org.sonar.ce.task.projectanalysis.metric.MetricRepository;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class ReportGeneratorTest {
+
+    @CsvSource({"12, 0.svg?sanitize=true, 21, 20plus.svg?sanitize=true",
+            "98, 90.svg?sanitize=true, 1, 3.svg?sanitize=true",
+            ",NoCoverageInfo.svg?sanitize=true,,NoDuplicationInfo.svg?sanitize=true"})
+    @ParameterizedTest
+    void shouldProduceCorrectAnlysisSummary(String coverage, String coverageImage, String duplications, String duplicationsImage) {
+        AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
+        doReturn("5").when(analysisDetails).getPullRequestId();
+        doReturn("projectKey").when(analysisDetails).getAnalysisProjectKey();
+
+        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
+
+        PostAnalysisIssueVisitor.LightIssue issue1 = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        doReturn(Issue.STATUS_CLOSED).when(issue1).status();
+
+        PostAnalysisIssueVisitor.LightIssue issue2 = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        doReturn(Issue.STATUS_OPEN).when(issue2).status();
+        doReturn(RuleType.BUG).when(issue2).type();
+
+        PostAnalysisIssueVisitor.LightIssue issue3 = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        doReturn(Issue.STATUS_OPEN).when(issue3).status();
+        doReturn(RuleType.SECURITY_HOTSPOT).when(issue3).type();
+
+        PostAnalysisIssueVisitor.LightIssue issue4 = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        doReturn(Issue.STATUS_OPEN).when(issue4).status();
+        doReturn(RuleType.CODE_SMELL).when(issue4).type();
+
+        PostAnalysisIssueVisitor.LightIssue issue5 = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        doReturn(Issue.STATUS_OPEN).when(issue5).status();
+        doReturn(RuleType.VULNERABILITY).when(issue5).type();
+
+        PostAnalysisIssueVisitor.LightIssue issue6 = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        doReturn(Issue.STATUS_OPEN).when(issue6).status();
+        doReturn(RuleType.BUG).when(issue6).type();
+
+        doReturn(Stream.of(issue1, issue2, issue3, issue4, issue5, issue6).map(i -> {
+            PostAnalysisIssueVisitor.ComponentIssue componentIssue =
+                    mock(PostAnalysisIssueVisitor.ComponentIssue.class);
+            doReturn(i).when(componentIssue).getIssue();
+            return componentIssue;
+        }).collect(Collectors.toList())).when(analysisDetails).getIssues();
+
+        QualityGate.Condition condition1 = mock(QualityGate.Condition.class);
+        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition1).getStatus();
+        doReturn(CoreMetrics.LINES_TO_COVER.getKey()).when(condition1).getMetricKey();
+        doReturn("19").when(condition1).getValue();
+        doReturn(QualityGate.Operator.LESS_THAN).when(condition1).getOperator();
+        doReturn("20").when(condition1).getErrorThreshold();
+
+        QualityGate.Condition condition2 = mock(QualityGate.Condition.class);
+        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition2).getStatus();
+        doReturn(CoreMetrics.CODE_SMELLS.getKey()).when(condition2).getMetricKey();
+        doReturn("2").when(condition2).getValue();
+        doReturn(QualityGate.Operator.GREATER_THAN).when(condition2).getOperator();
+        doReturn("0").when(condition2).getErrorThreshold();
+
+        QualityGate.Condition condition3 = mock(QualityGate.Condition.class);
+        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition3).getStatus();
+        doReturn(CoreMetrics.LINE_COVERAGE.getKey()).when(condition3).getMetricKey();
+        doReturn("68").when(condition3).getValue();
+        doReturn(QualityGate.Operator.LESS_THAN).when(condition3).getOperator();
+        doReturn("80").when(condition3).getErrorThreshold();
+
+        QualityGate.Condition condition4 = mock(QualityGate.Condition.class);
+        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition4).getStatus();
+        doReturn(CoreMetrics.NEW_SECURITY_RATING.getKey()).when(condition4).getMetricKey();
+        doReturn("5").when(condition4).getValue();
+        doReturn(QualityGate.Operator.GREATER_THAN).when(condition4).getOperator();
+        doReturn("4").when(condition4).getErrorThreshold();
+
+        QualityGate.Condition condition5 = mock(QualityGate.Condition.class);
+        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition5).getStatus();
+        doReturn(CoreMetrics.RELIABILITY_RATING.getKey()).when(condition5).getMetricKey();
+        doReturn("1").when(condition5).getValue();
+        doReturn(QualityGate.Operator.LESS_THAN).when(condition5).getOperator();
+        doReturn("3").when(condition5).getErrorThreshold();
+
+        QualityGate.Condition condition6 = mock(QualityGate.Condition.class);
+        doReturn(QualityGate.EvaluationStatus.ERROR).when(condition6).getStatus();
+        doReturn(CoreMetrics.NEW_COVERAGE.getKey()).when(condition6).getMetricKey();
+        doReturn(coverage).when(condition6).getValue();
+        doReturn(QualityGate.Operator.GREATER_THAN).when(condition6).getOperator();
+        doReturn("15").when(condition6).getErrorThreshold();
+
+        QualityGate.Condition condition7 = mock(QualityGate.Condition.class);
+        doReturn(QualityGate.EvaluationStatus.OK).when(condition7).getStatus();
+        doReturn(CoreMetrics.NEW_BUGS.getKey()).when(condition7).getMetricKey();
+        doReturn("0").when(condition7).getValue();
+        doReturn(QualityGate.Operator.LESS_THAN).when(condition7).getOperator();
+        doReturn("1").when(condition7).getErrorThreshold();
+
+        QualityGate.Condition condition8 = mock(QualityGate.Condition.class);
+        doReturn(QualityGate.EvaluationStatus.OK).when(condition8).getStatus();
+        doReturn(CoreMetrics.NEW_DUPLICATED_LINES_DENSITY.getKey()).when(condition8).getMetricKey();
+        doReturn(duplications).when(condition8).getValue();
+        doReturn(QualityGate.Operator.GREATER_THAN).when(condition8).getOperator();
+        doReturn("1").when(condition8).getErrorThreshold();
+
+
+        doReturn(Arrays.asList(condition1, condition2, condition3, condition4))
+                .when(analysisDetails).findFailedQualityGateConditions();
+        doAnswer(i -> Stream.of(condition1, condition2, condition3, condition4, condition5, condition6, condition7, condition8).filter(condition -> condition.getMetricKey().equals(i.getArgument(0, String.class))).findFirst()).when(analysisDetails).findQualityGateCondition(any());
+        doReturn(QualityGate.Status.ERROR).when(analysisDetails).getQualityGateStatus();
+
+        Project project = mock(Project.class);
+        doReturn("Project Key").when(project).getKey();
+
+        Component rootComponent = mock(Component.class);
+        doReturn(rootComponent).when(treeRootHolder).getRoot();
+
+        MeasureRepository measureRepository = mock(MeasureRepository.class);
+        if (coverage != null) {
+            doReturn(Optional.of(Measure.newMeasureBuilder().create(Double.parseDouble(coverage), 2, "data")),
+                    Optional.of(Measure.newMeasureBuilder().create(Double.parseDouble(duplications), 2, "data"))).when(measureRepository)
+                    .getRawMeasure(eq(rootComponent), any(Metric.class));
+        }
+
+        MetricRepository metricRepository = mock(MetricRepository.class);
+        doReturn(mock(Metric.class)).when(metricRepository).getByKey(anyString());
+
+        Server server = mock(Server.class);
+        doReturn("http://localhost:9000").when(server).getPublicRootUrl();
+        Configuration configuration = mock(Configuration.class);
+        ReportGenerator underTest = new ReportGenerator(server, configuration, measureRepository, metricRepository, treeRootHolder);
+
+        AnalysisSummary expected = AnalysisSummary.builder()
+                        .withBugCount(2)
+                        .withBugImageUrl("http://localhost:9000/static/communityBranchPlugin/common/bug.svg?sanitize=true")
+                        .withCoverage(null == coverage ? null : new BigDecimal(coverage))
+                        .withCoverageImageUrl("http://localhost:9000/static/communityBranchPlugin/checks/CoverageChart/" + coverageImage)
+                        .withNewCoverage(null == coverage ? null : new BigDecimal(coverage))
+                        .withDuplications(null == duplications ? null : new BigDecimal(duplications).setScale(1, RoundingMode.CEILING))
+                        .withDuplicationsImageUrl("http://localhost:9000/static/communityBranchPlugin/checks/Duplications/" + duplicationsImage)
+                        .withNewDuplications(null == duplications ? null : new BigDecimal(duplications))
+                        .withCodeSmellCount(1)
+                        .withCodeSmellImageUrl("http://localhost:9000/static/communityBranchPlugin/common/code_smell.svg?sanitize=true")
+                        .withDashboardUrl("http://localhost:9000/dashboard?id=projectKey&pullRequest=5")
+                        .withProjectKey("projectKey")
+                        .withSummaryImageUrl("http://localhost:9000/static/communityBranchPlugin/common/icon.png")
+                        .withSecurityHotspotCount(1)
+                        .withVulnerabilityCount(1)
+                        .withVulnerabilityImageUrl("http://localhost:9000/static/communityBranchPlugin/common/vulnerability.svg?sanitize=true")
+                        .withStatusDescription("Failed")
+                        .withStatusImageUrl("http://localhost:9000/static/communityBranchPlugin/checks/QualityGateBadge/failed.svg?sanitize=true")
+                        .withTotalIssueCount(5)
+                        .withFailedQualityGateConditions(List.of("19 Lines to Cover (is less than 20)",
+                                "2 Code Smells (is greater than 0)",
+                                "68.00% Line Coverage (is less than 80.00%)",
+                                "E Security Rating on New Code (is worse than D)"))
+                        .build();
+
+        assertThat(underTest.createAnalysisSummary(analysisDetails))
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @CsvSource({"SECURITY_HOTSPOT, security_hotspots?id=project-key&pullRequest=pull-request-id&hotspots=issue-key",
+            "BUG, project/issues?id=project-key&pullRequest=pull-request-id&issues=issue-key&open=issue-key"})
+    @ParameterizedTest
+    void shouldProduceCorrectAnalysisIssueSummary(RuleType ruleType, String issueUrlPostfix) {
+        MeasureRepository measureRepository = mock(MeasureRepository.class);
+        MetricRepository metricRepository = mock(MetricRepository.class);
+        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
+
+        Server server = mock(Server.class);
+        doReturn("http://target.host:port/path/to/root").when(server).getPublicRootUrl();
+        Configuration configuration = mock(Configuration.class);
+        ReportGenerator underTest = new ReportGenerator(server, configuration, measureRepository, metricRepository, treeRootHolder);
+
+        AnalysisIssueSummary expected = AnalysisIssueSummary.builder()
+                .withEffortInMinutes(101L)
+                .withIssueKey("issue-key")
+                .withIssueUrl("http://target.host:port/path/to/root/" + issueUrlPostfix)
+                .withMessage("message")
+                .withResolution("FIXED")
+                .withSeverity("CRITICAL")
+                .withSeverityImageUrl("http://target.host:port/path/to/root/static/communityBranchPlugin/checks/Severity/critical.svg?sanitize=true")
+                .withType(ruleType.name())
+                .withTypeImageUrl("http://target.host:port/path/to/root/static/communityBranchPlugin/checks/IssueType/" + ruleType.name().toLowerCase(Locale.ENGLISH) + ".svg?sanitize=true")
+                .withProjectKey("project-key")
+                .build();
+
+        PostAnalysisIssueVisitor.LightIssue lightIssue = mock(PostAnalysisIssueVisitor.LightIssue.class);
+        doReturn("issue-key").when(lightIssue).key();
+        doReturn("CRITICAL").when(lightIssue).severity();
+        doReturn("message").when(lightIssue).getMessage();
+        doReturn("FIXED").when(lightIssue).resolution();
+        doReturn(ruleType).when(lightIssue).type();
+        doReturn(101L).when(lightIssue).effortInMinutes();
+        PostAnalysisIssueVisitor.ComponentIssue componentIssue = mock(PostAnalysisIssueVisitor.ComponentIssue.class);
+        doReturn(lightIssue).when(componentIssue).getIssue();
+
+        AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
+        doReturn("project-key").when(analysisDetails).getAnalysisProjectKey();
+        doReturn("pull-request-id").when(analysisDetails).getPullRequestId();
+
+        assertThat(underTest.createAnalysisIssueSummary(componentIssue, analysisDetails))
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+}


### PR DESCRIPTION
The access to metrics from a Pull Request analysis is exposed through an
`AnalysisDetails` instance, which also provides the ability to extract a
formatted report. As a number of the metrics used in the summary report
need to be retrieved through various additional DAOs, and as the
resolution of URLs for links and images requiring access to core
Sonarqube configuration, `AnalysisDetails` holds references to a high
number of classes from Sonarqube's core. Some of those core Sonarqube
classes are also referenced directly in some decorators which don't make
use of the summary report but need equivalent metrics to those shown in
the summary which means some searching logic is duplicated across the
plugin.

This change pulls the report generation into a `ReportGenerator` class,
with the report being an interim set of collected metrics that each
decorator can extract required information, or generate a formatted
report from.