### PR TITLE
Let ListAction skip pull requests having no binary data

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
@@ -118,7 +118,12 @@ class ListActionTest {
                     .setBranch("prBranch2")
                     .setTitle("title3")
                     .setUrl("url3")
-                    .build())));
+                    .build()),
+                new BranchDto()
+                        .setBranchType(BranchType.PULL_REQUEST)
+                        .setKey("prKey4")
+                        .setUuid("uuid5")
+                        .setMergeBranchUuid("uuid2")));
 
         when(branchDao.selectByUuids(any(), any())).thenReturn(List.of(new BranchDto()
             .setUuid("uuid2")


### PR DESCRIPTION
Following https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/759#issuecomment-1777469548, this change lets `ListAction` skip pull requests without binary data.