### PR TITLE
New config options for issue/summary comments desactivation and previous summary deletion

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -60,15 +60,35 @@ import org.sonar.api.PropertyType;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
+import org.sonar.api.rule.Severity;
 import org.sonar.core.config.PurgeConstants;
 import org.sonar.core.extension.CoreExtension;
+
+import java.util.List;
 
 /**
  * @author Michael Clarke
  */
 public class CommunityBranchPlugin implements Plugin, CoreExtension {
 
+    public static final String SUBCATEGORY_BRANCH = "Branch";
+
     public static final String IMAGE_URL_BASE = "com.github.mc1arke.sonarqube.plugin.branch.image-url-base";
+
+    public static final String PR_MINIMUM_ISSUE_SEVERITY =
+            "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.minimumIssueSeverity";
+    public static final String PR_ISSUE_DISCUSSION_THRESHOLD =
+            "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.issueDiscussionThreshold";
+    public static final String PR_DISABLE_ANALYSIS_SUMMARY =
+            "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.disableAnalysisSummary";
+    public static final String PR_DELETE_RESOLVED_DISCUSSIONS =
+            "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.deleteResolvedDiscussions";
+    public static final String PR_DISABLE_ANALYSIS_PIPELINE_STATUS =
+            "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.disableAnalysisPipelineStatus";
+    public static final List<String> PR_SEVERITIES_LIST = List.of(
+            Severity.INFO, Severity.MINOR, Severity.MAJOR, Severity.CRITICAL, Severity.BLOCKER);
+    public static final Long PR_ISSUE_DISCUSSION_THRESHOLD_UNLIMITED = -1L;
+    public static final Long PR_ISSUE_DISCUSSION_THRESHOLD_NONE = 0L;
 
     @Override
     public String getName() {
@@ -148,6 +168,64 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                                           .description("Base URL used to load the images for the PR comments (please use this only if images are not displayed properly).")
                                           .type(PropertyType.STRING)
                                           .build());
+
+            context.addExtensions(PropertyDefinition.builder(PR_MINIMUM_ISSUE_SEVERITY)
+                    .category(CoreProperties.CATEGORY_GENERAL)
+                    .subCategory(SUBCATEGORY_BRANCH)
+                    .onQualifiers(Qualifiers.PROJECT)
+                    .name("Minimum issue severity for comment")
+                    .description("Minimum level of severity required for issue discussion thread creation (Gitlab and Azure DevOps only).")
+                    .type(PropertyType.SINGLE_SELECT_LIST)
+                    .options(PR_SEVERITIES_LIST)
+                    .defaultValue(Severity.INFO)
+                    .index(1)
+                    .build());
+
+            context.addExtensions(PropertyDefinition.builder(PR_ISSUE_DISCUSSION_THRESHOLD)
+                    .category(CoreProperties.CATEGORY_GENERAL)
+                    .subCategory(SUBCATEGORY_BRANCH)
+                    .onQualifiers(Qualifiers.PROJECT)
+                    .name("Maximum number of issue comments")
+                    .description("Maximum number of issues for which discussion threads will be created ("
+                            + PR_ISSUE_DISCUSSION_THRESHOLD_UNLIMITED + ": unlimited, "
+                            + PR_ISSUE_DISCUSSION_THRESHOLD_NONE + ": none) (Gitlab and Azure DevOps only).")
+                    .type(PropertyType.INTEGER)
+                    .defaultValue(String.valueOf(PR_ISSUE_DISCUSSION_THRESHOLD_UNLIMITED))
+                    .index(2)
+                    .build());
+
+            context.addExtensions(PropertyDefinition.builder(PR_DISABLE_ANALYSIS_SUMMARY)
+                    .category(CoreProperties.CATEGORY_GENERAL)
+                    .subCategory(SUBCATEGORY_BRANCH)
+                    .onQualifiers(Qualifiers.PROJECT)
+                    .name("Disable analysis summary")
+                    .description("Disable analysis summary discussion thread creation (Gitlab and Azure DevOps only).")
+                    .type(PropertyType.BOOLEAN)
+                    .defaultValue(String.valueOf(false))
+                    .index(3)
+                    .build());
+
+            context.addExtensions(PropertyDefinition.builder(PR_DELETE_RESOLVED_DISCUSSIONS)
+                    .category(CoreProperties.CATEGORY_GENERAL)
+                    .subCategory(SUBCATEGORY_BRANCH)
+                    .onQualifiers(Qualifiers.PROJECT)
+                    .name("Delete issues/summary")
+                    .description("Delete issues/summary discussion threads instead of resolving them (Gitlab only).")
+                    .type(PropertyType.BOOLEAN)
+                    .defaultValue(String.valueOf(false))
+                    .index(4)
+                    .build());
+
+            context.addExtensions(PropertyDefinition.builder(PR_DISABLE_ANALYSIS_PIPELINE_STATUS)
+                    .category(CoreProperties.CATEGORY_GENERAL)
+                    .subCategory(SUBCATEGORY_BRANCH)
+                    .onQualifiers(Qualifiers.PROJECT)
+                    .name("Disable analysis pipeline status")
+                    .description("Disable analysis pipeline status creation (Gitlab and Azure DevOps only).")
+                    .type(PropertyType.BOOLEAN)
+                    .defaultValue(String.valueOf(false))
+                    .index(5)
+                    .build());
 
         }
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabClient.java
@@ -43,6 +43,8 @@ public interface GitlabClient {
 
     void addMergeRequestDiscussionNote(long projectId, long mergeRequestIid, String discussionId, String noteContent) throws IOException;
 
+    void deleteMergeRequestDiscussionNote(long projectId, long mergeRequestIid, String discussionId, long noteId) throws IOException;
+
     void resolveMergeRequestDiscussion(long projectId, long mergeRequestIid, String discussionId) throws IOException;
 
     void setMergeRequestPipelineStatus(long projectId, String commitRevision, PipelineStatus status) throws IOException;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClient.java
@@ -31,6 +31,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.User;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -124,6 +125,14 @@ class GitlabRestClient implements GitlabClient {
         HttpPost httpPost = new HttpPost(targetUrl);
         httpPost.setEntity(new UrlEncodedFormEntity(Collections.singletonList(new BasicNameValuePair("body", noteContent)), StandardCharsets.UTF_8));
         entity(httpPost, null, httpResponse -> validateResponse(httpResponse, 201, "Commit discussions note added"));
+    }
+
+    @Override
+    public void deleteMergeRequestDiscussionNote(long projectId, long mergeRequestIid, String discussionId, long noteId) throws IOException {
+        String noteIdUrl = String.format("%s/projects/%s/merge_requests/%s/discussions/%s/notes/%s", baseGitlabApiUrl, projectId, mergeRequestIid, discussionId, noteId);
+
+        HttpDelete httpDel = new HttpDelete(noteIdUrl);
+        entity(httpDel, null, httpResponse -> validateResponse(httpResponse, 204, "Discussion note deleted"));
     }
 
     @Override

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
@@ -228,6 +228,11 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
     }
 
     @Override
