### PR TITLE
Fix release task not creating any artefacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ release {
         requireBranch.set('')
         commitVersionFileOnly.set(true)
     }
+    buildTasks.set(["assemble"])
 }
 
 tasks.jar.configure {


### PR DESCRIPTION
When the release plugin was upgraded, the configuration was not altered to set a pre-release task needing executed, so no plugin JAR was being created as part of the release step. The `assemble` task is now being set to ensure the JAR exists in the relevant output directory for dependent steps to pick up.