### PR TITLE
#753: Add support for Sonarqube 10.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         java:
-          - 11
+          - 17
     steps:
       -
         name: Checkout
@@ -67,7 +67,7 @@ jobs:
           ./gradlew clean build
       -
         name: Archive artifact
-        if: success() && matrix.java == '11'
+        if: success() && matrix.java == '17'
         uses: actions/upload-artifact@v3
         with:
           name: snapshot
@@ -87,7 +87,7 @@ jobs:
         name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           java-package: jdk
           distribution: 'zulu'
       -
@@ -148,7 +148,7 @@ jobs:
         name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           java-package: jdk
           distribution: 'zulu'
       -

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: 17
+        java-package: jdk
+        distribution: 'zulu'
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '9.8.0.63668'
+def sonarqubeVersion = '10.0.0.68432'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 
@@ -100,7 +100,7 @@ jar {
           'Plugin-License': 'GNU LGPL 3',
           'Plugin-Version': "${project.version}",
           'Plugin-Organization': 'Michael Clarke',
-          'Sonar-Version': "${sonarqubeVersion}",
+          'Sonar-Version': "9.14.0.375",
           'Plugin-IssueTrackerUrl': 'https://github.com/mc1arke/sonarqube-community-branch-plugin/issues',
           'Plugin-Key': 'communityBranchPlugin',
           'Plugin-Class': 'com.github.mc1arke.sonarqube.plugin.CommunityBranchPluginBootstrap',

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgent.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Michael Clarke
+ * Copyright (C) 2021-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -52,9 +52,9 @@ public final class CommunityBranchAgent {
 
         if (component == Component.CE) {
             redefineEdition(instrumentation, "org.sonar.core.platform.PlatformEditionProvider", redefineOptionalEditionGetMethod());
-            redefineEdition(instrumentation, "org.sonar.server.almsettings.MultipleAlmFeature", redefineIsEnabledFlag());
+            redefineEdition(instrumentation, "org.sonar.server.almsettings.MultipleAlmFeature", redefineIsAvailableFlag());
         } else if (component == Component.WEB) {
-            redefineEdition(instrumentation, "org.sonar.server.almsettings.MultipleAlmFeature", redefineIsEnabledFlag());
+            redefineEdition(instrumentation, "org.sonar.server.almsettings.MultipleAlmFeature", redefineIsAvailableFlag());
             redefineEdition(instrumentation, "org.sonar.server.newcodeperiod.ws.SetAction", redefineConstructorEditionProviderField(EditionProvider.Edition.DEVELOPER));
             redefineEdition(instrumentation, "org.sonar.server.newcodeperiod.ws.UnsetAction", redefineConstructorEditionProviderField(EditionProvider.Edition.DEVELOPER));
         }
@@ -102,9 +102,9 @@ public final class CommunityBranchAgent {
         };
     }
 
-    private static Redefiner redefineIsEnabledFlag() {
+    private static Redefiner redefineIsAvailableFlag() {
         return ctClass -> {
-            CtMethod ctMethod = ctClass.getDeclaredMethod("isEnabled");
+            CtMethod ctMethod = ctClass.getDeclaredMethod("isAvailable");
             ctMethod.setBody("return true;");
         };
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoader.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,8 +18,16 @@
  */
 package com.github.mc1arke.sonarqube.plugin.scanner;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang.StringUtils;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.utils.MessageException;
 import org.sonar.api.utils.System2;
 import org.sonar.api.utils.log.Logger;
@@ -29,15 +37,6 @@ import org.sonar.scanner.scan.branch.BranchConfiguration;
 import org.sonar.scanner.scan.branch.BranchConfigurationLoader;
 import org.sonar.scanner.scan.branch.DefaultBranchConfiguration;
 import org.sonar.scanner.scan.branch.ProjectBranches;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author Michael Clarke
@@ -54,16 +53,13 @@ public class CommunityBranchConfigurationLoader implements BranchConfigurationLo
                           ScannerProperties.PULL_REQUEST_BASE));
 
     private final System2 system2;
-    private final AnalysisWarnings analysisWarnings;
     private final BranchConfigurationFactory branchConfigurationFactory;
     private final List<BranchAutoConfigurer> autoConfigurers;
 
-    public CommunityBranchConfigurationLoader(System2 system2, AnalysisWarnings analysisWarnings,
-                                              BranchConfigurationFactory branchConfigurationFactory,
+    public CommunityBranchConfigurationLoader(System2 system2, BranchConfigurationFactory branchConfigurationFactory,
                                               List<BranchAutoConfigurer> autoConfigurers) {
         super();
         this.system2 = system2;
-        this.analysisWarnings = analysisWarnings;
         this.branchConfigurationFactory = branchConfigurationFactory;
         this.autoConfigurers = autoConfigurers;
     }
@@ -92,12 +88,6 @@ public class CommunityBranchConfigurationLoader implements BranchConfigurationLo
                     return branchConfiguration;
                 }
             }
