### PR TITLE
Feature/9.7 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '9.1.0.47736'
+def sonarqubeVersion = '9.7.1.62043'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -54,6 +54,10 @@ import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.SetBitbu
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.SetGithubBindingAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.SetGitlabBindingAction;
 import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.action.ValidateBindingAction;
+import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.DeleteAction;
+import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.ListAction;
+import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestWsModule;
+import com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWs;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.Plugin;
 import org.sonar.api.PropertyType;
@@ -80,14 +84,22 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
         if (SonarQubeSide.COMPUTE_ENGINE == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(CommunityReportAnalysisComponentProvider.class);
         } else if (SonarQubeSide.SERVER == context.getRuntime().getSonarQubeSide()) {
-            context.addExtensions(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class,
-                                  DeleteBindingAction.class,
-                                  SetGithubBindingAction.class,
-                                  SetAzureBindingAction.class,
-                                  SetBitbucketBindingAction.class,
-                                  SetBitbucketCloudBindingAction.class,
-                                  SetGitlabBindingAction.class,
+            context.addExtensions(
+                    CommunityBranchFeatureExtension.class,
+                    CommunityBranchSupportDelegate.class,
+
+                    DeleteBindingAction.class,
+                    SetGithubBindingAction.class,
+                    SetAzureBindingAction.class,
+                    SetBitbucketBindingAction.class,
+                    SetBitbucketCloudBindingAction.class,
+                    SetGitlabBindingAction.class,
                     ValidateBindingAction.class,
+
+                    new PullRequestWsModule(),
+                    DeleteAction.class,
+                    ListAction.class,
+                    PullRequestsWs.class,
 
                     GithubValidator.class,
                     DefaultGraphqlProvider.class,
@@ -106,48 +118,48 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                 /* org.sonar.db.purge.PurgeConfiguration uses the value for the this property if it's configured, so it only
                 needs to be specified here, but doesn't need any additional classes to perform the relevant purge/cleanup
                 */
-                                  PropertyDefinition
-                                          .builder(PurgeConstants.DAYS_BEFORE_DELETING_INACTIVE_BRANCHES_AND_PRS)
-                                          .name("Number of days before purging inactive branches and pull requests")
-                                          .description(
-                                                  "Branches and pull requests are permanently deleted when there has been no analysis for the configured number of days.")
-                                          .category(CoreProperties.CATEGORY_HOUSEKEEPING)
-                                          .subCategory(CoreProperties.SUBCATEGORY_BRANCHES_AND_PULL_REQUESTS).defaultValue("30")
-                                          .type(PropertyType.INTEGER)
-                                          .index(1)
-                                          .build()
-                                  ,
+                    PropertyDefinition
+                            .builder(PurgeConstants.DAYS_BEFORE_DELETING_INACTIVE_BRANCHES_AND_PRS)
+                            .name("Number of days before purging inactive branches and pull requests")
+                            .description(
+                                    "Branches and pull requests are permanently deleted when there has been no analysis for the configured number of days.")
+                            .category(CoreProperties.CATEGORY_HOUSEKEEPING)
+                            .subCategory(CoreProperties.SUBCATEGORY_BRANCHES_AND_PULL_REQUESTS).defaultValue("30")
+                            .type(PropertyType.INTEGER)
+                            .index(1)
+                            .build()
+                    ,
 
-                                  PropertyDefinition
-                                          .builder(PurgeConstants.BRANCHES_TO_KEEP_WHEN_INACTIVE)
-                                          .name("Branches to keep when inactive")
-                                          .description("By default, branches and pull requests are automatically deleted when inactive. This setting allows you "
-                                                + "to protect branches (but not pull requests) from this deletion. When a branch is created with a name that "
-                                                + "matches any of the regular expressions on the list of values of this setting, the branch will not be deleted "
-                                                + "automatically even when it becomes inactive. Example:"
-                                                + "<ul><li>develop</li><li>release-.*</li></ul>")
-                                          .category(CoreProperties.CATEGORY_HOUSEKEEPING)
-                                          .subCategory(CoreProperties.SUBCATEGORY_BRANCHES_AND_PULL_REQUESTS)
-                                          .multiValues(true)
-                                          .defaultValue("master,develop,trunk")
-                                          .onQualifiers(Qualifiers.PROJECT)
-                                          .index(2)
-                                          .build()
+                    PropertyDefinition
+                            .builder(PurgeConstants.BRANCHES_TO_KEEP_WHEN_INACTIVE)
+                            .name("Branches to keep when inactive")
+                            .description("By default, branches and pull requests are automatically deleted when inactive. This setting allows you "
+                                    + "to protect branches (but not pull requests) from this deletion. When a branch is created with a name that "
+                                    + "matches any of the regular expressions on the list of values of this setting, the branch will not be deleted "
+                                    + "automatically even when it becomes inactive. Example:"
+                                    + "<ul><li>develop</li><li>release-.*</li></ul>")
+                            .category(CoreProperties.CATEGORY_HOUSEKEEPING)
+                            .subCategory(CoreProperties.SUBCATEGORY_BRANCHES_AND_PULL_REQUESTS)
+                            .multiValues(true)
+                            .defaultValue("master,develop,trunk")
+                            .onQualifiers(Qualifiers.PROJECT)
+                            .index(2)
+                            .build()
 
-                                 );
+            );
 
         }
 
         if (SonarQubeSide.COMPUTE_ENGINE == context.getRuntime().getSonarQubeSide() ||
-            SonarQubeSide.SERVER == context.getRuntime().getSonarQubeSide()) {
+                SonarQubeSide.SERVER == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(PropertyDefinition.builder(IMAGE_URL_BASE)
-                                          .category(CoreProperties.CATEGORY_GENERAL)
-                                          .subCategory(CoreProperties.SUBCATEGORY_GENERAL)
-                                          .onQualifiers(Qualifiers.APP)
-                                          .name("Images base URL")
-                                          .description("Base URL used to load the images for the PR comments (please use this only if images are not displayed properly).")
-                                          .type(PropertyType.STRING)
-                                          .build());
+                    .category(CoreProperties.CATEGORY_GENERAL)
+                    .subCategory(CoreProperties.SUBCATEGORY_GENERAL)
+                    .onQualifiers(Qualifiers.APP)
+                    .name("Images base URL")
+                    .description("Base URL used to load the images for the PR comments (please use this only if images are not displayed properly).")
+                    .type(PropertyType.STRING)
+                    .build());
 
         }
     }
@@ -156,12 +168,12 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
     public void define(Plugin.Context context) {
         if (SonarQubeSide.SCANNER == context.getRuntime().getSonarQubeSide()) {
             context.addExtensions(CommunityProjectBranchesLoader.class, CommunityProjectPullRequestsLoader.class,
-                                  CommunityBranchConfigurationLoader.class, CommunityBranchParamsValidator.class,
-                                  ScannerPullRequestPropertySensor.class, BranchConfigurationFactory.class,
-                                  AzureDevopsAutoConfigurer.class, BitbucketPipelinesAutoConfigurer.class,
-                                  CirrusCiAutoConfigurer.class, CodeMagicAutoConfigurer.class,
-                                  GithubActionsAutoConfigurer.class, GitlabCiAutoConfigurer.class,
-                                  JenkinsAutoConfigurer.class);
+                    CommunityBranchConfigurationLoader.class, CommunityBranchParamsValidator.class,
+                    ScannerPullRequestPropertySensor.class, BranchConfigurationFactory.class,
+                    AzureDevopsAutoConfigurer.class, BitbucketPipelinesAutoConfigurer.class,
+                    CirrusCiAutoConfigurer.class, CodeMagicAutoConfigurer.class,
+                    GithubActionsAutoConfigurer.class, GitlabCiAutoConfigurer.class,
+                    JenkinsAutoConfigurer.class);
         }
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranch.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranch.java
@@ -18,11 +18,8 @@
  */
 package com.github.mc1arke.sonarqube.plugin.ce;
 
