### PR TITLE
Clean-up retrieval of Github authentication tokens

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProviderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,16 +18,17 @@
  */
 package com.github.mc1arke.sonarqube.plugin.almclient.github.v3;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mc1arke.sonarqube.plugin.InvalidConfigurationException;
 import com.github.mc1arke.sonarqube.plugin.almclient.LinkHeaderReader;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.RepositoryAuthenticationToken;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model.AppInstallation;
-import java.util.List;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model.AppToken;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model.InstallationRepositories;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model.Owner;
+import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model.Repository;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayInputStream;
@@ -39,210 +40,127 @@ import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class RestApplicationAuthenticationProviderTest {
+class RestApplicationAuthenticationProviderTest {
 
     @Test
-    public void testTokenRetrievedHappyPath() throws IOException {
-        testTokenForUrl("apiUrl", "apiUrl/app/installations");
-    }
-
-    @Test
-    public void testTokenRetrievedHappyPathApiPath() throws IOException {
-        testTokenForUrl("apiUrl/api", "apiUrl/api/v3/app/installations");
-    }
-
-    @Test
-    public void testTokenRetrievedHappyPathApiPathTrailingSlash() throws IOException {
-        testTokenForUrl("apiUrl/api/", "apiUrl/api/v3/app/installations");
-    }
-
-    @Test
-    public void testTokenRetrievedHappyPathV3Path() throws IOException {
-        testTokenForUrl("apiUrl/api/v3", "apiUrl/api/v3/app/installations");
-    }
-
-    @Test
-    public void testTokenRetrievedHappyPathV3PathTrailingSlash() throws IOException {
-        testTokenForUrl("apiUrl/api/v3/", "apiUrl/api/v3/app/installations");
-    }
-
-    private void testTokenForUrl(String apiUrl, String fullUrl) throws IOException {
-        UrlConnectionProvider urlProvider = mock(UrlConnectionProvider.class);
+    void shouldReturnTokenForPaginatedInstallationsAndTokens() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        UrlConnectionProvider urlConnectionProvider = mock(UrlConnectionProvider.class);
         Clock clock = Clock.fixed(Instant.ofEpochMilli(123456789L), ZoneId.of("UTC"));
-
-        String expectedAuthenticationToken = "expected authentication token";
-        String projectPath = "project path";
-        String expectedRepositoryId = "expected repository Id";
-        String expectedHtmlUrl = "http://url.for/users/repo";
-
-        URLConnection installationsUrlConnection = mock(URLConnection.class);
-        doReturn(new ByteArrayInputStream(
-                "[{\"repositories_url\": \"repositories_url\", \"access_tokens_url\": \"tokens_url\"}]"
-                        .getBytes(StandardCharsets.UTF_8))).when(installationsUrlConnection).getInputStream();
-
-        HttpURLConnection accessTokensUrlConnection = mock(HttpURLConnection.class);
-        doReturn(new ByteArrayInputStream(
-                ("{\"token\": \"" + expectedAuthenticationToken + "\"}").getBytes(StandardCharsets.UTF_8)))
-                .when(accessTokensUrlConnection).getInputStream();
-        doReturn(accessTokensUrlConnection).when(urlProvider).createUrlConnection("tokens_url");
-
-
-        HttpURLConnection repositoriesUrlConnection = mock(HttpURLConnection.class);
-        doReturn(new ByteArrayInputStream(
-                ("{\"repositories\": [{\"node_id\": \"" + expectedRepositoryId + "\", \"full_name\": \"" + projectPath +
-                 "\", \"html_url\": \"" + expectedHtmlUrl + "\", \"name\": \"project\", \"owner\": {\"login\": \"owner_name\"}}]}").getBytes(StandardCharsets.UTF_8))).when(repositoriesUrlConnection).getInputStream();
-        doReturn(repositoriesUrlConnection).when(urlProvider).createUrlConnection("repositories_url");
-
-        doReturn(installationsUrlConnection).when(urlProvider).createUrlConnection(fullUrl);
-
-        String appId = "appID";
-
-        String apiPrivateKey;
-        try (InputStream inputStream = getClass().getResourceAsStream("/rsa-private-key.pem")) {
-            apiPrivateKey = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
-        }
-
-        RestApplicationAuthenticationProvider testCase = new RestApplicationAuthenticationProvider(clock, h -> Optional.empty(), urlProvider);
-        RepositoryAuthenticationToken result = testCase.getInstallationToken(apiUrl, appId, apiPrivateKey, projectPath);
-
-        assertEquals(expectedAuthenticationToken, result.getAuthenticationToken());
-        assertEquals(expectedRepositoryId, result.getRepositoryId());
-        assertEquals(expectedHtmlUrl, result.getRepositoryUrl());
-
-        ArgumentCaptor<String> requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
-        verify(installationsUrlConnection, times(2))
-                .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
-        assertEquals(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
-                                   "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"),
-                     requestPropertyArgumentCaptor.getAllValues());
-
-        requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
-        verify(accessTokensUrlConnection, times(2))
-                .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
-        verify(accessTokensUrlConnection).setRequestMethod("POST");
-        assertEquals(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
-                                   "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"),
-                     requestPropertyArgumentCaptor.getAllValues());
-
-        requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
-        verify(repositoriesUrlConnection, times(2))
-                .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
-        verify(repositoriesUrlConnection).setRequestMethod("GET");
-        assertEquals(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
-                                   "Bearer " + expectedAuthenticationToken),
-                     requestPropertyArgumentCaptor.getAllValues());
-    }
-
-    @Test
-    public void testAppInstallationsPagination() throws IOException {
-
-        UrlConnectionProvider urlProvider = mock(UrlConnectionProvider.class);
-        Clock clock = Clock.fixed(Instant.ofEpochMilli(123456789L), ZoneId.of("UTC"));
-
-        String apiUrl = "apiUrl";
-
-        int pages=4;
-
-        for(int i=1; i<=pages;i++) {
-            HttpURLConnection installationsUrlConnection = mock(HttpURLConnection.class);
-            doReturn(installationsUrlConnection).when(urlProvider).createUrlConnection(eq(apiUrl + "/app/installations?page=" + i));
-            when(installationsUrlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(
-                "[{\"repositories_url\": \"repositories_url\", \"access_tokens_url\": \"tokens_url\"}]"
-                    .getBytes(StandardCharsets.UTF_8)));
-            when(installationsUrlConnection.getHeaderField("Link")).thenReturn(i == pages ? null:  apiUrl + "/app/installations?page=" + (i+1) );
-        }
-
-        RestApplicationAuthenticationProvider testCase = new RestApplicationAuthenticationProvider(clock, Optional::ofNullable, urlProvider);
-        ObjectMapper objectMapper = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        List<AppInstallation> token = testCase.getAppInstallations(objectMapper, apiUrl + "/app/installations?page=1", "token");
-        assertThat(token).hasSize(pages);
-
-    }
-
-    @Test
-    public void testTokenRetrievedPaginatedHappyPath() throws IOException {
-        UrlConnectionProvider urlProvider = mock(UrlConnectionProvider.class);
-        Clock clock = Clock.fixed(Instant.ofEpochMilli(123456789L), ZoneId.of("UTC"));
-
-        String expectedAuthenticationToken = "expected authentication token";
-        String projectPath = "project path";
-        String expectedRepositoryId = "expected repository Id";
-
-        URLConnection installationsUrlConnection = mock(URLConnection.class);
-        doReturn(new ByteArrayInputStream(
-                "[{\"repositories_url\": \"repositories_url\", \"access_tokens_url\": \"tokens_url\"}]"
-                        .getBytes(StandardCharsets.UTF_8))).when(installationsUrlConnection).getInputStream();
-
-        HttpURLConnection accessTokensUrlConnection = mock(HttpURLConnection.class);
-        doReturn(new ByteArrayInputStream(
-                ("{\"token\": \"" + expectedAuthenticationToken + "\"}").getBytes(StandardCharsets.UTF_8)))
-                .when(accessTokensUrlConnection).getInputStream();
-        doReturn(accessTokensUrlConnection).when(urlProvider).createUrlConnection("tokens_url");
-
-
-        for (int i = 0; i < 2; i ++) {
-            HttpURLConnection repositoriesUrlConnection = mock(HttpURLConnection.class);
-            doReturn(new ByteArrayInputStream(
-                    ("{\"repositories\": [{\"node_id\": \"" + expectedRepositoryId + (i == 0 ? "a" : "") + "\", \"full_name\": \"" +
-                     projectPath + (i == 0 ? "a" : "") + "\", \"name\": \"name\", \"owner\": {\"login\": \"login\"}}]}").getBytes(StandardCharsets.UTF_8))).when(repositoriesUrlConnection).getInputStream();
-
-            doReturn(i == 0 ? "a" : null).when(repositoriesUrlConnection).getHeaderField("Link");
-            doReturn(repositoriesUrlConnection).when(urlProvider).createUrlConnection(i == 0 ? "repositories_url" : "https://dummy.url/path?param=dummy&page=" + (i + 1));
-        }
-
-
-        String apiUrl = "apiUrl";
-        doReturn(installationsUrlConnection).when(urlProvider).createUrlConnection(apiUrl + "/app/installations");
-
-        String appId = "appID";
-
-        String apiPrivateKey;
-        try (InputStream inputStream = getClass().getResourceAsStream("/rsa-private-key.pem")) {
-            apiPrivateKey = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
-        }
-
         LinkHeaderReader linkHeaderReader = mock(LinkHeaderReader.class);
-        doReturn(Optional.of("https://dummy.url/path?param=dummy&page=2")).when(linkHeaderReader).findNextLink("a");
-        doReturn(Optional.empty()).when(linkHeaderReader).findNextLink(isNull());
 
-        RestApplicationAuthenticationProvider testCase = new RestApplicationAuthenticationProvider(clock, linkHeaderReader, urlProvider);
-        RepositoryAuthenticationToken result = testCase.getInstallationToken(apiUrl, appId, apiPrivateKey, projectPath);
+        when(linkHeaderReader.findNextLink(any())).thenAnswer(i -> Optional.ofNullable(i.getArgument(0)));
 
-        assertEquals(expectedAuthenticationToken, result.getAuthenticationToken());
-        assertEquals(expectedRepositoryId, result.getRepositoryId());
+        String apiUrl = "https://api.url/api/v3";
+        String appId = "appID";
+        String apiPrivateKey;
+        try (InputStream inputStream = Optional.ofNullable(getClass().getResourceAsStream("/rsa-private-key.pem")).orElseThrow()) {
+            apiPrivateKey = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        }
+        String projectPath = "path/repo-49.3";
 
-        ArgumentCaptor<String> requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
-        verify(installationsUrlConnection, times(2))
-                .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
-        assertEquals(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
-                                   "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"),
-                     requestPropertyArgumentCaptor.getAllValues());
+        List<HttpURLConnection> appPageUrlConnections = new ArrayList<>();
+        List<HttpURLConnection> appTokenConnections = new ArrayList<>();
+        List<HttpURLConnection> appRepositoryConnections = new ArrayList<>();
+        for (int appPage = 0; appPage < 5; appPage++) {
+            List<AppInstallation> appPageContents = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                int itemNumber = (appPage * 10) + i;
+                appPageContents.add(new AppInstallation("http://repository.url/item-" + itemNumber, "http://acccess-token.url/item-" + itemNumber));
 
-        requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
-        verify(accessTokensUrlConnection, times(2))
-                .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
-        verify(accessTokensUrlConnection).setRequestMethod("POST");
-        assertEquals(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
-                                   "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"),
-                     requestPropertyArgumentCaptor.getAllValues());
+                HttpURLConnection appTokenConnection = mock(HttpURLConnection.class);
+                when(appTokenConnection.getInputStream()).thenReturn(new ByteArrayInputStream(objectMapper.writeValueAsBytes(new AppToken("token-" + itemNumber))));
+                when(urlConnectionProvider.createUrlConnection("http://acccess-token.url/item-" + itemNumber)).thenReturn(appTokenConnection);
+                appTokenConnections.add(appTokenConnection);
+
+                List<Repository> repositories = new ArrayList<>();
+                for (int x = 0; x < 5; x++) {
+                    repositories.add(new Repository("nodeId", "path/repo-" + itemNumber + "." + x, "url", "repo-" + itemNumber + "." + x, new Owner("login")));
+                }
+
+                HttpURLConnection repositoryConnection = mock(HttpURLConnection.class);
+                when(repositoryConnection.getInputStream()).thenAnswer(invocation -> new ByteArrayInputStream(objectMapper.writeValueAsBytes(new InstallationRepositories(repositories.toArray(new Repository[0])))));
+                when(urlConnectionProvider.createUrlConnection("http://repository.url/item-" + itemNumber)).thenReturn(repositoryConnection);
+                if (i == 1 && appPage == 1) {
+                    when(repositoryConnection.getHeaderField("Link")).thenReturn("http://repository.url/item-" + (itemNumber + 1));
+                }
+                appRepositoryConnections.add(repositoryConnection);
+            }
+            HttpURLConnection appPageUrlConnection = mock(HttpURLConnection.class);
+            when(appPageUrlConnection.getInputStream()).thenReturn(new ByteArrayInputStream(objectMapper.writeValueAsBytes(appPageContents)));
+            if (appPage < 4) {
+                when(appPageUrlConnection.getHeaderField("Link")).thenReturn(apiUrl + "/app/installations?page=" + (appPage + 1));
+            }
+            appPageUrlConnections.add(appPageUrlConnection);
+            if (appPage == 0) {
+                when(urlConnectionProvider.createUrlConnection(apiUrl + "/app/installations")).thenReturn(appPageUrlConnection);
+            } else {
+                when(urlConnectionProvider.createUrlConnection(apiUrl + "/app/installations?page=" + appPage)).thenReturn(appPageUrlConnection);
+            }
+        }
+
+        RepositoryAuthenticationToken expected = new RepositoryAuthenticationToken("nodeId", "token-49", "url", "repo-49.3", "login");
+
+        RestApplicationAuthenticationProvider restApplicationAuthenticationProvider = new RestApplicationAuthenticationProvider(clock, linkHeaderReader, urlConnectionProvider);
+
+        RepositoryAuthenticationToken repositoryAuthenticationToken = restApplicationAuthenticationProvider.getInstallationToken("https://api.url/api/", appId, apiPrivateKey, projectPath);
+        assertThat(repositoryAuthenticationToken).usingRecursiveComparison().isEqualTo(expected);
+
+
+        for (URLConnection installationsUrlConnection : appPageUrlConnections) {
+            ArgumentCaptor<String> requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
+            verify(installationsUrlConnection, times(2))
+                    .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
+            assertThat(requestPropertyArgumentCaptor.getAllValues()).isEqualTo(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
+                            "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"));
+        }
+
+        for (HttpURLConnection accessTokensUrlConnection : appTokenConnections) {
+            ArgumentCaptor<String> requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
+            verify(accessTokensUrlConnection, times(2))
+                    .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
+            verify(accessTokensUrlConnection).setRequestMethod("POST");
+            assertThat(requestPropertyArgumentCaptor.getAllValues()).isEqualTo(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json",
+                    "Authorization", "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"));
+
+        }
+
+        for (int i = 0; i < appRepositoryConnections.size(); i++) {
+            HttpURLConnection appRepositoryConnection = appRepositoryConnections.get(i);
+            ArgumentCaptor<String> requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
+            if (i == 12) {
+                verify(appRepositoryConnection, times(4))
+                        .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
+                assertThat(requestPropertyArgumentCaptor.getAllValues()).isEqualTo(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json",
+                        "Authorization", "Bearer token-11",
+                        "Accept", "application/vnd.github.machine-man-preview+json",
+                        "Authorization", "Bearer token-12"));
+            } else {
+                verify(appRepositoryConnection, times(2))
+                        .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
+                assertThat(requestPropertyArgumentCaptor.getAllValues()).isEqualTo(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json",
+                        "Authorization", "Bearer token-" + i));
+            }
+
+        }
     }
 
     @Test
