### PR TITLE
Fix Bitbucket PR reports

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
@@ -86,7 +86,8 @@ public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
     private static ObjectMapper createObjectMapper() {
         return new ObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .findAndRegisterModules();
     }
 
     private static OkHttpClient.Builder createBaseClientBuilder(HttpClientBuilderFactory httpClientBuilderFactory) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/model/BitbucketConfiguration.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/model/BitbucketConfiguration.java
@@ -23,7 +23,7 @@ public class BitbucketConfiguration {
     private final String repository;
     private final String project;
 
-    public BitbucketConfiguration(String repository, String project) {
+    public BitbucketConfiguration(String project, String repository) {
         this.repository = repository;
         this.project = project;
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/model/server/BitbucketServerConfiguration.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/model/server/BitbucketServerConfiguration.java
@@ -24,8 +24,8 @@ public class BitbucketServerConfiguration extends BitbucketConfiguration {
 
     private final String url;
 
-    public BitbucketServerConfiguration(String almRepo, String almSlug, String url) {
-        super(almRepo, almSlug);
+    public BitbucketServerConfiguration(String project, String repository, String url) {
+        super(project, repository);
         this.url = url;
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
@@ -45,6 +45,7 @@ import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -110,9 +111,9 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
     private static List<ReportData> toReport(BitbucketClient client, AnalysisSummary analysisSummary) {
         List<ReportData> reportData = new ArrayList<>();
         reportData.add(reliabilityReport(analysisSummary.getBugCount()));
-        reportData.add(new ReportData("Code coverage", new DataValue.Percentage(analysisSummary.getNewCoverage())));
+        reportData.add(new ReportData("Code coverage", new DataValue.Percentage(Optional.ofNullable(analysisSummary.getNewCoverage()).orElse(BigDecimal.ZERO))));
         reportData.add(securityReport(analysisSummary.getVulnerabilityCount(), analysisSummary.getSecurityHotspotCount()));
-        reportData.add(new ReportData("Duplication", new DataValue.Percentage(analysisSummary.getNewDuplications())));
+        reportData.add(new ReportData("Duplication", new DataValue.Percentage(Optional.ofNullable(analysisSummary.getNewDuplications()).orElse(BigDecimal.ZERO))));
         reportData.add(maintainabilityReport(analysisSummary.getCodeSmellCount()));
         reportData.add(new ReportData("Analysis details", client.createLinkDataValue(analysisSummary.getDashboardUrl())));
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClientUnitTest.java
@@ -68,7 +68,7 @@ public class BitbucketCloudClientUnitTest {
 
     @Before
     public void before() {
-        BitbucketConfiguration bitbucketConfiguration = new BitbucketConfiguration("repository", "project");
+        BitbucketConfiguration bitbucketConfiguration = new BitbucketConfiguration("project", "repository");
         Call call = mock(Call.class);
         when(client.newCall(any())).thenReturn(call);
         underTest = new BitbucketCloudClient(mapper, client, bitbucketConfiguration);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
@@ -74,7 +74,7 @@ public class BitbucketServerClientUnitTest {
     @Before
     public void before() {
         BitbucketServerConfiguration
-                config = new BitbucketServerConfiguration("repository", "slug", "https://my-server.org");
+                config = new BitbucketServerConfiguration("project", "repository", "https://my-server.org");
         underTest = new BitbucketServerClient(config, mapper, client);
     }
 
@@ -246,7 +246,7 @@ public class BitbucketServerClientUnitTest {
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("PUT", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/reportKey", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/reportKey", request.url().toString());
     }
 
     @Test
@@ -329,7 +329,7 @@ public class BitbucketServerClientUnitTest {
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("POST", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/reportKey/annotations", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/reportKey/annotations", request.url().toString());
 
         try (Buffer bodyContent = new Buffer()) {
             request.body().writeTo(bodyContent);
@@ -367,7 +367,7 @@ public class BitbucketServerClientUnitTest {
         verify(client).newCall(captor.capture());
         Request request = captor.getValue();
         assertEquals("DELETE", request.method());
-        assertEquals("https://my-server.org/rest/insights/1.0/projects/slug/repos/repository/commits/commit/reports/reportKey/annotations", request.url().toString());
+        assertEquals("https://my-server.org/rest/insights/1.0/projects/project/repos/repository/commits/commit/reports/reportKey/annotations", request.url().toString());
     }
 
     @Test


### PR DESCRIPTION
With the Sonar 9.4 support the project key and repository slug for Bitbucket repositories got swapped, causing the plugin not being able to find the repository to send the PR report to.

The available ObjectMapper modules also had to be registered in order write the report timestamp to JSON.