### PR TITLE
#801: Add support for Sonarqube 10.2

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=10.1-community
+SONARQUBE_VERSION=10.2-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '10.1.0.73491'
+def sonarqubeVersion = '10.2.1.78527'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegate.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -119,7 +119,7 @@ public class CommunityBranchLoaderDelegate implements BranchLoaderDelegate {
 
     private static Optional<BranchDto> findBranchByUuid(String projectUuid, DbClient dbClient) {
         try (DbSession dbSession = dbClient.openSession(false)) {
-            return dbClient.branchDao().selectByUuid(dbSession, projectUuid);
+            return dbClient.branchDao().selectMainBranchByProjectUuid(dbSession, projectUuid);
         }
     }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegate.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegate.java
@@ -96,12 +96,11 @@ public class CommunityBranchSupportDelegate implements BranchSupportDelegate {
             .setUuid(branchUuid)
             .setBranchUuid(branchUuid)
             .setUuidPath(ComponentDto.UUID_PATH_OF_ROOT)
-            .setMainBranchProjectUuid(mainComponentDto.uuid())
             .setCreatedAt(new Date(clock.millis()));
         dbClient.componentDao().insert(dbSession, componentDto, false);
 
         BranchDto branchDto = new BranchDto()
-            .setProjectUuid(mainComponentDto.uuid())
+            .setProjectUuid(mainComponentBranchDto.getProjectUuid())
             .setUuid(branchUuid);
         componentKey.getPullRequestKey().ifPresent(pullRequestKey -> branchDto.setBranchType(BranchType.PULL_REQUEST)
             .setExcludeFromPurge(false)

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/ProjectWsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/ProjectWsAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -69,7 +69,7 @@ public abstract class ProjectWsAction implements AlmSettingsWsAction {
 
         try (DbSession dbSession = dbClient.openSession(false)) {
             ProjectDto project = componentFinder.getProjectByKey(dbSession, projectKey);
-            userSession.checkProjectPermission(permission, project);
+            userSession.hasEntityPermission(permission, project);
             handleProjectRequest(project, request, response, dbSession);
         }
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/DeleteAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/DeleteAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2022 SonarSource SA (mailto:info AT sonarsource DOT com), Michael Clarke
+ * Copyright (C) 2009-2023 SonarSource SA (mailto:info AT sonarsource DOT com), Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -53,8 +53,7 @@ public class DeleteAction extends ProjectWsAction {
 
     @Override
     public void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
-        userSession.checkLoggedIn()
-            .checkProjectPermission(UserRole.ADMIN, project);
+        userSession.checkLoggedIn().hasEntityPermission(UserRole.ADMIN, project);
 
         String pullRequestId = request.mandatoryParam(PULL_REQUEST_PARAMETER);
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegateTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -91,7 +91,7 @@ public class CommunityBranchLoaderDelegateTest {
         when(branchDto.isMain()).thenReturn(false);
 
         BranchDao branchDao = mock(BranchDao.class);
-        when(branchDao.selectByUuid(any(), any())).thenReturn(Optional.of(branchDto));
+        when(branchDao.selectMainBranchByProjectUuid(any(), any())).thenReturn(Optional.of(branchDto));
 
         ScannerReport.Metadata metadata = ScannerReport.Metadata.getDefaultInstance();
         when(dbClient.branchDao()).thenReturn(branchDao);
@@ -118,7 +118,7 @@ public class CommunityBranchLoaderDelegateTest {
         verify(dbClient).openSession(anyBoolean());
         verifyNoMoreInteractions(dbClient);
 
-        verify(branchDao).selectByUuid(any(), any());
+        verify(branchDao).selectMainBranchByProjectUuid(any(), any());
         verifyNoMoreInteractions(branchDao);
     }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/AnalysisDetailsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -174,15 +174,13 @@ class AnalysisDetailsTest {
         QualityGate.Condition condition3 = mock(QualityGate.Condition.class);
         when(condition3.getStatus()).thenReturn(QualityGate.EvaluationStatus.NO_VALUE);
         QualityGate.Condition condition4 = mock(QualityGate.Condition.class);
-        when(condition4.getStatus()).thenReturn(QualityGate.EvaluationStatus.WARN);
-        QualityGate.Condition condition5 = mock(QualityGate.Condition.class);
-        when(condition5.getStatus()).thenReturn(QualityGate.EvaluationStatus.ERROR);
+        when(condition4.getStatus()).thenReturn(QualityGate.EvaluationStatus.ERROR);
 
-        when(qualityGate.getConditions()).thenReturn(List.of(condition1, condition2, condition3, condition4, condition5));
+        when(qualityGate.getConditions()).thenReturn(List.of(condition1, condition2, condition3, condition4));
 
         AnalysisDetails underTest = new AnalysisDetails("pullRequest", "commit", List.of(), qualityGate, mock(PostProjectAnalysisTask.ProjectAnalysis.class));
 
-        assertThat(underTest.findFailedQualityGateConditions()).isEqualTo(List.of(condition2, condition5));
+        assertThat(underTest.findFailedQualityGateConditions()).isEqualTo(List.of(condition2, condition4));
     }
 
     @Test

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/CommunityBranchSupportDelegateTest.java
@@ -156,11 +156,10 @@ class CommunityBranchSupportDelegateTest {
         when(copyComponentDto.setKey(any())).thenReturn(copyComponentDto);
         when(copyComponentDto.setUuidPath(any())).thenReturn(copyComponentDto);
         when(copyComponentDto.setUuid(any())).thenReturn(copyComponentDto);
-        when(copyComponentDto.setMainBranchProjectUuid(any())).thenReturn(copyComponentDto);
         when(copyComponentDto.setCreatedAt(any())).thenReturn(copyComponentDto);
 
         BranchDto branchDto = mock(BranchDto.class);
-        when(branchDto.getUuid()).thenReturn("componentUuid");
+        when(branchDto.getProjectUuid()).thenReturn("projectUuid");
         when(branchDto.getKey()).thenReturn("nonDummy");
 
         when(clock.millis()).thenReturn(12345678901234L);
@@ -186,7 +185,6 @@ class CommunityBranchSupportDelegateTest {
         verify(componentDao).insert(dbSession, copyComponentDto, false);
         verify(copyComponentDto).setUuid("uuid0");
         verify(copyComponentDto).setUuidPath(".");
-        verify(copyComponentDto).setMainBranchProjectUuid("componentUuid");
         verify(copyComponentDto).setCreatedAt(new Date(12345678901234L));
 
         assertThat(result).isSameAs(copyComponentDto);
@@ -197,7 +195,7 @@ class CommunityBranchSupportDelegateTest {
         assertThat(branchDtoArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(new BranchDto()
             .setBranchType(branchType)
             .setExcludeFromPurge(excludedFromPurge)
-            .setProjectUuid("componentUuid")
+            .setProjectUuid("projectUuid")
             .setKey(branchType == BranchType.BRANCH ? branchName : pullRequestKey)
             .setUuid("uuid0")
             .setIsMain(false));

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/DeleteBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/DeleteBindingActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -89,7 +89,7 @@ class DeleteBindingActionTest {
         verify(dbSession).commit();
         verify(projectAlmSettingDao).deleteByProject(dbSession, componentDto);
         verify(response).noContent();
-        verify(userSession).checkProjectPermission("admin", componentDto);
+        verify(userSession).hasEntityPermission("admin", componentDto);
 
     }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/ValidateBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/ValidateBindingActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Michael Clarke
+ * Copyright (C) 2021-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -203,6 +203,6 @@ class ValidateBindingActionTest {
         underTest.handle(request, response);
 
         verify(validator).validate(projectAlmSettingDto, almSettingDto);
-        verify(userSession).checkProjectPermission(UserRole.USER, projectDto);
+        verify(userSession).hasEntityPermission(UserRole.USER, projectDto);
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/DeleteActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/DeleteActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Michael Clarke
+ * Copyright (C) 2022-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -37,6 +37,7 @@ import org.sonar.db.DbClient;
 import org.sonar.db.component.BranchDao;
 import org.sonar.db.component.BranchDto;
 import org.sonar.db.component.BranchType;
+import org.sonar.db.entity.EntityDto;
 import org.sonar.db.project.ProjectDto;
 import org.sonar.server.component.ComponentCleanerService;
 import org.sonar.server.component.ComponentFinder;
@@ -129,7 +130,7 @@ class DeleteActionTest {
         when(componentFinder.getProjectByKey(any(), any())).thenReturn(new ProjectDto().setKey("projectKey").setUuid("uuid0"));
 
         when(userSession.checkLoggedIn()).thenReturn(userSession);
-        when(userSession.checkProjectPermission(any(), any())).thenThrow(new UnauthorizedException("Dummy"));
+        when(userSession.hasEntityPermission(any(), any(EntityDto.class))).thenThrow(new UnauthorizedException("Dummy"));
 
         Response response = mock(Response.class);
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Michael Clarke
+ * Copyright (C) 2022-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -132,7 +132,7 @@ class ListActionTest {
 
         SnapshotDao snapshotDao = mock(SnapshotDao.class);
         when(dbClient.snapshotDao()).thenReturn(snapshotDao);
-        when(snapshotDao.selectLastAnalysesByRootComponentUuids(any(), any())).thenReturn(List.of(new SnapshotDto().setComponentUuid("componentUuid").setCreatedAt(1234L)));
+        when(snapshotDao.selectLastAnalysesByRootComponentUuids(any(), any())).thenReturn(List.of(new SnapshotDto().setUuid("componentUuid").setCreatedAt(1234L)));
 
         Response response = mock(Response.class);
 


### PR DESCRIPTION
The `checkProjectPermission` on Sonarqube's UserSession has been replaced with `hasEntityPermission`, and the `mainBranchProjectUuid` has been dropped from ComponentDTO, which has required a fix to set the right UUID as the project UUID for the branch. Additionally, the `MoreCollectors` map/identity collectors have been dropped from Sonarqube core, so their references have been replaced with equivalent `toMap` collectors from the JRE.