### PR TITLE
#782: Fix container build for Sonarqube 10.1

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=latest
+SONARQUBE_VERSION=10.1-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG SONARQUBE_VERSION
 
-FROM gradle:7.3.3-jdk11-alpine as builder
+FROM gradle:7.3.3-jdk17-alpine as builder
 
 COPY . /home/build/project
 WORKDIR /home/build/project


### PR DESCRIPTION
Sonarqube 10.1 includes classes compiled with a Java 17 target, so the plugin fails to compile in the container build that uses Java 11. The build container is therefore being bumped to Java 17, and the environment file configured to pin to Sonarqube 10.1 to allow repeated builds.