-import org.apache.commons.lang.StringUtils;
 import org.sonar.ce.task.projectanalysis.analysis.Branch;
-import org.sonar.core.component.ComponentKeys;
 import org.sonar.db.component.BranchType;
-import org.sonar.db.component.ComponentDto;
 
 /**
  * @author Michael Clarke
@@ -81,26 +78,19 @@ public class CommunityBranch implements Branch {
     }
 
     @Override
-    public String generateKey(String projectKey, String fileOrDirPath) {
-        String effectiveKey;
-        if (null == fileOrDirPath) {
-            effectiveKey = projectKey;
-        } else {
-            effectiveKey = ComponentKeys.createEffectiveKey(projectKey, StringUtils.trimToNull(fileOrDirPath));
-        }
-
-        if (main) {
-            return effectiveKey;
-        } else if (BranchType.PULL_REQUEST == branchType) {
-            return ComponentDto.generatePullRequestKey(effectiveKey, pullRequestKey);
-        } else {
-            return ComponentDto.generateBranchKey(effectiveKey, name);
-        }
-    }
-
-    @Override
     public String getTargetBranchName() {
         return targetBranchName;
     }
 
+    @Override
+    public String toString() {
+        return "CommunityBranch{" +
+                "name='" + name + '\'' +
+                ", branchType=" + branchType +
+                ", main=" + main +
+                ", referenceBranchUuid='" + referenceBranchUuid + '\'' +
+                ", pullRequestKey='" + pullRequestKey + '\'' +
+                ", targetBranchName='" + targetBranchName + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchPersister.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchPersister.java
@@ -1,0 +1,124 @@
+package com.github.mc1arke.sonarqube.plugin.ce;
+
+import org.jetbrains.annotations.NotNull;
+import org.sonar.ce.task.projectanalysis.analysis.AnalysisMetadataHolder;
+import org.sonar.ce.task.projectanalysis.analysis.Branch;
+import org.sonar.ce.task.projectanalysis.batch.BatchReportReader;
+import org.sonar.ce.task.projectanalysis.component.*;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.component.*;
+import org.sonar.db.protobuf.DbProjectBranches;
+import org.springframework.context.annotation.Primary;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+
+@Primary
+public class CommunityBranchPersister implements BranchPersister {
+    private final DbClient dbClient;
+    private final TreeRootHolder treeRootHolder;
+    private final AnalysisMetadataHolder analysisMetadataHolder;
+    private final ConfigurationRepository configurationRepository;
+
+    public CommunityBranchPersister(DbClient dbClient, TreeRootHolder treeRootHolder, AnalysisMetadataHolder analysisMetadataHolder, ConfigurationRepository configurationRepository) {
+        this.dbClient = dbClient;
+        this.treeRootHolder = treeRootHolder;
+        this.analysisMetadataHolder = analysisMetadataHolder;
+        this.configurationRepository = configurationRepository;
+    }
+
+    @Override
+    public void persist(DbSession dbSession) {
+        Branch branch = this.analysisMetadataHolder.getBranch();
+        Component root = this.treeRootHolder.getRoot();
+        String branchUuid = root.getUuid();
+        Optional<ComponentDto> optBanchComponentDto = this.dbClient.componentDao().selectByUuid(dbSession, branchUuid);
+
+        ComponentDto branchComponentDto;
+        if (!optBanchComponentDto.isPresent()) {
+            if (branch.getType() == BranchType.PULL_REQUEST || !branch.isMain()) {
+                ComponentDto componentDto = createPullRequestComponentDto(branch, root);
+
+                this.dbClient.componentDao().insert(dbSession, componentDto);
+                branchComponentDto = componentDto;
+            } else {
+                throw new IllegalStateException("Component has been deleted by end-user during analysis");
+            }
+        } else {
+            branchComponentDto = optBanchComponentDto.get();
+        }
+        this.dbClient.branchDao().upsert(dbSession, this.toBranchDto(dbSession, branchComponentDto, branch, this.checkIfExcludedFromPurge()));
+    }
+
+    @NotNull
+    private static ComponentDto createPullRequestComponentDto(Branch branch, Component root) {
+        ComponentDto componentDto = new ComponentDto();
+        componentDto.setUuid(root.getUuid());
+        componentDto.setRootUuid(root.getUuid());
+        componentDto.setBranchUuid(root.getUuid());
+        componentDto.setKey(root.getKey());
+        componentDto.setScope("PRJ");
+        componentDto.setQualifier("TRK");
+        componentDto.setName(root.getName());
+        componentDto.setLongName(root.getName());
+        componentDto.setUuidPath(ComponentDto.UUID_PATH_OF_ROOT);
+        componentDto.setPrivate(false);
+        componentDto.setMainBranchProjectUuid(branch.getReferenceBranchUuid());
+        return componentDto;
+    }
+
+    private boolean checkIfExcludedFromPurge() {
+        if (this.analysisMetadataHolder.getBranch().isMain()) {
+            return true;
+        } else if (BranchType.PULL_REQUEST.equals(this.analysisMetadataHolder.getBranch().getType())) {
+            return false;
+        } else {
+            String[] branchesToKeep = this.configurationRepository.getConfiguration().getStringArray("sonar.dbcleaner.branchesToKeepWhenInactive");
+            return Arrays.stream(branchesToKeep).map(Pattern::compile).anyMatch((excludePattern) -> excludePattern.matcher(this.analysisMetadataHolder.getBranch().getName()).matches());
+        }
+    }
+
+    // REF - https://github.com/SonarSource/sonarqube/blob/7fe987ca5622f7732223496787ac13e6bb592d74/server/sonar-ce-task-projectanalysis/src/main/java/org/sonar/ce/task/projectanalysis/component/BranchPersisterImpl.java#L79
+    protected BranchDto toBranchDto(DbSession dbSession, ComponentDto componentDto, Branch branch, boolean excludeFromPurge) {
+        BranchDto dto = new BranchDto();
+        dto.setUuid(componentDto.uuid());
+
+        // MainBranchProjectUuid will be null if it's a main branch
+        String projectUuid = firstNonNull(componentDto.getMainBranchProjectUuid(), componentDto.branchUuid());
+        dto.setProjectUuid(projectUuid);
+        dto.setBranchType(branch.getType());
+        dto.setExcludeFromPurge(excludeFromPurge);
+
+        // merge branch is only present if it's not a main branch and not an application
+        if (!branch.isMain() && !"APP".equals(componentDto.qualifier())) {
+            dto.setMergeBranchUuid(branch.getReferenceBranchUuid());
+        }
+
+        if (branch.getType() == BranchType.PULL_REQUEST) {
+            String pullRequestKey = this.analysisMetadataHolder.getPullRequestKey();
+            dto.setKey(pullRequestKey);
+            DbProjectBranches.PullRequestData pullRequestData = this.getBuilder(dbSession, projectUuid, pullRequestKey)
+                    .setBranch(branch.getName())
+                    .setTitle(branch.getName())
+                    .setTarget(branch.getTargetBranchName())
+                    .build();
+            dto.setPullRequestData(pullRequestData);
+        } else {
+            dto.setKey(branch.getName());
+        }
+
+        return dto;
+    }
+
+    private DbProjectBranches.PullRequestData.Builder getBuilder(DbSession dbSession, String projectUuid, String pullRequestKey) {
+        return this.dbClient.branchDao().selectByPullRequestKey(dbSession, projectUuid, pullRequestKey).map(BranchDto::getPullRequestData).map(DbProjectBranches.PullRequestData::toBuilder).orElse(DbProjectBranches.PullRequestData.newBuilder());
+    }
+
+    private static <T> T firstNonNull(@Nullable T first, T second) {
+        return first != null ? first : second;
+    }
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProvider.java
@@ -47,13 +47,27 @@ public class CommunityReportAnalysisComponentProvider implements ReportAnalysisC
 
     @Override
     public List<Object> getComponents() {
-        return Arrays.asList(CommunityBranchLoaderDelegate.class, PullRequestPostAnalysisTask.class,
-                             PostAnalysisIssueVisitor.class, DefaultLinkHeaderReader.class, ReportGenerator.class,
-                             MarkdownFormatterFactory.class, DefaultGraphqlProvider.class, DefaultUrlConnectionProvider.class,
-                             DefaultGithubClientFactory.class, RestApplicationAuthenticationProvider.class, GithubPullRequestDecorator.class,
-                             HttpClientBuilderFactory.class, DefaultBitbucketClientFactory.class, BitbucketPullRequestDecorator.class,
-                             DefaultGitlabClientFactory.class, GitlabMergeRequestDecorator.class,
-                             DefaultAzureDevopsClientFactory.class, AzureDevOpsPullRequestDecorator.class);
+        return Arrays.asList(
+                CommunityBranchLoaderDelegate.class,
+                CommunityBranchPersister.class,
+                PullRequestPostAnalysisTask.class,
+                PostAnalysisIssueVisitor.class,
+                DefaultLinkHeaderReader.class,
+                ReportGenerator.class,
+                MarkdownFormatterFactory.class,
+                DefaultGraphqlProvider.class,
+                DefaultUrlConnectionProvider.class,
+                DefaultGithubClientFactory.class,
+                RestApplicationAuthenticationProvider.class,
+                GithubPullRequestDecorator.class,
+                HttpClientBuilderFactory.class,
+                DefaultBitbucketClientFactory.class,
+                BitbucketPullRequestDecorator.class,
+                DefaultGitlabClientFactory.class,
+                GitlabMergeRequestDecorator.class,
+                DefaultAzureDevopsClientFactory.class,
+                AzureDevOpsPullRequestDecorator.class
+        );
     }
 
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchFeatureExtension.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchFeatureExtension.java
@@ -28,6 +28,11 @@ import org.sonar.server.branch.BranchFeatureExtension;
 public class CommunityBranchFeatureExtension implements BranchFeatureExtension {
 
     @Override
+    public String getName() {
+        return "branch-support"; // must be this name
+    }
+
+    @Override
     public boolean isEnabled() {
         return true;
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegate.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegate.java
@@ -38,7 +38,6 @@ import java.util.Optional;
  * @author Michael Clarke
  */
 public class CommunityBranchSupportDelegate implements BranchSupportDelegate {
-
     private final UuidFactory uuidFactory;
     private final DbClient dbClient;
     private final Clock clock;
@@ -58,12 +57,10 @@ public class CommunityBranchSupportDelegate implements BranchSupportDelegate {
             String pullRequest = StringUtils.trimToNull(characteristics.get(CeTaskCharacteristicDto.PULL_REQUEST));
             if (null == pullRequest) {
                 throw new IllegalArgumentException(String.format("One of '%s' or '%s' parameters must be specified",
-                                                                 CeTaskCharacteristicDto.BRANCH_TYPE_KEY,
-                                                                 CeTaskCharacteristicDto.PULL_REQUEST));
+                        CeTaskCharacteristicDto.BRANCH_TYPE_KEY,
+                        CeTaskCharacteristicDto.PULL_REQUEST));
             } else {
-                return new CommunityComponentKey(projectKey,
-                                                 ComponentDto.generatePullRequestKey(projectKey, pullRequest), null,
-                                                 pullRequest);
+                return new CommunityComponentKey(projectKey, null, pullRequest);
             }
         }
 
