### PR TITLE
Added default value for commentType area.

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/model/Comment.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/model/Comment.java
@@ -19,7 +19,7 @@ public class Comment {
                    @JsonProperty("commentType") CommentType commentType) {
         this.content = content;
         this.author = author;
-        this.commentType = commentType;
+        this.commentType = CommentType.TEXT;
     }
 
     /**


### PR DESCRIPTION
With this contribution Azure DevOps can see comment as text. Without this, commentType field was sending as unknown. Therefore Azure DevOps did not deliver to "new comment" email to subscribers.