### PR TITLE
#601 Strip user info from Azure DevOps repository link

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecoratorTest.java
@@ -2,6 +2,8 @@ package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.azuredevops;
 
 import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.AzureDevopsClientFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.DefaultAzureDevopsClientFactory;
+import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.model.PullRequest;
+import com.github.mc1arke.sonarqube.plugin.almclient.azuredevops.model.Repository;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PostAnalysisIssueVisitor;
@@ -582,6 +584,26 @@ public class AzureDevOpsPullRequestDecoratorTest {
 
         DecorationResult result = pullRequestDecorator.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
         assertThat(result.getPullRequestUrl()).isEqualTo(Optional.of(String.format("%s/%s/_git/%s/pullRequest/%s", wireMockRule.baseUrl(), azureProject, azureRepository, pullRequestId)));
+    }
+
+    @Test
+    public void shouldRemoveUserInfoFromRepositoryUrlForLinking() {
+        ScmInfoRepository scmInfoRepository = mock(ScmInfoRepository.class);
+        AzureDevopsClientFactory azureDevopsClientFactory = mock(AzureDevopsClientFactory.class);
+        ReportGenerator reportGenerator = mock(ReportGenerator.class);
+        MarkdownFormatterFactory markdownFormatterFactory = mock(MarkdownFormatterFactory.class);
+
+        AzureDevOpsPullRequestDecorator underTest = new AzureDevOpsPullRequestDecorator(scmInfoRepository, azureDevopsClientFactory, reportGenerator, markdownFormatterFactory);
+
+        Repository repository = mock(Repository.class);
+        when(repository.getRemoteUrl()).thenReturn("https://user@domain.com/path/to/repo");
+        PullRequest pullRequest = mock(PullRequest.class);
+        when(pullRequest.getRepository()).thenReturn(repository);
+        when(pullRequest.getId()).thenReturn(999);
+
+        AnalysisDetails analysisDetails = mock(AnalysisDetails.class);
+
+        assertThat(underTest.createFrontEndUrl(pullRequest, analysisDetails)).contains("https://domain.com/path/to/repo/pullRequest/999");
     }
 
 }


### PR DESCRIPTION
When creating the link from Sonarqube to an Azure Devops Pull Request,
the URL of the owning repository is used as a base for the URL. If the
Azure DevOps API returns a URL containing user authentication details
then this is included in the resulting link, even though the details
may not be valid for a front-end user. The authentication detail is
therefore being stripped from the URL before the Pull Request URL is
generated.