### PR TITLE
Ensure correct coverage is reported to Sonarcloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,11 +160,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       -
-        name: Sonar
+        name: Test and Sonar
         if: ${{ env.SONAR_TOKEN != null }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            ./gradlew sonarqube \
+            ./gradlew test sonar \
+              -Dsonar.gradle.skipCompile=true \
               -Dsonar.pullrequest.provider=github \
               -Dsonar.pullrequest.github.repository=${{ github.repository }} \
               -Dsonar.host.url=https://sonarcloud.io \
@@ -173,7 +174,8 @@ jobs:
               -Dsonar.pullrequest.key=${{ github.event.number }} \
               -Dsonar.pullrequest.base=${{ github.base_ref }}
           elif [ "${{ needs.prep.outputs.release }}" = 'true' ]; then
-            ./gradlew sonarqube \
+            ./gradlew test sonar \
+              -Dsonar.gradle.skipCompile=true \
               -Dsonar.pullrequest.provider=github \
               -Dsonar.pullrequest.github.repository=${{ github.repository }} \
               -Dsonar.host.url=https://sonarcloud.io \
@@ -181,7 +183,8 @@ jobs:
               -Dsonar.projectKey=${SONAR_PROJECT_KEY} \
               -Dsonar.projectVersion=${{ needs.prep.outputs.version }}
           else
-            ./gradlew sonarqube \
+            ./gradlew test sonar \
+              -Dsonar.gradle.skipCompile=true \
               -Dsonar.pullrequest.provider=github \
               -Dsonar.pullrequest.github.repository=${{ github.repository }} \
               -Dsonar.host.url=https://sonarcloud.io \


### PR DESCRIPTION
Since the Gradle upgrade and the associated Sonarqube plugin upgrade, Sonarcloud has been reporting no coverage on the project's main branch. This is due to the Sonarqube plugin no longer executing the test task so have no coverage report available. The relevant pipeline steps are being altered to run the `test` task before the Sonarqube task, and have switched to the new `sonar` name for the task, as well as removing the compile task dependency since this is implicit from the test task and matches the future state of Sonarqube's Gradle plugin.