### PR TITLE
#790: Add an ability to edit Summary Note instead of creating a new one

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchPlugin.java
@@ -73,6 +73,7 @@ import org.sonar.core.extension.CoreExtension;
 public class CommunityBranchPlugin implements Plugin, CoreExtension {
 
     public static final String IMAGE_URL_BASE = "com.github.mc1arke.sonarqube.plugin.branch.image-url-base";
+    public static final String PR_SUMMARY_NOTE_EDIT = "com.github.mc1arke.sonarqube.plugin.branch.pullrequest.summary.edit";
 
     @Override
     public String getName() {
@@ -157,6 +158,15 @@ public class CommunityBranchPlugin implements Plugin, CoreExtension {
                                           .build(),
                 MonoRepoFeature.class);
 
+            context.addExtensions(PropertyDefinition.builder(PR_SUMMARY_NOTE_EDIT)
+                    .category(getName())
+                    .subCategory("Merge Request Decoration")
+                    .onQualifiers(Qualifiers.PROJECT)
+                    .name("Edit summary note")
+                    .description("Edit summary discussion thread instead of resolving it and creating a new one (Gitlab only).")
+                    .type(PropertyType.BOOLEAN)
+                    .defaultValue(String.valueOf(false))
+                    .build());
         }
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabClient.java
@@ -43,6 +43,8 @@ public interface GitlabClient {
 
     void addMergeRequestDiscussionNote(long projectId, long mergeRequestIid, String discussionId, String noteContent) throws IOException;
 
+    void editMergeRequestDisscussionNote(long projectId, long mergeRequestIid, String discussionId, long noteId, String noteContent) throws IOException;
+
     void resolveMergeRequestDiscussion(long projectId, long mergeRequestIid, String discussionId) throws IOException;
 
     void setMergeRequestPipelineStatus(long projectId, String commitRevision, PipelineStatus status) throws IOException;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/gitlab/GitlabRestClient.java
@@ -127,6 +127,15 @@ class GitlabRestClient implements GitlabClient {
     }
 
     @Override
+    public void editMergeRequestDisscussionNote(long projectId, long mergeRequestIid, String discussionId, long noteId, String noteContent) throws IOException {
+        String targetUrl = String.format("%s/projects/%s/merge_requests/%s/discussions/%s/notes/%s", baseGitlabApiUrl, projectId, mergeRequestIid, discussionId, noteId);
+
+        HttpPut httpPut = new HttpPut(targetUrl);
+        httpPut.setEntity(new UrlEncodedFormEntity(Collections.singletonList(new BasicNameValuePair("body", noteContent)), StandardCharsets.UTF_8));
+        entity(httpPut, null);
+    }
+
+    @Override
     public void resolveMergeRequestDiscussion(long projectId, long mergeRequestIid, String discussionId) throws IOException {
         String discussionIdUrl = String.format("%s/projects/%s/merge_requests/%s/discussions/%s?resolved=true", baseGitlabApiUrl, projectId, mergeRequestIid, discussionId);
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestBuildStatusDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestBuildStatusDecorator.java
@@ -30,4 +30,8 @@ public interface PullRequestBuildStatusDecorator {
                                    ProjectAlmSettingDto projectAlmSettingDto);
 
     List<ALM> alm();
+
+    default boolean isEditSummaryNoteEnabled(AnalysisDetails analysisDetails) {
+        return false;
+    }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
@@ -185,6 +185,11 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
         }
     }
 
+    @Override
+    protected void editSummaryNote(AzureDevopsClient client, PullRequest pullRequest, CommentThread discussion, AnalysisDetails analysis, AnalysisSummary analysisSummary) {
+        // not implemented
+    }
+
     protected List<CommentThread> getDiscussions(AzureDevopsClient client, PullRequest pullRequest) {
         try {
             return client.retrieveThreads(pullRequest.getRepository().getProject().getName(), pullRequest.getRepository().getName(), pullRequest.getId());

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensor.java
@@ -18,6 +18,7 @@
  */
 package com.github.mc1arke.sonarqube.plugin.scanner;
 
+import com.github.mc1arke.sonarqube.plugin.CommunityBranchPlugin;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabMergeRequestDecorator;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -54,6 +55,8 @@ public class ScannerPullRequestPropertySensor implements Sensor {
         Optional.ofNullable(system2.property(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID)).ifPresent(
                 v -> sensorContext.addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, v));
 
+        sensorContext.config().get(CommunityBranchPlugin.PR_SUMMARY_NOTE_EDIT)
+                .ifPresent(p -> sensorContext.addContextProperty(CommunityBranchPlugin.PR_SUMMARY_NOTE_EDIT, p));
     }
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/DiscussionMock.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/DiscussionMock.java
@@ -1,0 +1,86 @@
+package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab;
+
+import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.Discussion;
+import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.Note;
+import com.github.mc1arke.sonarqube.plugin.almclient.gitlab.model.User;
+
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+class DiscussionMock {
+    private static final String PROJECT_KEY = "projectKey";
+    private static final String SONARQUBE_USERNAME = "sonarqube@gitlab.dummy";
+    private static final String OLD_SONARQUBE_ISSUE_COMMENT = "This issue no longer exists in SonarQube, " +
+            "but due to other comments being present in this discussion, " +
+            "the discussion is not being being closed automatically. " +
+            "Please manually resolve this discussion once the other comments have been reviewed.";
+    private static final User sonarqubeUser = new User(SONARQUBE_USERNAME);
+
+    private static Discussion createIssueComment() {
+        Note note = createUnresolvedSonarQubeNote(
+                "Reported issue\n[View in SonarQube](http://domain.url/sonar/issue?issues=issueKey1&id=" +
+                        PROJECT_KEY + ")");
+        return new Discussion("issue-comment-id", Collections.singletonList(note));
+    }
+
+    private static Discussion createResolvedIssueComment() {
+        Note note = createResolvedSonarQubeNote(
+                "Reported issue\n[View in SonarQube](http://domain.url/sonar/issue?issues=issueKey1&id=" +
+                        PROJECT_KEY + ")");
+        return new Discussion("resolved-issue-comment-id", Collections.singletonList(note));
+    }
+
+    private static Discussion createResolvedByCommentIssueComment() {
+        Note note = createUnresolvedSonarQubeNote(
+                "Reported issue\n[View in SonarQube](http://domain.url/sonar/issue?issues=issueKey1&id=" +
+                        PROJECT_KEY + ")");
+        Note note2 = createUnresolvedSonarQubeNote(OLD_SONARQUBE_ISSUE_COMMENT);
+        Note note3 = createUnresolvedSonarQubeNote("Some additional comment");
+        return new Discussion("issue-with-resolved-comment-id", Arrays.asList(note, note2, note3));
+    }
+
+    private static Discussion createUnresolvedSummaryNote() {
+        Note note = createUnresolvedSonarQubeNote(
+                "Analysis Details\n[View in SonarQube](http://domain.url/sonar/dashboard?id=" + PROJECT_KEY + ")");
+        return new Discussion("summary-note-id", Collections.singletonList(note));
+    }
+
+    private static Discussion createResolvedSummaryNote() {
+        Note note = createResolvedSonarQubeNote(
+                "Analysis Details\n[View in SonarQube](http://domain.url/sonar/dashboard?id=" + PROJECT_KEY + ")");
+        return new Discussion("summary-note-id", Collections.singletonList(note));
+    }
+
+    private static Note createUnresolvedSonarQubeNote(String body) {
+        return new Note(new Random().nextLong(), false, sonarqubeUser, body, false, true);
+    }
+
+    private static Note createResolvedSonarQubeNote(String body) {
+        return new Note(new Random().nextLong(), false, sonarqubeUser, body, true, true);
+    }
+
+    public static Map<DiscussionType, Discussion> getDiscussionsMap(DiscussionType... discussions) {
+        return Arrays.stream(discussions)
+                .collect(Collectors.toMap(k -> k, DiscussionType::create, (e1, e2) -> e1, LinkedHashMap::new));
+    }
+
+    enum DiscussionType {
+        RESOLVED_SUMMARY_NOTE(DiscussionMock::createResolvedSummaryNote),
+        UNRESOLVED_SUMMARY_NOTE(DiscussionMock::createUnresolvedSummaryNote),
+        ISSUE_COMMENT(DiscussionMock::createIssueComment),
+        RESOLVED_ISSUE_COMMENT(DiscussionMock::createResolvedIssueComment),
+        RESOLVED_BY_COMMENT_ISSUE_COMMENT(DiscussionMock::createResolvedByCommentIssueComment);
+
+        private final Supplier<Discussion> creationMethod;
+
+        DiscussionType(Supplier<Discussion> creationMethod) {
+            this.creationMethod = creationMethod;
+        }
+
+        public Discussion create() {
+            return creationMethod.get();
+        }
+    }
+
+}


### PR DESCRIPTION
Closes https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/790

* Added configuration option to allow edit existing Summary Note instead of creating a new thread;
* Added tests for the current behavior;
* GitlabMergeRequestDecoratorTest -> switch to JUnit 5;
* Some efforts to simplify creation of mocks for GitlabMergeRequestDecoratorTest and minimize duplication.