+    protected void deleteDiscussionNote(AzureDevopsClient client, CommentThread discussion, PullRequest pullRequest, Comment note) {
+
+    }
+
+    @Override
     protected void resolveDiscussion(AzureDevopsClient client, CommentThread discussion, PullRequest pullRequest) {
         try {
             client.resolvePullRequestThread(pullRequest.getRepository().getProject().getName(), pullRequest.getRepository().getName(), pullRequest.getId(), discussion.getId());

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab;
 
+import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.GitlabClient;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.GitlabClientFactory;
 import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.Commit;
@@ -212,6 +213,15 @@ public class GitlabMergeRequestDecorator extends DiscussionAwarePullRequestDecor
             client.addMergeRequestDiscussionNote(pullRequest.getTargetProjectId(), pullRequest.getIid(), discussion.getId(), note);
         } catch (IOException ex) {
             throw new IllegalStateException("Could not add note to Merge Request discussion", ex);
+        }
+    }
+
+    @Override
+    protected void deleteDiscussionNote(GitlabClient client, Discussion discussion, MergeRequest pullRequest, Note note) {
+        try {
+            client.deleteMergeRequestDiscussionNote(pullRequest.getTargetProjectId(), pullRequest.getIid(), discussion.getId(), note.getId());
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not delete note from Merge Request discussion", ex);
         }
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin.scanner;
 
+import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabMergeRequestDecorator;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -54,6 +55,15 @@ public class ScannerPullRequestPropertySensor implements Sensor {
         Optional.ofNullable(system2.property(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID)).ifPresent(
                 v -> sensorContext.addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, v));
 
+        // Handle new project configuration options to allow disabling of issue and/or summary discussion creation
+        toContextPropertyIfPresent(sensorContext, CommunityBranchPlugin.PR_MINIMUM_ISSUE_SEVERITY);
+        toContextPropertyIfPresent(sensorContext, CommunityBranchPlugin.PR_ISSUE_DISCUSSION_THRESHOLD);
+        toContextPropertyIfPresent(sensorContext, CommunityBranchPlugin.PR_DISABLE_ANALYSIS_SUMMARY);
+        toContextPropertyIfPresent(sensorContext, CommunityBranchPlugin.PR_DELETE_RESOLVED_DISCUSSIONS);
+        toContextPropertyIfPresent(sensorContext, CommunityBranchPlugin.PR_DISABLE_ANALYSIS_PIPELINE_STATUS);
     }
 
+    private static void toContextPropertyIfPresent(final SensorContext context, final String propertyName) {
+        context.config().get(propertyName).ifPresent(p -> context.addContextProperty(propertyName, p));
+    }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -98,7 +98,7 @@ public class CommunityBranchPluginTest {
         testCase.load(context);
 
         final ArgumentCaptor<Class> argumentCaptor = ArgumentCaptor.forClass(Class.class);
-        verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
+        verify(context, times(7)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
 
         assertEquals(Collections.singletonList(CommunityReportAnalysisComponentProvider.class),
@@ -116,9 +116,9 @@ public class CommunityBranchPluginTest {
         testCase.load(context);
 
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
-        verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
+        verify(context, times(7)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(25, argumentCaptor.getAllValues().size());
+        assertEquals(30, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));


### PR DESCRIPTION
This PR adds five new project configuration options allowing to:

- require a minimum level of severity for issue comments (Gitlab and Azure DevOps only),
- define a maximum number of issue comments (Gitlab and Azure DevOps only),
- disable the analysis summary comment (Gitlab and Azure DevOps only),
- delete resolved issues/summary instead of resolving them (Gitlab only),
- disable the analysis pipeline status (Gitlab and Azure DevOps only).

<img width="691" alt="image" src="https://user-images.githubusercontent.com/385653/182039838-e9f43271-1833-433f-b235-3f3966e8c727.png">


