### PR TITLE
SonarQube 10.4 compatibility fixes

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=10.3-community
+SONARQUBE_VERSION=10.4-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '10.3.0.82913'
+def sonarqubeVersion = '10.4.0.87286'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v3/RestApplicationAuthenticationProvider.java
@@ -28,7 +28,7 @@ import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model.AppInstalla
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model.AppToken;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model.InstallationRepositories;
 import com.github.mc1arke.sonarqube.plugin.almclient.github.v3.model.Repository;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.impl.DefaultJwtBuilder;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
@@ -78,8 +78,8 @@ public class RestApplicationAuthenticationProvider implements GithubApplicationA
 
         Instant issued = clock.instant().minus(10, ChronoUnit.SECONDS);
         Instant expiry = issued.plus(2, ChronoUnit.MINUTES);
-        String jwtToken = new DefaultJwtBuilder().setIssuedAt(Date.from(issued)).setExpiration(Date.from(expiry))
-                .claim("iss", appId).signWith(createPrivateKey(apiPrivateKey), SignatureAlgorithm.RS256).compact();
+        String jwtToken = new DefaultJwtBuilder().issuedAt(Date.from(issued)).expiration(Date.from(expiry))
+                .claim("iss", appId).signWith(createPrivateKey(apiPrivateKey), Jwts.SIG.RS256).compact();
 
         Optional<RepositoryAuthenticationToken> repositoryAuthenticationToken = findTokenFromAppInstallationList(getV3Url(apiUrl) + "/app/installations", jwtToken, projectPath);
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ClassReferenceElevatedClassLoaderFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ClassReferenceElevatedClassLoaderFactoryTest.java
@@ -82,10 +82,10 @@ public class ClassReferenceElevatedClassLoaderFactoryTest {
     public void testLoadClass() throws ClassNotFoundException, MalformedURLException {
         ClassloaderBuilder builder = new ClassloaderBuilder();
         builder.newClassloader("_api_", getClass().getClassLoader());
-        builder.setMask("_api_", new Mask().addInclusion("java/").addInclusion("org/sonar/api/"));
+        builder.setMask("_api_", Mask.builder().include("java/", "org/sonar/api/").build());
 
         builder.newClassloader("_customPlugin");
-        builder.setParent("_customPlugin", "_api_", new Mask());
+        builder.setParent("_customPlugin", "_api_", Mask.ALL);
         builder.setLoadingOrder("_customPlugin", ClassloaderBuilder.LoadingOrder.SELF_FIRST);
 
         for (URL pluginUrl : findSonarqubePluginJars()) {

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ReflectiveElevatedClassLoaderFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/classloader/ReflectiveElevatedClassLoaderFactoryTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertNotSame;
  * @author Michael Clarke
  */
 public class ReflectiveElevatedClassLoaderFactoryTest {
-    
+
     private static final String TARGET_PLUGIN_CLASS = "org.sonar.plugins.java.JavaPlugin";
     private static final String BUNDLED_PLUGINS_DIRECTORY = "lib/extensions";
     private static final String SONARQUBE_LIB_DIRECTORY = "sonarqube-lib/";
@@ -54,10 +54,10 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
     public void testLoadClass() throws ClassNotFoundException, MalformedURLException {
         ClassloaderBuilder builder = new ClassloaderBuilder();
         builder.newClassloader("_api_", getClass().getClassLoader());
-        builder.setMask("_api_", new Mask().addInclusion("java/").addInclusion("org/sonar/api/"));
+        builder.setMask("_api_", Mask.builder().include("java/", "org/sonar/api/").build());
 
         builder.newClassloader("_customPlugin");
-        builder.setParent("_customPlugin", "_api_", new Mask());
+        builder.setParent("_customPlugin", "_api_", Mask.ALL);
         builder.setLoadingOrder("_customPlugin", ClassloaderBuilder.LoadingOrder.SELF_FIRST);
 
         File[] sonarQubeDistributions = new File(SONARQUBE_LIB_DIRECTORY).listFiles();
@@ -84,10 +84,10 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
     public void testLoadClassInvalidClassRealmKey() throws ClassNotFoundException, MalformedURLException {
         ClassloaderBuilder builder = new ClassloaderBuilder();
         builder.newClassloader("_xxx_", getClass().getClassLoader());
-        builder.setMask("_xxx_", new Mask().addInclusion("java/").addInclusion("org/sonar/api/"));
+        builder.setMask("_xxx_", Mask.builder().include("java/", "org/sonar/api/").build());
 
         builder.newClassloader("_customPlugin");
-        builder.setParent("_customPlugin", "_xxx_", new Mask());
+        builder.setParent("_customPlugin", "_xxx_", Mask.ALL);
         builder.setLoadingOrder("_customPlugin", ClassloaderBuilder.LoadingOrder.SELF_FIRST);
 
         File[] sonarQubeDistributions = new File(SONARQUBE_LIB_DIRECTORY).listFiles();
@@ -115,7 +115,7 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
     public void testLoadClassNoParentRef() throws ClassNotFoundException, MalformedURLException {
         ClassloaderBuilder builder = new ClassloaderBuilder();
         builder.newClassloader("_xxx_", getClass().getClassLoader());
-        builder.setMask("_xxx_", new Mask());
+        builder.setMask("_xxx_", Mask.ALL);
 
         File[] sonarQubeDistributions = new File(SONARQUBE_LIB_DIRECTORY).listFiles();
 
@@ -141,7 +141,7 @@ public class ReflectiveElevatedClassLoaderFactoryTest {
     public void testLoadClassInvalidApiClassloader() throws ClassNotFoundException, MalformedURLException {
         ClassloaderBuilder builder = new ClassloaderBuilder();
         builder.newClassloader("_customPlugin");
-        builder.setParent("_customPlugin", new URLClassLoader(new URL[0]), new Mask());
+        builder.setParent("_customPlugin", new URLClassLoader(new URL[0]), Mask.ALL);
         builder.setLoadingOrder("_customPlugin", ClassloaderBuilder.LoadingOrder.SELF_FIRST);
 
         File[] sonarQubeDistributions = new File(SONARQUBE_LIB_DIRECTORY).listFiles();


### PR DESCRIPTION
When installed into SonarQube 10.4, community-branch-plugin fails with
```
Caused by: java.lang.NoSuchMethodError: 'io.jsonwebtoken.JwtBuilder io.jsonwebtoken.JwtBuilder.setExpiration(java.util.Date)'
	at com.github.mc1arke.sonarqube.plugin.almclient.github.v3.RestApplicationAuthenticationProvider.getInstallationToken(RestApplicationAuthenticationProvider.java:81)
	at com.github.mc1arke.sonarqube.plugin.almclient.github.DefaultGithubClientFactory.createClient(DefaultGithubClientFactory.java:56)
	at com.github.mc1arke.sonarqube.plugin.server.pullrequest.validator.GithubValidator.validate(GithubValidator.java:43)
	at com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.binding.action.ValidateBindingAction.validateProject(ValidateBindingAction.java:73)
	at com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.binding.action.ValidateBindingAction.lambda$handleProjectRequest$0(ValidateBindingAction.java:58)
	at java.base/java.util.Optional.ifPresent(Unknown Source)
	at com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.binding.action.ValidateBindingAction.handleProjectRequest(ValidateBindingAction.java:58)
	at com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.binding.action.ProjectWsAction.handle(ProjectWsAction.java:73)
	at org.sonar.server.ws.WebServiceEngine.execute(WebServiceEngine.java:114)
	at org.sonar.server.platform.web.WebServiceFilter.doFilter(WebServiceFilter.java:84)
	at org.sonar.server.platform.web.MasterServletFilter$JavaxFilterAdapter.doFilter(MasterServletFilter.java:227)
	at org.sonar.server.platform.web.MasterServletFilter$GodFilterChain.doFilter(MasterServletFilter.java:198)
	at org.sonar.server.platform.web.MasterServletFilter$HttpFilterChainAdapter.doFilter(MasterServletFilter.java:241)
	at org.sonar.server.platform.web.SonarLintConnectionFilter.doFilter(SonarLintConnectionFilter.java:66)
	at org.sonar.server.platform.web.MasterServletFilter$JavaxFilterAdapter.doFilter(MasterServletFilter.java:227)
	at org.sonar.server.platform.web.MasterServletFilter$GodFilterChain.doFilter(MasterServletFilter.java:198)
	at org.sonar.server.platform.web.MasterServletFilter.doFilter(MasterServletFilter.java:146)
	at jdk.internal.reflect.GeneratedMethodAccessor25.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.apache.catalina.security.SecurityUtil.lambda$execute$0(SecurityUtil.java:222)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at java.base/javax.security.auth.Subject.doAsPrivileged(Unknown Source)
	at org.apache.catalina.security.SecurityUtil.execute(SecurityUtil.java:250)
	... 141 common frames omitted
```

That seems to be a binary compatibility issue - the method `io.jsonwebtoken.JwtBuilder.setExpiration` is still available to the code (inherited from the `io.jsonwebtoken.ClaimsMutator`), however, it used to be explicitly overridden in the `io.jsonwebtoken.JwtBuilder` and now it's not.

Simply rebuilding the project against SonarQube 10.4 was enough to make it work - I'm able to get PR annotations with the rebuilt plugin.

This PR also tackles a few deprecations caused by JJwt 0.11.x -> 0.12.x upgrade in SonarQube 10.4. There are, however, more deprecations in the SonarQube API that are not required yet for the plugin to work.

---

Fixes https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/870