-    public void testExceptionOnNoMatchingToken() throws IOException {
+    void shouldThrowExceptionIfNotTokensMatch() throws IOException {
         UrlConnectionProvider urlProvider = mock(UrlConnectionProvider.class);
         Clock clock = Clock.fixed(Instant.ofEpochMilli(123456789L), ZoneId.of("UTC"));
 
@@ -275,7 +193,7 @@ public class RestApplicationAuthenticationProviderTest {
         String appId = "appID";
 
         String apiPrivateKey;
-        try (InputStream inputStream = getClass().getResourceAsStream("/rsa-private-key.pem")) {
+        try (InputStream inputStream = Optional.ofNullable(getClass().getResourceAsStream("/rsa-private-key.pem")).orElseThrow()) {
             apiPrivateKey = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
         }
 
@@ -287,25 +205,22 @@ public class RestApplicationAuthenticationProviderTest {
         ArgumentCaptor<String> requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(installationsUrlConnection, times(2))
                 .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
-        assertEquals(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
-                                   "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"),
-                     requestPropertyArgumentCaptor.getAllValues());
+        assertThat(requestPropertyArgumentCaptor.getAllValues()).isEqualTo(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
+                                   "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"));
 
         requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(accessTokensUrlConnection, times(2))
                 .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
         verify(accessTokensUrlConnection).setRequestMethod("POST");
-        assertEquals(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
-                                   "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"),
-                     requestPropertyArgumentCaptor.getAllValues());
+        assertThat(requestPropertyArgumentCaptor.getAllValues()).isEqualTo(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
+                                   "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjEyMzQ0NiwiZXhwIjoxMjM1NjYsImlzcyI6ImFwcElEIn0.yMvAoUmmAHli-Mc-RidLbqlX2Cvc2RwPBwkgY6n1R2ZkV-IaY8uBO4s7pp0-3hcJvY4F7-UGnAi1dteGOODY8cOmx86DsSASJIHJ3wxaRxyLGOq2Z8A1KSWZj-F8O6wFf5pm2xzumm0gSSwdd3gQR0FiSn2TIHemjyoieNJfzvG2kgtHPBNIVaJcS8LqkVYBlvAujnAt1nQ1hIAbeQJyEmyVyb_NRMPQZZioBraobTlWdPWdnTQoNTWjmjcopIbUFw8s21uhMcDpA_6lS1iAZcoZKcpzMqsItEvQaiwYQWRccfZT69M_zWaVRjw2-eKsTuFXzumVyq3MnAoxy6R2Xw"));
 
         requestPropertyArgumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(repositoriesUrlConnection, times(2))
                 .setRequestProperty(requestPropertyArgumentCaptor.capture(), requestPropertyArgumentCaptor.capture());
         verify(repositoriesUrlConnection).setRequestMethod("GET");
-        assertEquals(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
-                                   "Bearer " + expectedAuthenticationToken),
-                     requestPropertyArgumentCaptor.getAllValues());
+        assertThat(requestPropertyArgumentCaptor.getAllValues()).isEqualTo(Arrays.asList("Accept", "application/vnd.github.machine-man-preview+json", "Authorization",
+                                   "Bearer " + expectedAuthenticationToken));
 
     }
 }


### PR DESCRIPTION
The current implementation of the RestApplicationAuthenticationProvider contains an instance-level Object Mapper but doesn't use it instead constructing a new Object Mapper on each invocation and eagerly loads all pages of App Installations even though the first page may contain a token with access to the required repository. The implementation has therefore been altered to use the constructed object mapper for all operations and to work through the full contents of a page of AppInstallations before moving on to the next page of installations.