### PR TITLE
Remove references to deprecated Sonar logger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id('java')
     id('jacoco')
     id('org.sonarqube') version('2.8')
-    id('info.solidsoft.pitest') version('1.4.0')
+    id('info.solidsoft.pitest') version('1.15.0')
     id('com.github.johnrengelman.shadow') version('5.1.0')
     id('net.researchgate.release') version('2.6.0')
 }
@@ -134,8 +134,9 @@ tasks.withType(JavaCompile) {
 assemble.dependsOn('shadowJar')
 
 pitest {
+    junit5PluginVersion = '1.2.1'
     timestampedReports = false
-    avoidCallsTo = ['org.sonar.api.utils.log.Logger']
+    avoidCallsTo = ['org.slf4j.Logger']
 }
 
 jacocoTestReport {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgent.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgent.java
@@ -24,8 +24,8 @@ import javassist.CtClass;
 import javassist.CtConstructor;
 import javassist.CtMethod;
 import javassist.NotFoundException;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.core.platform.EditionProvider;
 
 import java.io.IOException;
@@ -39,7 +39,7 @@ import java.util.Optional;
 
 public final class CommunityBranchAgent {
 
-    private static final Logger LOGGER = Loggers.get(CommunityBranchAgent.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommunityBranchAgent.class);
 
     private CommunityBranchAgent() {
         super();
@@ -73,7 +73,7 @@ public final class CommunityBranchAgent {
                     return byteCode;
                 }
 
-                LOGGER.debug("Transforming class " + targetClassName);
+                LOGGER.debug("Transforming class {}", targetClassName);
                 try {
                     ClassPool cp = ClassPool.getDefault();
                     CtClass cc = cp.get(targetClassName);
@@ -83,7 +83,7 @@ public final class CommunityBranchAgent {
                     byteCode = cc.toBytecode();
                     cc.detach();
                 } catch (NotFoundException | CannotCompileException | IOException e) {
-                    LOGGER.error(String.format("Could not transform class %s, will use default class definition", targetClassName), e);
+                    LOGGER.error("Could not transform class {}}, will use default class definition", targetClassName, e);
                 }
 
                 return byteCode;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Marvin Wichmann, Michael Clarke
+ * Copyright (C) 2020-2023 Marvin Wichmann, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,6 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.almclient.bitbucket;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.AnnotationUploadLimit;
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.model.BitbucketConfiguration;
@@ -35,8 +36,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -52,7 +53,7 @@ import static java.lang.String.format;
 
 class BitbucketCloudClient implements BitbucketClient {
 
-    private static final Logger LOGGER = Loggers.get(BitbucketCloudClient.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BitbucketCloudClient.class);
     private static final MediaType APPLICATION_JSON_MEDIA_TYPE = MediaType.get("application/json");
     private static final String TITLE = "SonarQube";
     private static final String REPORTER = "SonarQube";
@@ -133,7 +134,14 @@ class BitbucketCloudClient implements BitbucketClient {
                 .build();
 
         LOGGER.info("Creating annotations on bitbucket cloud");
-        LOGGER.debug("Create annotations: " + objectMapper.writeValueAsString(annotations));
+        LOGGER.atDebug().setMessage("Create annotations: {}").addArgument(() -> {
+            try {
+                return objectMapper.writeValueAsString(annotations);
+            } catch (JsonProcessingException e) {
+                return "An error occurred whilst converting annotations to JSON: " + e.getClass().getName() + ": " + e.getMessage();
+            }
+        }).log();
+
 
         try (Response response = okHttpClient.newCall(req).execute()) {
             validate(response);
@@ -156,8 +164,8 @@ class BitbucketCloudClient implements BitbucketClient {
                 .url(targetUrl)
                 .build();
 
-        LOGGER.info("Create report on bitbucket cloud: " + targetUrl);
-        LOGGER.debug("Create report: " + body);
+        LOGGER.info("Create report on bitbucket cloud: {}", targetUrl);
+        LOGGER.debug("Create report: {}", body);
 
         try (Response response = okHttpClient.newCall(req).execute()) {
             validate(response);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Mathias Åhsberg, Michael Clarke
+ * Copyright (C) 2020-2023 Mathias Åhsberg, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -37,8 +37,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 
 class BitbucketServerClient implements BitbucketClient {
-    private static final Logger LOGGER = Loggers.get(BitbucketServerClient.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BitbucketServerClient.class);
     private static final MediaType APPLICATION_JSON_MEDIA_TYPE = MediaType.get("application/json");
     private static final String TITLE = "SonarQube";
     private static final String REPORTER = "SonarQube";
@@ -140,12 +140,16 @@ class BitbucketServerClient implements BitbucketClient {
     public boolean supportsCodeInsights() {
         try {
             ServerProperties server = getServerProperties();
-            LOGGER.debug(format("Your Bitbucket Server installation is version %s", server.getVersion()));
+            LOGGER.atDebug()
+                    .setMessage("Your Bitbucket Server installation is version {}")
+                    .addArgument(server::getVersion)
+                    .log();
             if (server.hasCodeInsightsApi()) {
                 return true;
             } else {
-                LOGGER.info("Bitbucket Server version is to old. %s is the minimum version that supports Code Insights",
-                        ServerProperties.CODE_INSIGHT_VERSION);
+                LOGGER.atInfo().setMessage("Bitbucket Server version is to old. {} is the minimum version that supports Code Insights")
+                        .addArgument(ServerProperties.CODE_INSIGHT_VERSION)
+                        .log();
             }
         } catch (IOException e) {
             LOGGER.error("Could not determine Bitbucket Server version", e);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Marvin Wichmann, Michael Clarke
+ * Copyright (C) 2020-2023 Marvin Wichmann, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -28,11 +28,11 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.config.internal.Settings;
 import org.sonar.api.server.ServerSide;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
@@ -45,7 +45,7 @@ import static java.lang.String.format;
 @ComputeEngineSide
 public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
 
-    private static final Logger LOGGER = Loggers.get(DefaultBitbucketClientFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultBitbucketClientFactory.class);
 
     private final HttpClientBuilderFactory httpClientBuilderFactory;
     private final Settings settings;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2023 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -31,8 +31,8 @@ import io.aexp.nodes.graphql.GraphQLResponseEntity;
 import io.aexp.nodes.graphql.GraphQLTemplate;
 import io.aexp.nodes.graphql.InputObject;
 import io.aexp.nodes.graphql.internal.Error;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -50,7 +50,7 @@ import static org.apache.commons.lang.ArrayUtils.isEmpty;
 
 public class GraphqlGithubClient implements GithubClient {
 
-    private static final Logger LOGGER = Loggers.get(GraphqlGithubClient.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GraphqlGithubClient.class);
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX")
             .withZone(ZoneId.of("UTC"));
     private static final String INPUT = "input";
@@ -230,11 +230,11 @@ public class GraphqlGithubClient implements GithubClient {
 
     private static <R> GraphQLResponseEntity<R> executeRequest(
             BiFunction<GraphQLRequestEntity, Class<R>, GraphQLResponseEntity<R>> executor, GraphQLRequestEntity graphQLRequestEntity, Class<R> responseType) {
-        LOGGER.debug("Using request: " + graphQLRequestEntity.getRequest());
+        LOGGER.atDebug().setMessage("Using request: {}").addArgument(graphQLRequestEntity::getRequest).log();
 
         GraphQLResponseEntity<R> response = executor.apply(graphQLRequestEntity, responseType);
 
-        LOGGER.debug("Received response: " + response.toString());
+        LOGGER.debug("Received response: {}", response);
 
         if (!isEmpty(response.getErrors())) {
             List<String> errors = new ArrayList<>();

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Markus Heberling, Michael Clarke
+ * Copyright (C) 2020-2023 Markus Heberling, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -42,9 +42,9 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report.AnalysisIssueSu
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report.AnalysisSummary;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report.ReportGenerator;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.ce.posttask.QualityGate;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
 import org.sonar.ce.task.projectanalysis.scm.ScmInfoRepository;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
@@ -62,7 +62,7 @@ import java.util.stream.Collectors;
 
 public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestDecorator<AzureDevopsClient, PullRequest, Void, CommentThread, Comment> implements PullRequestBuildStatusDecorator {
 
-    private static final Logger logger = Loggers.get(AzureDevOpsPullRequestDecorator.class);
+    private static final Logger logger = LoggerFactory.getLogger(AzureDevOpsPullRequestDecorator.class);
     private static final Pattern NOTE_MARKDOWN_LEGACY_SEE_LINK_PATTERN = Pattern.compile("^\\[See in SonarQube]\\((.*?)\\)$");
     private final AzureDevopsClientFactory azureDevopsClientFactory;
     private final MarkdownFormatterFactory markdownFormatterFactory;

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Mathias Åhsberg, Michael Clarke
+ * Copyright (C) 2020-2023 Mathias Åhsberg, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -34,12 +34,12 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.AnalysisDetails;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.DecorationResult;
 import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.PullRequestBuildStatusDecorator;
 import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.ce.posttask.QualityGate;
 import org.sonar.api.issue.Issue;
 import org.sonar.api.rule.Severity;
 import org.sonar.api.rules.RuleType;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
 import org.sonar.db.alm.setting.ALM;
 import org.sonar.db.alm.setting.AlmSettingDto;
 import org.sonar.db.alm.setting.ProjectAlmSettingDto;
@@ -61,7 +61,7 @@ import static java.util.stream.Collectors.toSet;
 
 public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDecorator {
 
-    private static final Logger LOGGER = Loggers.get(BitbucketPullRequestDecorator.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BitbucketPullRequestDecorator.class);
 
     private static final DecorationResult DEFAULT_DECORATION_RESULT = DecorationResult.builder().build();
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoader.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/CommunityBranchConfigurationLoader.java
@@ -28,10 +28,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.utils.MessageException;
 import org.sonar.api.utils.System2;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
 import org.sonar.core.config.ScannerProperties;
 import org.sonar.scanner.scan.branch.BranchConfiguration;
 import org.sonar.scanner.scan.branch.BranchConfigurationLoader;
@@ -43,7 +43,7 @@ import org.sonar.scanner.scan.branch.ProjectBranches;
  */
 public class CommunityBranchConfigurationLoader implements BranchConfigurationLoader {
 
-    private static final Logger LOGGER = Loggers.get(CommunityBranchConfigurationLoader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommunityBranchConfigurationLoader.class);
 
     private static final Set<String> BRANCH_ANALYSIS_PARAMETERS =
             new HashSet<>(Collections.singletonList(ScannerProperties.BRANCH_NAME));
@@ -84,7 +84,11 @@ public class CommunityBranchConfigurationLoader implements BranchConfigurationLo
                 Optional<BranchConfiguration> optionalBranchConfiguration = branchAutoConfigurer.detectConfiguration(system2, projectBranches);
                 if (optionalBranchConfiguration.isPresent()) {
                     BranchConfiguration branchConfiguration = optionalBranchConfiguration.get();
-                    LOGGER.info("Auto detected {} configuration with source {} using {}", branchConfiguration.branchType(), branchConfiguration.branchName(), branchAutoConfigurer.getClass().getName());
+                    LOGGER.atInfo().setMessage("Auto detected {} configuration with source {} using {}")
+                            .addArgument(branchConfiguration::branchType)
+                            .addArgument(branchConfiguration::branchName)
+                            .addArgument(() -> branchAutoConfigurer.getClass().getName())
+                            .log();
                     return branchConfiguration;
                 }
             }


### PR DESCRIPTION
The Sonar logger has been deprecated in favour of SLF4J's Logger and LoggerFactory, so the references have been replaced throughout the plugin, and log lines updated to use formats and conditional execution. Includes fixes to make Pi Test work in the Gradle build.