### PR TITLE
Allow mono-repo decoration for Bitbucket

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
@@ -60,14 +60,14 @@ public interface BitbucketClient {
      *
      * @throws IOException if the annotations cannot be deleted
      */
-    void deleteAnnotations(String commitSha) throws IOException;
+    void deleteAnnotations(String commitSha, String reportKey) throws IOException;
 
     /**
      * Uploads CodeInsights Annotations for the given commit.
      *
      * @throws IOException if the annotations cannot be uploaded
      */
-    void uploadAnnotations(String commitSha, Set<CodeInsightsAnnotation> annotations) throws IOException;
+    void uploadAnnotations(String commitSha, Set<CodeInsightsAnnotation> annotations, String reportKey) throws IOException;
 
     /**
      * Creates a DataValue of type DataValue.Link or DataValue.CloudLink depending on the implementation
@@ -77,7 +77,7 @@ public interface BitbucketClient {
     /**
      * Uploads the code insights report for the given commit
      */
-    void uploadReport(String commitSha, CodeInsightsReport codeInsightReport) throws IOException;
+    void uploadReport(String commitSha, CodeInsightsReport codeInsightReport, String reportKey) throws IOException;
 
     /**
      * <p>

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
@@ -53,7 +53,6 @@ import static java.lang.String.format;
 class BitbucketCloudClient implements BitbucketClient {
 
     private static final Logger LOGGER = Loggers.get(BitbucketCloudClient.class);
-    private static final String REPORT_KEY = "com.github.mc1arke.sonarqube";
     private static final MediaType APPLICATION_JSON_MEDIA_TYPE = MediaType.get("application/json");
     private static final String TITLE = "SonarQube";
     private static final String REPORTER = "SonarQube";
@@ -116,12 +115,12 @@ class BitbucketCloudClient implements BitbucketClient {
     }
 
     @Override
-    public void deleteAnnotations(String commitSha) {
+    public void deleteAnnotations(String commitSha, String reportKey) {
         // not needed here.
     }
 
     @Override
-    public void uploadAnnotations(String commit, Set<CodeInsightsAnnotation> baseAnnotations) throws IOException {
+    public void uploadAnnotations(String commit, Set<CodeInsightsAnnotation> baseAnnotations, String reportKey) throws IOException {
         Set<CloudAnnotation> annotations = baseAnnotations.stream().map(CloudAnnotation.class::cast).collect(Collectors.toSet());
 
         if (annotations.isEmpty()) {
@@ -130,7 +129,7 @@ class BitbucketCloudClient implements BitbucketClient {
 
         Request req = new Request.Builder()
                 .post(RequestBody.create(objectMapper.writeValueAsString(annotations), APPLICATION_JSON_MEDIA_TYPE))
-                .url(format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s/annotations", bitbucketConfiguration.getProject(), bitbucketConfiguration.getRepository(), commit, REPORT_KEY))
+                .url(format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s/annotations", bitbucketConfiguration.getProject(), bitbucketConfiguration.getRepository(), commit, reportKey))
                 .build();
 
         LOGGER.info("Creating annotations on bitbucket cloud");
@@ -147,10 +146,10 @@ class BitbucketCloudClient implements BitbucketClient {
     }
 
     @Override
-    public void uploadReport(String commit, CodeInsightsReport codeInsightReport) throws IOException {
-        deleteExistingReport(commit);
+    public void uploadReport(String commit, CodeInsightsReport codeInsightReport, String reportKey) throws IOException {
+        deleteExistingReport(commit, reportKey);
 
-        String targetUrl = format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s", bitbucketConfiguration.getProject(), bitbucketConfiguration.getRepository(), commit, REPORT_KEY);
+        String targetUrl = format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s", bitbucketConfiguration.getProject(), bitbucketConfiguration.getRepository(), commit, reportKey);
         String body = objectMapper.writeValueAsString(codeInsightReport);
         Request req = new Request.Builder()
                 .put(RequestBody.create(body, APPLICATION_JSON_MEDIA_TYPE))
@@ -191,10 +190,10 @@ class BitbucketCloudClient implements BitbucketClient {
         }
     }
 
-    void deleteExistingReport(String commit) throws IOException {
+    void deleteExistingReport(String commit, String reportKey) throws IOException {
         Request req = new Request.Builder()
                 .delete()
-                .url(format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s", bitbucketConfiguration.getProject(), bitbucketConfiguration.getRepository(), commit, REPORT_KEY))
+                .url(format("https://api.bitbucket.org/2.0/repositories/%s/%s/commit/%s/reports/%s", bitbucketConfiguration.getProject(), bitbucketConfiguration.getRepository(), commit, reportKey))
                 .build();
 
         LOGGER.info("Deleting existing reports on bitbucket cloud");

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
@@ -51,7 +51,6 @@ import static java.lang.String.format;
 
 class BitbucketServerClient implements BitbucketClient {
     private static final Logger LOGGER = Loggers.get(BitbucketServerClient.class);
-    private static final String REPORT_KEY = "com.github.mc1arke.sonarqube";
     private static final MediaType APPLICATION_JSON_MEDIA_TYPE = MediaType.get("application/json");
     private static final String TITLE = "SonarQube";
     private static final String REPORTER = "SonarQube";
@@ -93,10 +92,10 @@ class BitbucketServerClient implements BitbucketClient {
     }
 
     @Override
-    public void deleteAnnotations(String commit) throws IOException {
+    public void deleteAnnotations(String commit, String reportKey) throws IOException {
         Request req = new Request.Builder()
                 .delete()
-                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", config.getUrl(), config.getProject(), config.getRepository(), commit, REPORT_KEY))
+                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", config.getUrl(), config.getProject(), config.getRepository(), commit, reportKey))
                 .build();
         try (Response response = okHttpClient.newCall(req).execute()) {
             validate(response);
@@ -104,7 +103,7 @@ class BitbucketServerClient implements BitbucketClient {
     }
 
     @Override
-    public void uploadAnnotations(String commit, Set<CodeInsightsAnnotation> annotations) throws IOException {
+    public void uploadAnnotations(String commit, Set<CodeInsightsAnnotation> annotations, String reportKey) throws IOException {
         if (annotations.isEmpty()) {
             return;
         }
@@ -112,7 +111,7 @@ class BitbucketServerClient implements BitbucketClient {
         CreateAnnotationsRequest request = new CreateAnnotationsRequest(annotationSet);
         Request req = new Request.Builder()
                 .post(RequestBody.create(objectMapper.writeValueAsString(request), APPLICATION_JSON_MEDIA_TYPE))
-                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", config.getUrl(), config.getProject(), config.getRepository(), commit, REPORT_KEY))
+                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s/annotations", config.getUrl(), config.getProject(), config.getRepository(), commit, reportKey))
                 .build();
         try (Response response = okHttpClient.newCall(req).execute()) {
             validate(response);
@@ -125,11 +124,11 @@ class BitbucketServerClient implements BitbucketClient {
     }
 
     @Override
-    public void uploadReport(String commit, CodeInsightsReport codeInsightReport) throws IOException {
+    public void uploadReport(String commit, CodeInsightsReport codeInsightReport, String reportKey) throws IOException {
         String body = objectMapper.writeValueAsString(codeInsightReport);
         Request req = new Request.Builder()
                 .put(RequestBody.create(body, APPLICATION_JSON_MEDIA_TYPE))
-                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s", config.getUrl(), config.getProject(), config.getRepository(), commit, REPORT_KEY))
+                .url(format("%s/rest/insights/1.0/projects/%s/repos/%s/commits/%s/reports/%s", config.getUrl(), config.getProject(), config.getRepository(), commit, reportKey))
                 .build();
 
         try (Response response = okHttpClient.newCall(req).execute()) {

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClientUnitTest.java
@@ -89,13 +89,13 @@ public class BitbucketCloudClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when
-        underTest.uploadReport("commit", report);
+        underTest.uploadReport("commit", report, "reportKey");
 
         // then
         verify(client, times(2)).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("PUT", request.method());
-        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/com.github.mc1arke.sonarqube", request.url().toString());
+        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/reportKey", request.url().toString());
     }
 
     @Test
@@ -109,13 +109,13 @@ public class BitbucketCloudClientUnitTest {
         when(call.execute()).thenReturn(response);
 
         // when
-        underTest.deleteExistingReport("commit");
+        underTest.deleteExistingReport("commit", "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("DELETE", request.method());
-        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/com.github.mc1arke.sonarqube", request.url().toString());
+        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/reportKey", request.url().toString());
     }
 
     @Test
@@ -134,13 +134,13 @@ public class BitbucketCloudClientUnitTest {
         when(mapper.writeValueAsString(any())).thenReturn("{payload}");
 
         // when
-        underTest.uploadAnnotations("commit", annotations);
+        underTest.uploadAnnotations("commit", annotations, "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("POST", request.method());
-        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+        assertEquals("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/reports/reportKey/annotations", request.url().toString());
     }
 
     @Test
@@ -172,7 +172,7 @@ public class BitbucketCloudClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when,then
-        assertThatThrownBy(() -> underTest.uploadReport("commit", report))
+        assertThatThrownBy(() -> underTest.uploadReport("commit", report, "reportKey"))
                 .isInstanceOf(BitbucketCloudException.class)
                 .hasMessage("HTTP Status Code: 400; Message:error!")
                 .extracting(e -> ((BitbucketCloudException) e).isError(400))
@@ -185,7 +185,7 @@ public class BitbucketCloudClientUnitTest {
         Set<CodeInsightsAnnotation> annotations = Sets.newHashSet();
 
         // when
-        underTest.uploadAnnotations("commit", annotations);
+        underTest.uploadAnnotations("commit", annotations, "reportKey");
 
         // then
         verify(client, never()).newCall(any());

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
@@ -240,13 +240,13 @@ public class BitbucketServerClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when
-        underTest.uploadReport("commit", report);
+        underTest.uploadReport("commit", report, "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("PUT", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/reportKey", request.url().toString());
     }
 
     @Test
@@ -264,7 +264,7 @@ public class BitbucketServerClientUnitTest {
         when(mapper.writeValueAsString(report)).thenReturn("{payload}");
 
         // when,then
-        assertThatThrownBy(() -> underTest.uploadReport("commit", report))
+        assertThatThrownBy(() -> underTest.uploadReport("commit", report, "reportKey"))
                 .isInstanceOf(BitbucketException.class);
     }
 
@@ -295,7 +295,7 @@ public class BitbucketServerClientUnitTest {
 
 
         // when,then
-        assertThatThrownBy(() -> underTest.uploadReport("commit", report))
+        assertThatThrownBy(() -> underTest.uploadReport("commit", report, "reportKey"))
                 .isInstanceOf(BitbucketException.class)
                 .hasMessage("error!")
                 .extracting(e -> ((BitbucketException) e).isError(400))
@@ -323,13 +323,13 @@ public class BitbucketServerClientUnitTest {
         when(response.isSuccessful()).thenReturn(true);
 
         // when
-        underTest.uploadAnnotations("commit", annotations);
+        underTest.uploadAnnotations("commit", annotations, "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("POST", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/reportKey/annotations", request.url().toString());
 
         try (Buffer bodyContent = new Buffer()) {
             request.body().writeTo(bodyContent);
@@ -343,7 +343,7 @@ public class BitbucketServerClientUnitTest {
         Set<CodeInsightsAnnotation> annotations = Sets.newHashSet();
 
         // when
-        underTest.uploadAnnotations("commit", annotations);
+        underTest.uploadAnnotations("commit", annotations, "reportKey");
 
         // then
         verify(client, never()).newCall(any());
@@ -361,13 +361,13 @@ public class BitbucketServerClientUnitTest {
         when(response.isSuccessful()).thenReturn(true);
 
         // when
-        underTest.deleteAnnotations("commit");
+        underTest.deleteAnnotations("commit", "reportKey");
 
         // then
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("DELETE", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/com.github.mc1arke.sonarqube/annotations", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/reportKey/annotations", request.url().toString());
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 class BitbucketPullRequestDecoratorTest {
 
     private static final String COMMIT = "commit";
+    private static final String REPORT_KEY = "report-key";
 
     private static final String ISSUE_KEY = "issue-key";
     private static final int ISSUE_LINE = 1;
@@ -73,7 +74,7 @@ class BitbucketPullRequestDecoratorTest {
         verify(client).createCodeInsightsAnnotation(ISSUE_KEY, ISSUE_LINE, ISSUE_LINK, ISSUE_MESSAGE, ISSUE_PATH, "HIGH", "BUG");
         verify(client).createLinkDataValue(DASHBOARD_URL);
         verify(client).createCodeInsightsReport(any(), eq("Quality Gate passed" + System.lineSeparator()), any(), eq(DASHBOARD_URL), eq(String.format("%s/common/icon.png", IMAGE_URL)), eq(ReportStatus.PASSED));
-        verify(client).deleteAnnotations(COMMIT);
+        verify(client).deleteAnnotations(COMMIT, REPORT_KEY);
     }
 
     @ParameterizedTest(name = "{arguments}")
@@ -94,6 +95,7 @@ class BitbucketPullRequestDecoratorTest {
     private void mockValidAnalysis() {
         when(analysisDetails.getCommitSha()).thenReturn(COMMIT);
         when(analysisDetails.getQualityGateStatus()).thenReturn(QualityGate.Status.OK);
+        when(analysisDetails.getAnalysisProjectKey()).thenReturn(REPORT_KEY);
 
         when(analysisDetails.getAnalysisDate()).thenReturn(Date.from(Instant.now()));
 


### PR DESCRIPTION
The key for the Code Insights report uses a static value which results
in any report submitted by Sonarqube overwriting any existing report,
even where reports are submitted from different projects, such as would
happen in a mono-report setup. The report key is therefore being changed
to use the project key, so that repeated scans from a single project
continue to overwrite each other, whilst scans against the same
repository from different projects will allow new reports to be
submitted without altering existing reports.