### PR TITLE
Improve test stability

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClientTest.java
@@ -56,7 +56,7 @@ class AzureDevopsRestClientTest {
 
         assertThat(request.getMethod()).isEqualTo("post");
         assertThat(request.getUri()).isEqualTo(URI.create("http://url.test/api/project/_apis/git/repositories/repo/pullRequests/101/statuses?api-version=4.1-preview"));
-        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new StringEntity("json", StandardCharsets.UTF_8));
+        assertThat(request.getEntity().getContent()).hasContent("json");
     }
 
     @Test
@@ -79,7 +79,7 @@ class AzureDevopsRestClientTest {
 
         assertThat(request.getMethod()).isEqualTo("post");
         assertThat(request.getUri()).isEqualTo(URI.create("http://url.test/api/project%20Id%20With%20Spaces/_apis/git/repositories/repository%20Name%20With%20Spaces/pullRequests/123/statuses?api-version=4.1-preview"));
-        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new StringEntity("json", StandardCharsets.UTF_8));
+        assertThat(request.getEntity().getContent()).hasContent("json");
     }
 
     @Test
@@ -102,7 +102,7 @@ class AzureDevopsRestClientTest {
 
         assertThat(request.getMethod()).isEqualTo("post");
         assertThat(request.getUri()).isEqualTo(URI.create("http://test.url/projectId/_apis/git/repositories/repository%20Name/pullRequests/123/threads/321/comments?api-version=4.1"));
-        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new StringEntity("json", StandardCharsets.UTF_8));
+        assertThat(request.getEntity().getContent()).hasContent("json");
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClientTest.java
@@ -56,7 +56,7 @@ class GitlabRestClientTest {
 
         assertThat(request.getRequestLine().getMethod()).isEqualTo("POST");
         assertThat(request.getRequestLine().getUri()).isEqualTo("http://url.test/api/projects/101/merge_requests/99/discussions");
-        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new UrlEncodedFormEntity(List.of(new BasicNameValuePair("body", "note")), StandardCharsets.UTF_8));
+        assertThat(request.getEntity().getContent()).hasContent("body=note");
     }
 
     @Test
@@ -81,7 +81,7 @@ class GitlabRestClientTest {
 
         assertThat(request.getRequestLine().getMethod()).isEqualTo("POST");
         assertThat(request.getRequestLine().getUri()).isEqualTo("http://api.url/projects/123/merge_requests/321/discussions");
-        assertThat(request.getEntity()).usingRecursiveComparison().isEqualTo(new UrlEncodedFormEntity(List.of(new BasicNameValuePair("body", "Merge request note")), StandardCharsets.UTF_8));
+        assertThat(request.getEntity().getContent()).hasContent("body=Merge+request+note");
     }
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.when;
 public class AzureDevOpsPullRequestDecoratorTest {
 
     @Rule
-    public final WireMockRule wireMockRule = new WireMockRule(wireMockConfig());
+    public final WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
     private final String azureProject = "azure Project";
     private final String sonarProject = "sonarProject";
@@ -229,7 +229,7 @@ public class AzureDevOpsPullRequestDecoratorTest {
                                 "      \"state\": \"wellFormed\"," + System.lineSeparator() +
                                 "      \"revision\": 7" + System.lineSeparator() +
                                 "    }," + System.lineSeparator() +
-                                "    \"remoteUrl\": \"http://localhost:8080/" + azureProject + "/_git/" + azureRepository + "\"" + System.lineSeparator() +
+                                "    \"remoteUrl\": \"" + wireMockRule.baseUrl() + "/" + azureProject + "/_git/" + azureRepository + "\"" + System.lineSeparator() +
                                 "  }," + System.lineSeparator() +
                                 "  \"pullRequestId\": " + pullRequestId + "," + System.lineSeparator() +
                                 "  \"codeReviewId\": " + pullRequestId + "," + System.lineSeparator() +

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecoratorIntegrationTest.java
@@ -66,7 +66,7 @@ import static org.mockito.Mockito.when;
 public class GitlabMergeRequestDecoratorIntegrationTest {
 
     @Rule
-    public final WireMockRule wireMockRule = new WireMockRule(wireMockConfig());
+    public final WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
     @Test
     public void decorateQualityGateStatusOk() {


### PR DESCRIPTION
The wiremock based tests currently fail if another service is running on
on port 8080, and other tests fail with newer dependencies due to
changes in recursive comparisons. The wiremock tests are being altered
to use a random port for runs to prevent port conflict, and the tests
comparing HTTP entities are being altered to extract the InputStream for
comparing the contents from.