### PR TITLE
Fix unit tests on Windows.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,10 @@ configurations {
 
 compileJava {
     options.compilerArgs += '-proc:none'
+    options.encoding = 'UTF-8'
+}
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
 }
 
 


### PR DESCRIPTION
iirc default charset on Windows is windows-1252 which causes unit tests to fail https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/569#issuecomment-1097698884 we can work around this by specifying utf8 in the gradle build file.