-        }
-
-        if (null != localSettings.get(ScannerProperties.BRANCH_TARGET)) { //NOSONAR - purposefully checking for a deprecated parameter
-            String warning = String.format("Property '%s' is no longer supported", ScannerProperties.BRANCH_TARGET); //NOSONAR - reporting use of deprecated parameter
-            analysisWarnings.addUnique(warning);
-            LOGGER.warn(warning);
         }
 
         if (hasBranchParameters) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchFeatureExtension.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchFeatureExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Michael Clarke
+ * Copyright (C) 2019-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,7 +33,7 @@ public class CommunityBranchFeatureExtension implements BranchFeatureExtension {
     }
 
     @Override
-    public boolean isEnabled() {
+    public boolean isAvailable() {
         return true;
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegate.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -94,10 +94,8 @@ public class CommunityBranchSupportDelegate implements BranchSupportDelegate {
 
         ComponentDto componentDto = mainComponentDto.copy()
             .setUuid(branchUuid)
-            .setRootUuid(branchUuid)
             .setBranchUuid(branchUuid)
             .setUuidPath(ComponentDto.UUID_PATH_OF_ROOT)
-            .setModuleUuidPath(ComponentDto.UUID_PATH_SEPARATOR + branchUuid + ComponentDto.UUID_PATH_SEPARATOR)
             .setMainBranchProjectUuid(mainComponentDto.uuid())
             .setCreatedAt(new Date(clock.millis()));
         dbClient.componentDao().insert(dbSession, componentDto);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/MonoRepoFeature.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/MonoRepoFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Michael Clarke
+ * Copyright (C) 2022-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -32,7 +32,7 @@ public class MonoRepoFeature implements SonarQubeFeature {
     }
 
     @Override
-    public boolean isEnabled() {
+    public boolean isAvailable() {
         return true;
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgentTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Michael Clarke
+ * Copyright (C) 2021-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -76,7 +76,7 @@ class CommunityBranchAgentTest {
             SonarRuntime sonarRuntime = mock(SonarRuntime.class);
 
             SonarQubeFeature multipleAlmFeatureProvider = redefined.getConstructor(SonarRuntime.class).newInstance(sonarRuntime);
-            assertThat(multipleAlmFeatureProvider.isEnabled()).isTrue();
+            assertThat(multipleAlmFeatureProvider.isAvailable()).isTrue();
         }
     }
 
@@ -207,7 +207,7 @@ class CommunityBranchAgentTest {
 
             Class<MultipleAlmFeature> redefined = (Class<MultipleAlmFeature>) classLoader.loadClass(MultipleAlmFeature.class.getName(), result);
             SonarQubeFeature multipleAlmFeatureProvider = redefined.getConstructor(SonarRuntime.class).newInstance(sonarRuntime);
-            assertThat(multipleAlmFeatureProvider.isEnabled()).isTrue();
+            assertThat(multipleAlmFeatureProvider.isAvailable()).isTrue();
         }
     }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoaderTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.utils.System2;
 import org.sonar.scanner.scan.branch.BranchConfiguration;
 import org.sonar.scanner.scan.branch.BranchConfigurationLoader;
@@ -43,11 +42,10 @@ import org.sonar.scanner.scan.branch.ProjectBranches;
  */
 class CommunityBranchConfigurationLoaderTest {
 
-    private final AnalysisWarnings analysisWarnings = mock(AnalysisWarnings.class);
     private final System2 system2 = mock(System2.class);
     private final BranchConfigurationFactory branchConfigurationFactory = mock(BranchConfigurationFactory.class);
     private final BranchAutoConfigurer branchAutoConfigurer = mock(BranchAutoConfigurer.class);
-    private final BranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(system2, analysisWarnings, branchConfigurationFactory, List.of(branchAutoConfigurer));
+    private final BranchConfigurationLoader testCase = new CommunityBranchConfigurationLoader(system2, branchConfigurationFactory, List.of(branchAutoConfigurer));
 
     @Test
     void shouldReturnResultFromAutoConfigurerIfPresentAndNoParametersSpecified() {
@@ -87,7 +85,6 @@ class CommunityBranchConfigurationLoaderTest {
         assertThat(actual).isSameAs(branchConfiguration);
         verify(branchConfigurationFactory).createBranchConfiguration("branch", projectBranches);
         verifyNoInteractions(branchAutoConfigurer);
-        verify(analysisWarnings).addUnique("Property 'sonar.branch.target' is no longer supported");
     }
 
     @Test
@@ -101,7 +98,6 @@ class CommunityBranchConfigurationLoaderTest {
         assertThat(actual).isSameAs(branchConfiguration);
         verify(branchConfigurationFactory).createPullRequestConfiguration("key", "source", "target", projectBranches);
         verifyNoInteractions(branchAutoConfigurer);
-        verifyNoInteractions(analysisWarnings);
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchFeatureExtensionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchFeatureExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Michael Clarke
+ * Copyright (C) 2019-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -36,6 +36,6 @@ class CommunityBranchFeatureExtensionTest {
 
     @Test
     void shouldReturnEnabledForFeature() {
-        assertThat(underTest.isEnabled()).isTrue();
+        assertThat(underTest.isAvailable()).isTrue();
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -154,9 +154,7 @@ class CommunityBranchSupportDelegateTest {
         when(componentDto.copy()).thenReturn(copyComponentDto);
         when(copyComponentDto.setBranchUuid(any())).thenReturn(copyComponentDto);
         when(copyComponentDto.setKey(any())).thenReturn(copyComponentDto);
-        when(copyComponentDto.setRootUuid(any())).thenReturn(copyComponentDto);
         when(copyComponentDto.setUuidPath(any())).thenReturn(copyComponentDto);
-        when(copyComponentDto.setModuleUuidPath(any())).thenReturn(copyComponentDto);
         when(copyComponentDto.setUuid(any())).thenReturn(copyComponentDto);
         when(copyComponentDto.setMainBranchProjectUuid(any())).thenReturn(copyComponentDto);
         when(copyComponentDto.setCreatedAt(any())).thenReturn(copyComponentDto);
@@ -187,9 +185,7 @@ class CommunityBranchSupportDelegateTest {
 
         verify(componentDao).insert(dbSession, copyComponentDto);
         verify(copyComponentDto).setUuid("uuid0");
-        verify(copyComponentDto).setRootUuid("uuid0");
         verify(copyComponentDto).setUuidPath(".");
-        verify(copyComponentDto).setModuleUuidPath(".uuid0.");
         verify(copyComponentDto).setMainBranchProjectUuid("componentUuid");
         verify(copyComponentDto).setCreatedAt(new Date(12345678901234L));
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/MonoRepoFeatureTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/MonoRepoFeatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Michael Clarke
+ * Copyright (C) 2022-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,7 +33,7 @@ class MonoRepoFeatureTest {
 
     @Test
     void shouldSetFeatureAsEnabled() {
-        assertThat(underTest.isEnabled()).isTrue();
+        assertThat(underTest.isAvailable()).isTrue();
     }
 
 }


### PR DESCRIPTION
Sonarqube 10 has removed legacy support for modules as well as removing deprecated properties historically used for specifying branch targets. Additionally, the interface for managing Sonarqube features has had a method renamed, which makes the new version of Sonarqube binary incompatible with the plugin. The references to Sonarqube's removed code have been removed from the plugin, and the implementations of the interface and Java agent that dynamically updates Sonarqube code that also implements the interface have been updated to use the new method name.