@@ -71,7 +68,7 @@ public class CommunityBranchSupportDelegate implements BranchSupportDelegate {
 
         try {
             BranchType.valueOf(branchTypeParam);
-            return new CommunityComponentKey(projectKey, ComponentDto.generateBranchKey(projectKey, branch), branch, null);
+            return new CommunityComponentKey(projectKey, branch, null);
         } catch (IllegalArgumentException ex) {
             throw new IllegalArgumentException(String.format("Unsupported branch type '%s'", branchTypeParam), ex);
         }
@@ -95,14 +92,15 @@ public class CommunityBranchSupportDelegate implements BranchSupportDelegate {
         // borrowed from https://github.com/SonarSource/sonarqube/blob/e80c0f3d1e5cd459f88b7e0c41a2d9a7519e260f/server/sonar-ce-task-projectanalysis/src/main/java/org/sonar/ce/task/projectanalysis/component/BranchPersisterImpl.java
         ComponentDto branchDto = mainComponentDto.copy();
         branchDto.setUuid(branchUuid);
-        branchDto.setProjectUuid(branchUuid);
+        branchDto.setBranchUuid(branchUuid);
         branchDto.setRootUuid(branchUuid);
         branchDto.setUuidPath(ComponentDto.UUID_PATH_OF_ROOT);
         branchDto.setModuleUuidPath(ComponentDto.UUID_PATH_SEPARATOR + branchUuid + ComponentDto.UUID_PATH_SEPARATOR);
         branchDto.setMainBranchProjectUuid(mainComponentDto.uuid());
-        branchDto.setDbKey(componentKey.getDbKey());
+        branchDto.setKey(componentKey.getKey());
         branchDto.setCreatedAt(new Date(clock.millis()));
         dbClient.componentDao().insert(dbSession, branchDto);
+
         return branchDto;
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityComponentKey.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityComponentKey.java
@@ -28,13 +28,11 @@ import java.util.Optional;
 /*package*/ class CommunityComponentKey extends BranchSupport.ComponentKey {
 
     private final String key;
-    private final String dbKey;
     private final String branchName;
     private final String pullRequestKey;
 
-    /*package*/ CommunityComponentKey(String key, String dbKey, String branchName, String pullRequestKey) {
+    /*package*/ CommunityComponentKey(String key, String branchName, String pullRequestKey) {
         this.key = key;
-        this.dbKey = dbKey;
         this.branchName = branchName;
         this.pullRequestKey = pullRequestKey;
     }
@@ -45,24 +43,11 @@ import java.util.Optional;
     }
 
     @Override
-    public String getDbKey() {
-        return dbKey;
-    }
-
-    @Override
     public Optional<String> getBranchName() {
         return Optional.ofNullable(branchName);
     }
     @Override
     public Optional<String> getPullRequestKey() {
         return Optional.ofNullable(pullRequestKey);
-    }
-
-    @Override
-    public CommunityComponentKey getMainBranchComponentKey() {
-        if (key.equals(dbKey)) {
-            return this;
-        }
-        return new CommunityComponentKey(key, key, null, null);
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/DeleteAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/DeleteAction.java
@@ -1,0 +1,94 @@
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
+
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.api.server.ws.WebService.NewController;
+import org.sonar.api.web.UserRole;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.component.BranchDto;
+import org.sonar.db.project.ProjectDto;
+import org.sonar.server.component.ComponentCleanerService;
+import org.sonar.server.component.ComponentFinder;
+import org.sonar.server.exceptions.NotFoundException;
+import org.sonar.server.user.UserSession;
+
+import static org.sonar.db.component.BranchType.PULL_REQUEST;
+import static com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWs.addProjectParam;
+import static com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWs.addPullRequestParam;
+import static com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWsParameters.PARAM_PROJECT;
+import static com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWsParameters.PARAM_PULL_REQUEST;
+import static org.sonar.server.branch.ws.ProjectBranchesParameters.ACTION_DELETE;
+
+public class DeleteAction implements PullRequestWsAction {
+    private final DbClient dbClient;
+    private final UserSession userSession;
+    private final ComponentCleanerService componentCleanerService;
+    private final ComponentFinder componentFinder;
+
+    public DeleteAction(DbClient dbClient, ComponentFinder componentFinder, UserSession userSession, ComponentCleanerService componentCleanerService) {
+        this.dbClient = dbClient;
+        this.componentFinder = componentFinder;
+        this.userSession = userSession;
+        this.componentCleanerService = componentCleanerService;
+    }
+
+    @Override
+    public void define(NewController context) {
+        WebService.NewAction action = context.createAction(ACTION_DELETE)
+                .setSince("7.1")
+                .setDescription("Delete a pull request.<br/>" +
+                        "Requires 'Administer' rights on the specified project.")
+                .setPost(true)
+                .setHandler(this);
+
+        addProjectParam(action);
+        addPullRequestParam(action);
+    }
+
+    @Override
+    public void handle(Request request, Response response) throws Exception {
+        userSession.checkLoggedIn();
+        String projectKey = request.mandatoryParam(PARAM_PROJECT);
+        String pullRequestId = request.mandatoryParam(PARAM_PULL_REQUEST);
+
+        try (DbSession dbSession = dbClient.openSession(false)) {
+            ProjectDto project = componentFinder.getProjectOrApplicationByKey(dbSession, projectKey);
+            checkPermission(project);
+
+            BranchDto pullRequest = dbClient.branchDao().selectByPullRequestKey(dbSession, project.getUuid(), pullRequestId)
+                    .filter(branch -> branch.getBranchType() == PULL_REQUEST)
+                    .orElseThrow(() -> new NotFoundException(String.format("Pull request '%s' is not found for project '%s'", pullRequestId, projectKey)));
+
+            componentCleanerService.deleteBranch(dbSession, pullRequest);
+            response.noContent();
+        }
+    }
+
+    private void checkPermission(ProjectDto project) {
+        userSession.checkProjectPermission(UserRole.ADMIN, project);
+    }
+
+}
+

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/DeleteAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/DeleteAction.java
@@ -1,5 +1,25 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import org.sonar.api.server.ws.Request;
 import org.sonar.api.server.ws.Response;
 import org.sonar.api.server.ws.WebService;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/DeleteAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/DeleteAction.java
@@ -1,25 +1,5 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
-/*
- * SonarQube
- * Copyright (C) 2009-2022 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
-
 import org.sonar.api.server.ws.Request;
 import org.sonar.api.server.ws.Response;
 import org.sonar.api.server.ws.WebService;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/ListAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/ListAction.java
@@ -1,25 +1,5 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
-/*
- * SonarQube
- * Copyright (C) 2009-2022 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/ListAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/ListAction.java
@@ -1,5 +1,25 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/ListAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/ListAction.java
@@ -1,0 +1,178 @@
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
+
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.server.ws.Change;
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.api.web.UserRole;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.component.BranchDto;
+import org.sonar.db.component.SnapshotDto;
+import org.sonar.db.measure.LiveMeasureDto;
+import org.sonar.db.permission.GlobalPermission;
+import org.sonar.db.project.ProjectDto;
+import org.sonar.db.protobuf.DbProjectBranches;
+import org.sonar.server.component.ComponentFinder;
+import org.sonar.server.issue.index.IssueIndex;
+import org.sonar.server.issue.index.PrStatistics;
+import org.sonar.server.user.UserSession;
+import org.sonarqube.ws.ProjectPullRequests;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+import static org.sonar.api.measures.CoreMetrics.ALERT_STATUS_KEY;
+import static org.sonar.api.utils.DateUtils.formatDateTime;
+import static org.sonar.api.web.UserRole.USER;
+import static org.sonar.core.util.stream.MoreCollectors.toList;
+import static org.sonar.core.util.stream.MoreCollectors.uniqueIndex;
+import static org.sonar.db.component.BranchType.PULL_REQUEST;
+import static com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWs.addProjectParam;
+import static com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWsParameters.PARAM_PROJECT;
+import static org.sonar.server.user.AbstractUserSession.insufficientPrivilegesException;
+import static org.sonar.server.ws.WsUtils.writeProtobuf;
+
+public class ListAction implements PullRequestWsAction {
+
+    private final DbClient dbClient;
+    private final UserSession userSession;
+    private final ComponentFinder componentFinder;
+    private final IssueIndex issueIndex;
+
+    public ListAction(DbClient dbClient, UserSession userSession, ComponentFinder componentFinder, IssueIndex issueIndex) {
+        this.dbClient = dbClient;
+        this.userSession = userSession;
+        this.componentFinder = componentFinder;
+        this.issueIndex = issueIndex;
+    }
+
+    @Override
+    public void define(WebService.NewController context) {
+        WebService.NewAction action = context.createAction("list")
+                .setSince("7.1")
+                .setDescription("List the pull requests of a project.<br/>" +
+                        "One of the following permissions is required: " +
+                        "<ul>" +
+                        "<li>'Browse' rights on the specified project</li>" +
+                        "<li>'Execute Analysis' rights on the specified project</li>" +
+                        "</ul>")
+                .setResponseExample(getClass().getResource("list-example.json"))
+                .setHandler(this)
+                .setChangelog(
+                        new Change("8.4", "Response fields: 'bugs', 'vulnerabilities', 'codeSmells' are deprecated."));
+        addProjectParam(action);
+    }
+
+    @Override
+    public void handle(Request request, Response response) throws Exception {
+        String projectKey = request.mandatoryParam(PARAM_PROJECT);
+
+        try (DbSession dbSession = dbClient.openSession(false)) {
+            ProjectDto project = componentFinder.getProjectOrApplicationByKey(dbSession, projectKey);
+            checkPermission(project);
+
+            List<BranchDto> pullRequests = dbClient.branchDao().selectByProject(dbSession, project).stream()
+                    .filter(b -> b.getBranchType() == PULL_REQUEST)
+                    .collect(toList());
+            List<String> pullRequestUuids = pullRequests.stream().map(BranchDto::getUuid).collect(toList());
+
+            Map<String, BranchDto> mergeBranchesByUuid = dbClient.branchDao()
+                    .selectByUuids(dbSession, pullRequests.stream().map(BranchDto::getMergeBranchUuid).filter(Objects::nonNull).collect(toList()))
+                    .stream().collect(uniqueIndex(BranchDto::getUuid));
+
+            Map<String, PrStatistics> branchStatisticsByBranchUuid = issueIndex.searchBranchStatistics(project.getUuid(), pullRequestUuids).stream()
+                    .collect(uniqueIndex(PrStatistics::getBranchUuid, Function.identity()));
+            Map<String, LiveMeasureDto> qualityGateMeasuresByComponentUuids = dbClient.liveMeasureDao()
+                    .selectByComponentUuidsAndMetricKeys(dbSession, pullRequestUuids, singletonList(ALERT_STATUS_KEY)).stream()
+                    .collect(uniqueIndex(LiveMeasureDto::getComponentUuid));
+            Map<String, String> analysisDateByBranchUuid = dbClient.snapshotDao().selectLastAnalysesByRootComponentUuids(dbSession, pullRequestUuids).stream()
+                    .collect(uniqueIndex(SnapshotDto::getComponentUuid, s -> formatDateTime(s.getCreatedAt())));
+
+            ProjectPullRequests.ListWsResponse.Builder protobufResponse = ProjectPullRequests.ListWsResponse.newBuilder();
+            pullRequests
+                    .forEach(b -> addPullRequest(protobufResponse, b, mergeBranchesByUuid, qualityGateMeasuresByComponentUuids.get(b.getUuid()), branchStatisticsByBranchUuid.get(b.getUuid()),
+                            analysisDateByBranchUuid.get(b.getUuid())));
+            writeProtobuf(protobufResponse.build(), request, response);
+        }
+    }
+
+    private void checkPermission(ProjectDto project) {
+        if (userSession.hasProjectPermission(USER, project) ||
+                userSession.hasProjectPermission(UserRole.SCAN, project) ||
+                userSession.hasPermission(GlobalPermission.SCAN)) {
+            return;
+        }
+        throw insufficientPrivilegesException();
+    }
+
+    private static void addPullRequest(ProjectPullRequests.ListWsResponse.Builder response, BranchDto branch, Map<String, BranchDto> mergeBranchesByUuid,
+                                       @Nullable LiveMeasureDto qualityGateMeasure, PrStatistics prStatistics, @Nullable String analysisDate) {
+        Optional<BranchDto> mergeBranch = Optional.ofNullable(mergeBranchesByUuid.get(branch.getMergeBranchUuid()));
+
+        ProjectPullRequests.PullRequest.Builder builder = ProjectPullRequests.PullRequest.newBuilder();
+        builder.setKey(branch.getKey());
+
+        DbProjectBranches.PullRequestData pullRequestData = requireNonNull(branch.getPullRequestData(), "Pull request data should be available for branch type PULL_REQUEST");
+        builder.setBranch(pullRequestData.getBranch());
+        ofNullable(emptyToNull(pullRequestData.getUrl())).ifPresent(builder::setUrl);
+        ofNullable(emptyToNull(pullRequestData.getTitle())).ifPresent(builder::setTitle);
+
+        if (mergeBranch.isPresent()) {
+            String mergeBranchKey = mergeBranch.get().getKey();
+            builder.setBase(mergeBranchKey);
+        } else {
+            builder.setIsOrphan(true);
+        }
+
+        if (StringUtils.isNotEmpty(pullRequestData.getTarget())) {
+            builder.setTarget(pullRequestData.getTarget());
+        } else if (mergeBranch.isPresent()) {
+            builder.setTarget(mergeBranch.get().getKey());
+        }
+
+        ofNullable(analysisDate).ifPresent(builder::setAnalysisDate);
+        setQualityGate(builder, qualityGateMeasure, prStatistics);
+        response.addPullRequests(builder);
+    }
+
+    private static void setQualityGate(ProjectPullRequests.PullRequest.Builder builder, @Nullable LiveMeasureDto qualityGateMeasure, @Nullable PrStatistics prStatistics) {
+        ProjectPullRequests.Status.Builder statusBuilder = ProjectPullRequests.Status.newBuilder();
+        if (qualityGateMeasure != null) {
+            ofNullable(qualityGateMeasure.getDataAsString()).ifPresent(statusBuilder::setQualityGateStatus);
+        }
+        statusBuilder.setBugs(prStatistics == null ? 0L : prStatistics.getBugs());
+        statusBuilder.setVulnerabilities(prStatistics == null ? 0L : prStatistics.getVulnerabilities());
+        statusBuilder.setCodeSmells(prStatistics == null ? 0L : prStatistics.getCodeSmells());
+        builder.setStatus(statusBuilder);
+    }
+}
+

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsAction.java
@@ -1,5 +1,25 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import org.sonar.server.ws.WsAction;
 
 public interface PullRequestWsAction extends WsAction {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsAction.java
@@ -1,5 +1,9 @@
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
+
 /*
- * Copyright (C) 2019 Michael Clarke
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -14,27 +18,11 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
  */
-package com.github.mc1arke.sonarqube.plugin.server;
 
-import org.junit.Test;
+import org.sonar.server.ws.WsAction;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-
-/**
- * @author Michael Clarke
- */
-public class CommunityBranchFeatureExtensionTest {
-
-    @Test
-    public void testGetName() {
-        assertThat(new CommunityBranchFeatureExtension().getName()).isEqualTo("branch-support");
-    }
-
-    @Test
-    public void testEnabled() {
-        assertTrue(new CommunityBranchFeatureExtension().isEnabled());
-    }
+public interface PullRequestWsAction extends WsAction {
+    // marker interface
 }
+

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsAction.java
@@ -1,25 +1,5 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
-/*
- * SonarQube
- * Copyright (C) 2009-2022 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
-
 import org.sonar.server.ws.WsAction;
 
 public interface PullRequestWsAction extends WsAction {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsModule.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsModule.java
@@ -1,5 +1,25 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import org.sonar.core.platform.Module;
 
 public class PullRequestWsModule extends Module {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsModule.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsModule.java
@@ -1,5 +1,9 @@
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
+
 /*
- * Copyright (C) 2019 Michael Clarke
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -14,27 +18,14 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
  */
-package com.github.mc1arke.sonarqube.plugin.server;
 
-import org.junit.Test;
+import org.sonar.core.platform.Module;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-
-/**
- * @author Michael Clarke
- */
-public class CommunityBranchFeatureExtensionTest {
-
-    @Test
-    public void testGetName() {
-        assertThat(new CommunityBranchFeatureExtension().getName()).isEqualTo("branch-support");
-    }
-
-    @Test
-    public void testEnabled() {
-        assertTrue(new CommunityBranchFeatureExtension().isEnabled());
+public class PullRequestWsModule extends Module {
+    @Override
+    protected void configureModule() {
+        add(ListAction.class, DeleteAction.class, PullRequestsWs.class);
     }
 }
+

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsModule.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestWsModule.java
@@ -1,25 +1,5 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
-/*
- * SonarQube
- * Copyright (C) 2009-2022 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
-
 import org.sonar.core.platform.Module;
 
 public class PullRequestWsModule extends Module {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWs.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWs.java
@@ -1,0 +1,62 @@
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
+
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import org.sonar.api.server.ws.WebService;
+
+import static java.util.Arrays.stream;
+import static com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWsParameters.PARAM_PROJECT;
+import static com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWsParameters.PARAM_PULL_REQUEST;
+import static org.sonar.server.ws.KeyExamples.KEY_PROJECT_EXAMPLE_001;
+
+public class PullRequestsWs implements WebService {
+    private final PullRequestWsAction[] actions;
+
+    public PullRequestsWs(PullRequestWsAction... actions) {
+        this.actions = actions;
+    }
+
+    @Override
+    public void define(Context context) {
+        NewController controller = context.createController("api/project_pull_requests")
+                .setSince("7.1")
+                .setDescription("Manage pull request");
+        stream(actions).forEach(action -> action.define(controller));
+        controller.done();
+    }
+
+    static void addProjectParam(NewAction action) {
+        action
+                .createParam(PARAM_PROJECT)
+                .setDescription("Project key")
+                .setExampleValue(KEY_PROJECT_EXAMPLE_001)
+                .setRequired(true);
+    }
+
+    static void addPullRequestParam(NewAction action) {
+        action
+                .createParam(PARAM_PULL_REQUEST)
+                .setDescription("Pull request id")
+                .setExampleValue("1543")
+                .setRequired(true);
+    }
+
+}

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWs.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWs.java
@@ -1,5 +1,25 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import org.sonar.api.server.ws.WebService;
 
 import static java.util.Arrays.stream;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWs.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWs.java
@@ -1,25 +1,5 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
-/*
- * SonarQube
- * Copyright (C) 2009-2022 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
-
 import org.sonar.api.server.ws.WebService;
 
 import static java.util.Arrays.stream;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWsParameters.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWsParameters.java
@@ -1,5 +1,9 @@
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
+
 /*
- * Copyright (C) 2019 Michael Clarke
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -14,27 +18,16 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
  */
-package com.github.mc1arke.sonarqube.plugin.server;
 
-import org.junit.Test;
+public class PullRequestsWsParameters {
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
+    public static final String PARAM_PROJECT = "project";
+    public static final String PARAM_COMPONENT = "component";
+    public static final String PARAM_PULL_REQUEST = "pullRequest";
 
-/**
- * @author Michael Clarke
- */
-public class CommunityBranchFeatureExtensionTest {
-
-    @Test
-    public void testGetName() {
-        assertThat(new CommunityBranchFeatureExtension().getName()).isEqualTo("branch-support");
-    }
-
-    @Test
-    public void testEnabled() {
-        assertTrue(new CommunityBranchFeatureExtension().isEnabled());
+    private PullRequestsWsParameters() {
+        // static utility class
     }
 }
+

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWsParameters.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWsParameters.java
@@ -1,25 +1,5 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
-/*
- * SonarQube
- * Copyright (C) 2009-2022 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
-
 public class PullRequestsWsParameters {
 
     public static final String PARAM_PROJECT = "project";

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWsParameters.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/PullRequestsWsParameters.java
@@ -1,5 +1,25 @@
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
 
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class PullRequestsWsParameters {
 
     public static final String PARAM_PROJECT = "project";

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPluginTest.java
@@ -118,7 +118,7 @@ public class CommunityBranchPluginTest {
         final ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(context, times(2)).addExtensions(argumentCaptor.capture(), argumentCaptor.capture());
 
-        assertEquals(25, argumentCaptor.getAllValues().size());
+        assertEquals(29, argumentCaptor.getAllValues().size());
 
         assertEquals(Arrays.asList(CommunityBranchFeatureExtension.class, CommunityBranchSupportDelegate.class),
                      argumentCaptor.getAllValues().subList(0, 2));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchPersisterTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchPersisterTest.java
@@ -1,0 +1,59 @@
+package com.github.mc1arke.sonarqube.plugin.ce;
+
+import org.junit.Test;
+import org.sonar.ce.task.projectanalysis.analysis.AnalysisMetadataHolder;
+import org.sonar.ce.task.projectanalysis.analysis.Branch;
+import org.sonar.ce.task.projectanalysis.component.Component;
+import org.sonar.ce.task.projectanalysis.component.ConfigurationRepository;
+import org.sonar.ce.task.projectanalysis.component.TreeRootHolder;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.component.*;
+import org.sonar.db.protobuf.DbProjectBranches;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+public class CommunityBranchPersisterTest {
+    @Test
+    public void testPersist() {
+        DbClient dbClient = mock(DbClient.class);
+        TreeRootHolder treeRootHolder = mock(TreeRootHolder.class);
+        AnalysisMetadataHolder analysisMetadataHolder = mock(AnalysisMetadataHolder.class);
+        ConfigurationRepository configurationRepository = mock(ConfigurationRepository.class);
+        DbSession dbSession = mock(DbSession.class);
+        Branch branch = mock(Branch.class);
+        Component component = mock(Component.class);
+        ComponentDao componentDao = mock(ComponentDao.class);
+        BranchDao branchDao = mock(BranchDao.class);
+        BranchDto branchDto = mock(BranchDto.class);
+
+        when(analysisMetadataHolder.getBranch()).thenReturn(branch);
+        when(treeRootHolder.getRoot()).thenReturn(component);
+        when(component.getUuid()).thenReturn("fake");
+        when(component.getKey()).thenReturn("fake");
+        when(component.getName()).thenReturn("fake");
+        when(branch.getReferenceBranchUuid()).thenReturn("fake");
+        when(branch.getName()).thenReturn("fake");
+        when(branch.getTargetBranchName()).thenReturn("fake");
+
+        when(componentDao.selectByUuid(eq(dbSession), eq("fake"))).thenReturn(Optional.empty());
+        when(dbClient.componentDao()).thenReturn(componentDao);
+
+        when(branch.getType()).thenReturn(BranchType.PULL_REQUEST);
+        when(branch.isMain()).thenReturn(false);
+        when(analysisMetadataHolder.getPullRequestKey()).thenReturn("fake");
+
+        when(dbClient.branchDao()).thenReturn(branchDao);
+        when(branchDao.selectByPullRequestKey(eq(dbSession), eq("fake"), eq("fake"))).thenReturn(Optional.of(branchDto));
+        when(branchDto.getPullRequestData()).thenReturn(DbProjectBranches.PullRequestData.newBuilder().build());
+
+        CommunityBranchPersister communityBranchPersister = new CommunityBranchPersister(dbClient, treeRootHolder, analysisMetadataHolder, configurationRepository);
+
+        communityBranchPersister.persist(dbSession);
+
+        verify(dbClient.componentDao()).insert(eq(dbSession), any(ComponentDto.class));
+        verify(dbClient.branchDao()).upsert(eq(dbSession), any(BranchDto.class));
+    }
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchTest.java
@@ -39,43 +39,6 @@ public class CommunityBranchTest {
     }
 
     @Test
-    public void testGenerateKeyMainBranchNullFileOfPath() {
-        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, true, null, null, null);
-
-        assertEquals("projectKey", testCase.generateKey("projectKey", null));
-    }
-
-    @Test
-    public void testGenerateKeyMainBranchNonNullFileOfPathHolder() {
-        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, true, null, null, null);
-
-        assertEquals("projectKey", testCase.generateKey("projectKey", ""));
-    }
-
-    @Test
-    public void testGenerateKeyMainBranchNonNullFileOfPathContent() {
-        CommunityBranch testCase = new CommunityBranch("name", BranchType.PULL_REQUEST, true, null, null, null);
-
-        assertEquals("projectKey:path", testCase.generateKey("projectKey", "path"));
-    }
-
-    @Test
-    public void testGenerateKeyNonMainBranchNonNullFileOfPathContentPullRequest() {
-        CommunityBranch testCase =
-                new CommunityBranch("name", BranchType.PULL_REQUEST, false, null, "pullRequestKey", null);
-
-        assertEquals("projectKey:path:PULL_REQUEST:pullRequestKey", testCase.generateKey("projectKey", "path"));
-    }
-
-    @Test
-    public void testGenerateKeyNonMainBranchNonNullFileOfPathContentBranch() {
-        CommunityBranch testCase = new CommunityBranch("name", BranchType.BRANCH, false, null, null, null);
-
-        assertEquals("projectKey:path:BRANCH:name", testCase.generateKey("projectKey", "path"));
-    }
-
-
-    @Test
     public void testGetPulRequestKey() {
         assertEquals("prKey", new CommunityBranch("name", BranchType.PULL_REQUEST, false, null, "prKey", null)
                 .getPullRequestKey());

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityReportAnalysisComponentProviderTest.java
@@ -32,7 +32,7 @@ public class CommunityReportAnalysisComponentProviderTest {
     @Test
     public void testGetComponents() {
         List<Object> result = new CommunityReportAnalysisComponentProvider().getComponents();
-        assertEquals(18, result.size());
+        assertEquals(19, result.size());
         assertEquals(CommunityBranchLoaderDelegate.class, result.get(0));
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
@@ -71,13 +71,11 @@ public class CommunityBranchSupportDelegateTest {
                 new CommunityBranchSupportDelegate(new SequenceUuidFactory(), mock(DbClient.class), mock(Clock.class))
                         .createComponentKey("yyy", params);
 
-        assertEquals("yyy:BRANCH:release-1.1", componentKey.getDbKey());
         assertEquals("yyy", componentKey.getKey());
         assertFalse(componentKey.getPullRequestKey().isPresent());
         assertFalse(componentKey.isMainBranch());
         assertTrue(componentKey.getBranchName().isPresent());
         assertEquals("release-1.1", componentKey.getBranchName().get());
-        assertTrue(componentKey.getMainBranchComponentKey().isMainBranch());
     }
 
     @Test
@@ -88,15 +86,11 @@ public class CommunityBranchSupportDelegateTest {
         CommunityComponentKey componentKey =
                 new CommunityBranchSupportDelegate(new SequenceUuidFactory(), mock(DbClient.class), mock(Clock.class))
                         .createComponentKey("yyy", params);
-        assertEquals("yyy:PULL_REQUEST:pullrequestkey", componentKey.getDbKey());
         assertEquals("yyy", componentKey.getKey());
         assertTrue(componentKey.getPullRequestKey().isPresent());
         assertEquals("pullrequestkey", componentKey.getPullRequestKey().get());
         assertFalse(componentKey.isMainBranch());
         assertFalse(componentKey.getBranchName().isPresent());
-        assertTrue(componentKey.getMainBranchComponentKey().isMainBranch());
-        CommunityComponentKey mainBranchComponentKey = componentKey.getMainBranchComponentKey();
-        assertSame(mainBranchComponentKey, mainBranchComponentKey.getMainBranchComponentKey());
     }
 
 
@@ -144,7 +138,6 @@ public class CommunityBranchSupportDelegateTest {
 
         BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
-        when(componentKey.getDbKey()).thenReturn("dbKey");
         when(componentKey.getBranchName()).thenReturn(Optional.of("dummy"));
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
@@ -183,7 +176,6 @@ public class CommunityBranchSupportDelegateTest {
 
         BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
-        when(componentKey.getDbKey()).thenReturn("dbKey");
         when(componentKey.getBranchName()).thenReturn(Optional.of("dummy"));
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
@@ -207,12 +199,11 @@ public class CommunityBranchSupportDelegateTest {
 
         verify(componentDao).insert(dbSession, copyComponentDto);
         verify(copyComponentDto).setUuid("uuid0");
-        verify(copyComponentDto).setProjectUuid("uuid0");
+        verify(copyComponentDto).setBranchUuid("uuid0");
         verify(copyComponentDto).setRootUuid("uuid0");
         verify(copyComponentDto).setUuidPath(".");
         verify(copyComponentDto).setModuleUuidPath(".uuid0.");
         verify(copyComponentDto).setMainBranchProjectUuid("componentUuid");
-        verify(copyComponentDto).setDbKey(componentKey.getDbKey());
         verify(copyComponentDto).setCreatedAt(new Date(12345678901234L));
 
         assertSame(copyComponentDto, result);
@@ -241,7 +232,6 @@ public class CommunityBranchSupportDelegateTest {
 
         BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
-        when(componentKey.getDbKey()).thenReturn("dbKey");
         when(componentKey.getBranchName()).thenReturn(Optional.of("dummy"));
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
@@ -280,7 +270,6 @@ public class CommunityBranchSupportDelegateTest {
 
         BranchSupport.ComponentKey componentKey = mock(BranchSupport.ComponentKey.class);
         when(componentKey.getKey()).thenReturn("componentKey");
-        when(componentKey.getDbKey()).thenReturn("dbKey");
         when(componentKey.getBranchName()).thenReturn(Optional.empty());
         when(componentKey.getPullRequestKey()).thenReturn(Optional.empty());
 
@@ -296,12 +285,11 @@ public class CommunityBranchSupportDelegateTest {
 
         verify(componentDao).insert(dbSession, copyComponentDto);
         verify(copyComponentDto).setUuid("1");
-        verify(copyComponentDto).setProjectUuid("1");
+        verify(copyComponentDto).setBranchUuid("1");
         verify(copyComponentDto).setRootUuid("1");
         verify(copyComponentDto).setUuidPath(".");
         verify(copyComponentDto).setModuleUuidPath(".1.");
         verify(copyComponentDto).setMainBranchProjectUuid("componentUuid");
-        verify(copyComponentDto).setDbKey(componentKey.getDbKey());
         verify(copyComponentDto).setCreatedAt(new Date(1234567890123L));
 
         assertSame(copyComponentDto, result);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/DeleteActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/DeleteActionTest.java
@@ -1,0 +1,94 @@
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
+
+import org.junit.Test;
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.api.web.UserRole;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.component.BranchDao;
+import org.sonar.db.component.BranchDto;
+import org.sonar.db.project.ProjectDto;
+import org.sonar.server.component.ComponentCleanerService;
+import org.sonar.server.component.ComponentFinder;
+import org.sonar.server.user.UserSession;
+
+import java.util.Optional;
+
+import static com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr.PullRequestsWsParameters.PARAM_PULL_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static org.sonar.db.component.BranchType.PULL_REQUEST;
+import static org.sonar.server.branch.ws.ProjectBranchesParameters.ACTION_DELETE;
+import static org.sonar.server.branch.ws.ProjectBranchesParameters.PARAM_PROJECT;
+
+public class DeleteActionTest {
+
+    @Test
+    public void testDefine() {
+        DbClient dbClient = mock(DbClient.class);
+        ComponentFinder componentFinder = mock(ComponentFinder.class);
+        UserSession userSession = mock(UserSession.class);
+        ComponentCleanerService componentCleanerService = mock(ComponentCleanerService.class);
+
+        DeleteAction testCase = new DeleteAction(dbClient, componentFinder, userSession, componentCleanerService);
+
+        WebService.NewParam keyParam = mock(WebService.NewParam.class);
+        when(keyParam.setDescription(anyString())).thenReturn(keyParam);
+        when(keyParam.setExampleValue(any())).thenReturn(keyParam);
+        when(keyParam.setRequired(eq(true))).thenReturn(keyParam);
+
+        WebService.NewController newController = mock(WebService.NewController.class);
+        WebService.NewAction newAction = mock(WebService.NewAction.class);
+
+        when(newController.createAction(eq(ACTION_DELETE))).thenReturn(newAction);
+
+        when(newAction.setSince(anyString())).thenReturn(newAction);
+        when(newAction.setDescription(anyString())).thenReturn(newAction);
+        when(newAction.setPost(eq(true))).thenReturn(newAction);
+        when(newAction.setHandler(eq(testCase))).thenReturn(newAction);
+        when(newAction.createParam(anyString())).thenReturn(keyParam);
+
+        testCase.define(newController);
+
+        verify(newAction).setHandler(eq(testCase));
+        verify(keyParam, times(2)).setRequired(true);
+    }
+
+    @Test
+    public void testHandle() throws Exception {
+        DbClient dbClient = mock(DbClient.class);
+        ComponentFinder componentFinder = mock(ComponentFinder.class);
+        UserSession userSession = mock(UserSession.class);
+        ComponentCleanerService componentCleanerService = mock(ComponentCleanerService.class);
+
+        DeleteAction testCase = new DeleteAction(dbClient, componentFinder, userSession, componentCleanerService);
+
+        Request request = mock(Request.class);
+        Response response = mock(Response.class);
+        DbSession dbSession = mock(DbSession.class);
+        ProjectDto projectDto = mock(ProjectDto.class);
+        BranchDao branchDao = mock(BranchDao.class);
+        BranchDto branchDto = mock(BranchDto.class);
+
+        when(userSession.checkLoggedIn()).thenReturn(null);
+        when(request.mandatoryParam(eq(PARAM_PROJECT))).thenReturn("fake");
+        when(request.mandatoryParam(eq(PARAM_PULL_REQUEST))).thenReturn("fake");
+
+        when(dbClient.openSession(eq(false))).thenReturn(dbSession);
+
+        when(componentFinder.getProjectOrApplicationByKey(eq(dbSession), eq("fake"))).thenReturn(projectDto);
+        when(userSession.checkProjectPermission(eq(UserRole.ADMIN), eq(projectDto))).thenReturn(null);
+        when(projectDto.getUuid()).thenReturn("fake");
+        when(branchDto.getBranchType()).thenReturn(PULL_REQUEST);
+        when(branchDao.selectByPullRequestKey(eq(dbSession), eq("fake"), eq("fake"))).thenReturn(Optional.of(branchDto));
+        when(dbClient.branchDao()).thenReturn(branchDao);
+
+        // verify no exception is thrown
+        testCase.handle(request, response);
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/ListActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pr/ListActionTest.java
@@ -1,0 +1,141 @@
+package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.pr;
+
+import org.junit.Test;
+import org.sonar.api.server.ws.Change;
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.api.web.UserRole;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.component.BranchDao;
+import org.sonar.db.component.BranchDto;
+import org.sonar.db.component.SnapshotDao;
+import org.sonar.db.component.SnapshotDto;
+import org.sonar.db.measure.LiveMeasureDao;
+import org.sonar.db.measure.LiveMeasureDto;
+import org.sonar.db.permission.GlobalPermission;
+import org.sonar.db.project.ProjectDto;
+import org.sonar.db.protobuf.DbProjectBranches;
+import org.sonar.server.component.ComponentFinder;
+import org.sonar.server.issue.index.IssueIndex;
+import org.sonar.server.issue.index.PrStatistics;
+import org.sonar.server.user.UserSession;
+
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Date;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.sonar.api.measures.CoreMetrics.ALERT_STATUS_KEY;
+import static org.sonar.db.component.BranchType.PULL_REQUEST;
+import static org.sonar.server.branch.ws.ProjectBranchesParameters.PARAM_PROJECT;
+
+public class ListActionTest {
+
+    @Test
+    public void testDefine() {
+        DbClient dbClient = mock(DbClient.class);
+        UserSession userSession = mock(UserSession.class);
+        ComponentFinder componentFinder = mock(ComponentFinder.class);
+        IssueIndex issueIndex = mock(IssueIndex.class);
+
+        ListAction testCase = new ListAction(dbClient, userSession, componentFinder, issueIndex);
+
+        WebService.NewParam keyParam = mock(WebService.NewParam.class);
+        when(keyParam.setDescription(anyString())).thenReturn(keyParam);
+        when(keyParam.setExampleValue(any())).thenReturn(keyParam);
+        when(keyParam.setRequired(eq(true))).thenReturn(keyParam);
+
+        WebService.NewController newController = mock(WebService.NewController.class);
+        WebService.NewAction newAction = mock(WebService.NewAction.class);
+
+        when(newController.createAction(eq("list"))).thenReturn(newAction);
+
+        when(newAction.setSince(anyString())).thenReturn(newAction);
+        when(newAction.setDescription(anyString())).thenReturn(newAction);
+        when(newAction.setResponseExample(eq(getClass().getResource("list-example.json")))).thenReturn(newAction);
+        when(newAction.setHandler(eq(testCase))).thenReturn(newAction);
+        when(newAction.setChangelog(any(Change.class))).thenReturn(newAction);
+        when(newAction.createParam(anyString())).thenReturn(keyParam);
+
+        testCase.define(newController);
+
+        verify(newAction).setHandler(eq(testCase));
+        verify(keyParam).setRequired(true);
+    }
+
+    @Test
+    public void testHandle() throws Exception {
+        DbClient dbClient = mock(DbClient.class);
+        UserSession userSession = mock(UserSession.class);
+        ComponentFinder componentFinder = mock(ComponentFinder.class);
+        IssueIndex issueIndex = mock(IssueIndex.class);
+
+        ListAction testCase = new ListAction(dbClient, userSession, componentFinder, issueIndex);
+
+        Request request = mock(Request.class);
+        Response response = mock(Response.class);
+        DbSession dbSession = mock(DbSession.class);
+        ProjectDto projectDto = mock(ProjectDto.class);
+        BranchDao branchDao = mock(BranchDao.class);
+        BranchDto branchDto = mock(BranchDto.class);
+        PrStatistics prStatistics = mock(PrStatistics.class);
+        LiveMeasureDto liveMeasureDto = mock(LiveMeasureDto.class);
+        LiveMeasureDao liveMeasureDao = mock(LiveMeasureDao.class);
+        SnapshotDto snapshotDto = mock(SnapshotDto.class);
+        SnapshotDao snapshotDao = mock(SnapshotDao.class);
+        Response.Stream responseStream = mock(Response.Stream.class);
+        OutputStream outputStream = mock(OutputStream.class);
+
+        when(userSession.hasProjectPermission(eq("user"), eq(projectDto))).thenReturn(true);
+        when(userSession.hasProjectPermission(eq("scan"), eq(projectDto))).thenReturn(true);
+        when(userSession.hasPermission(eq(GlobalPermission.SCAN))).thenReturn(true);
+        when(request.mandatoryParam(eq(PARAM_PROJECT))).thenReturn("fake");
+
+        when(dbClient.openSession(eq(false))).thenReturn(dbSession);
+
+        when(componentFinder.getProjectOrApplicationByKey(eq(dbSession), eq("fake"))).thenReturn(projectDto);
+        when(userSession.checkProjectPermission(eq(UserRole.ADMIN), eq(projectDto))).thenReturn(null);
+        when(projectDto.getUuid()).thenReturn("fake");
+        when(branchDto.getBranchType()).thenReturn(PULL_REQUEST);
+        when(branchDto.getMergeBranchUuid()).thenReturn("fake");
+        when(branchDto.getUuid()).thenReturn("fake");
+        when(branchDto.getKey()).thenReturn("fake");
+        when(branchDto.getPullRequestData()).thenReturn(
+                DbProjectBranches.PullRequestData.newBuilder()
+                        .setBranch("fake")
+                        .setUrl("fake")
+                        .setTitle("fake")
+                        .build()
+        );
+        when(branchDao.selectByProject(eq(dbSession), eq(projectDto))).thenReturn(Arrays.asList(branchDto));
+        when(branchDao.selectByUuids(eq(dbSession), eq(Arrays.asList("fake")))).thenReturn(Arrays.asList(branchDto));
+        when(dbClient.branchDao()).thenReturn(branchDao);
+
+        when(prStatistics.getBranchUuid()).thenReturn("fake");
+        when(issueIndex.searchBranchStatistics(eq("fake"), eq(Arrays.asList("fake")))).thenReturn(Arrays.asList(prStatistics));
+
+        when(liveMeasureDto.getComponentUuid()).thenReturn("fake");
+        when(liveMeasureDao.selectByComponentUuidsAndMetricKeys(eq(dbSession), eq(Arrays.asList("fake")), eq(singletonList(ALERT_STATUS_KEY))))
+                .thenReturn(Arrays.asList(liveMeasureDto));
+        when(dbClient.liveMeasureDao()).thenReturn(liveMeasureDao);
+
+        when(snapshotDto.getComponentUuid()).thenReturn("fake");
+        when(snapshotDto.getCreatedAt()).thenReturn(new Date().getTime());
+        when(snapshotDao.selectLastAnalysesByRootComponentUuids(eq(dbSession), eq(Arrays.asList("fake"))))
+                .thenReturn(Arrays.asList(snapshotDto));
+        when(dbClient.snapshotDao()).thenReturn(snapshotDao);
+
+        when(responseStream.output()).thenReturn(outputStream);
+        when(response.stream()).thenReturn(responseStream);
+        when(request.getMediaType()).thenReturn("application/x-protobuf");
+
+        // verify no exception is thrown
+        testCase.handle(request, response);
+    }
+
+}


### PR DESCRIPTION
why did things break from 9.6 -> 9.7:
  The majority of pull request supporting code was ripped out from the opensource version of sonarqube
  Additionally the underlying branch DTO was modified

What this PR does:
  Added PullRequest WS API - this was mostly grabbed from 9.6 sonarqube code
  Added CommunityBranchPersister - the code both saves and updates branch information from builds
  Modified CommunityBranchAgent to correctly 'update' locked classes
  
This has been tested in a staging environment with sonarqube 9.7.1

Very open to suggestions, not a java expert at all