### PR TITLE
Fix problem with unprocessed Pull Requests in SonarQube

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListAction.java
@@ -117,8 +117,10 @@ public class ListAction extends ProjectWsAction {
                                        @Nullable LiveMeasureDto qualityGateMeasure, @Nullable String analysisDate) {
         DbProjectBranches.PullRequestData pullRequestData = branch.getPullRequestData();
         
-        if (pullRequestData == null) return;
-
+        if (pullRequestData == null) {
+            return;
+        }
+        
         Optional<BranchDto> mergeBranch = Optional.ofNullable(mergeBranchesByUuid.get(branch.getMergeBranchUuid()));
 
         ProjectPullRequests.PullRequest.Builder builder = ProjectPullRequests.PullRequest.newBuilder();

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListAction.java
@@ -115,12 +115,15 @@ public class ListAction extends ProjectWsAction {
 
     private static void addPullRequest(ProjectPullRequests.ListWsResponse.Builder response, BranchDto branch, Map<String, BranchDto> mergeBranchesByUuid,
                                        @Nullable LiveMeasureDto qualityGateMeasure, @Nullable String analysisDate) {
+        DbProjectBranches.PullRequestData pullRequestData = Objects.requireNonNull(branch.getPullRequestData(), "Pull request data should be available for branch type PULL_REQUEST");
+        
+        if (pullRequestData == null) return;
+        
         Optional<BranchDto> mergeBranch = Optional.ofNullable(mergeBranchesByUuid.get(branch.getMergeBranchUuid()));
 
         ProjectPullRequests.PullRequest.Builder builder = ProjectPullRequests.PullRequest.newBuilder();
         builder.setKey(branch.getKey());
 
-        DbProjectBranches.PullRequestData pullRequestData = Objects.requireNonNull(branch.getPullRequestData(), "Pull request data should be available for branch type PULL_REQUEST");
         builder.setBranch(pullRequestData.getBranch());
         Optional.ofNullable(Strings.emptyToNull(pullRequestData.getUrl())).ifPresent(builder::setUrl);
         Optional.ofNullable(Strings.emptyToNull(pullRequestData.getTitle())).ifPresent(builder::setTitle);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListAction.java
@@ -115,10 +115,10 @@ public class ListAction extends ProjectWsAction {
 
     private static void addPullRequest(ProjectPullRequests.ListWsResponse.Builder response, BranchDto branch, Map<String, BranchDto> mergeBranchesByUuid,
                                        @Nullable LiveMeasureDto qualityGateMeasure, @Nullable String analysisDate) {
-        DbProjectBranches.PullRequestData pullRequestData = Objects.requireNonNull(branch.getPullRequestData(), "Pull request data should be available for branch type PULL_REQUEST");
+        DbProjectBranches.PullRequestData pullRequestData = branch.getPullRequestData();
         
         if (pullRequestData == null) return;
-        
+
         Optional<BranchDto> mergeBranch = Optional.ofNullable(mergeBranchesByUuid.get(branch.getMergeBranchUuid()));
 
         ProjectPullRequests.PullRequest.Builder builder = ProjectPullRequests.PullRequest.newBuilder();

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
@@ -178,7 +178,7 @@ class ListActionTest {
     }
 
     @Test
-    void shouldExExcludePullRequestsWithoutData() {
+    void shouldExcludePullRequestsWithoutData() {
         Request request = mock(Request.class);
         when(request.mandatoryParam("project")).thenReturn("project");
 


### PR DESCRIPTION
Related to the issue #738, it's true that any type of project should not be created with a Pull Request that their target branch is not scanned yet.

But the problem comes when the Pull Request, which its target branch is scanned, is waiting for being processed when there's a heavy project in progress status in the Background tasks section. Because SonarQube didn't add the proper Pull Request data to the project until is processed, we have the same problem as was described in the issue mentioned before, even when we have the target branch scan.

So the changes that are added in this Pull Request are simple:

- We ignore these unprocessed Pull Requests in the listing branches action.
- Add a test that covers this use case.

If there's any doubt, please, use this Pull Request for the discussion.