### PR TITLE
Compact Analysis Summary Layout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.19.2
+version=1.19.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.19.3
+version=1.19.1
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/List.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/List.java
@@ -37,6 +37,7 @@ public final class List extends Node {
     }
 
     public enum Style {
+        NONE,
         BULLET
     }
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/markup/MarkdownFormatterFactory.java
@@ -55,6 +55,8 @@ public final class MarkdownFormatterFactory extends BaseFormatterFactory {
             node.getChildren().forEach(i -> {
                 if (node.getStyle() == List.Style.BULLET) {
                     output.append("- ").append(format(i));
+                } else if (node.getStyle() == List.Style.NONE) {
+                    output.append(format(i));
                 } else {
                     throw new IllegalArgumentException("Unknown list type: " + node.getStyle());
                 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
@@ -204,10 +204,12 @@ public final class AnalysisSummary {
         List<String> failedConditions = getFailedQualityGateConditions();
 
         Document document = new Document(
-                new Paragraph(
-                    new Image(getStatusDescription(), getStatusImageUrl()),
-                    new Text(" "),
-                    new Text(String.format("**Project ID:** %s", getProjectKey()))),
+                new Heading(
+                    3, 
+                    new Text("Quality Gate"), 
+                    new Text(" "), 
+                    new Image(getStatusDescription(), getStatusImageUrl())),
+                new Paragraph(new Text(String.format("**Project ID:** %s", getProjectKey()))),
                 failedConditions.isEmpty() ? new Text("") :
                         new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
                                 com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
@@ -55,13 +55,14 @@ public final class AnalysisSummary {
     private final String duplicationsUrl;
     private final String duplicationsImageUrl;
 
-    private final long totalIssueCount;
-
     private final long bugCount;
     private final String bugUrl;
     private final String bugImageUrl;
 
     private final long securityHotspotCount;
+    private final String securityHotspotUrl;
+    private final String securityHotspotImageUrl;
+
     private final long vulnerabilityCount;
     private final String vulnerabilityUrl;
     private final String vulnerabilityImageUrl;
@@ -85,11 +86,12 @@ public final class AnalysisSummary {
         this.duplications = builder.duplications;
         this.duplicationsUrl = builder.duplicationsUrl;
         this.duplicationsImageUrl = builder.duplicationsImageUrl;
-        this.totalIssueCount = builder.totalIssueCount;
         this.bugCount = builder.bugCount;
         this.bugUrl = builder.bugUrl;
         this.bugImageUrl = builder.bugImageUrl;
         this.securityHotspotCount = builder.securityHotspotCount;
+        this.securityHotspotUrl = builder.securityHotspotUrl;
+        this.securityHotspotImageUrl = builder.securityHotspotImageUrl;
         this.vulnerabilityCount = builder.vulnerabilityCount;
         this.vulnerabilityUrl = builder.vulnerabilityUrl;
         this.vulnerabilityImageUrl = builder.vulnerabilityImageUrl;
@@ -154,10 +156,6 @@ public final class AnalysisSummary {
         return duplicationsImageUrl;
     }
 
-    public long getTotalIssueCount() {
-        return totalIssueCount;
-    }
-
     public long getBugCount() {
         return bugCount;
     }
@@ -172,6 +170,14 @@ public final class AnalysisSummary {
 
     public long getSecurityHotspotCount() {
         return securityHotspotCount;
+    }
+
+    public String getSecurityHotspotUrl() {
+        return securityHotspotUrl;
+    }
+
+    public String getSecurityHotspotImageUrl() {
+        return securityHotspotImageUrl;
     }
 
     public long getVulnerabilityCount() {
@@ -221,9 +227,12 @@ public final class AnalysisSummary {
                         new ListItem(new Link(getBugUrl(), new Image("Bug", getBugImageUrl())),
                                 new Text(" "),
                                 new Text(pluralOf(getBugCount(), "Bug", "Bugs"))),
+                        new ListItem(new Link(getSecurityHotspotUrl(), new Image("Security Hotspot", getSecurityHotspotImageUrl())),
+                                new Text(" "),
+                                new Text(pluralOf(getSecurityHotspotCount(), "Security Hotspot", "Security Hotspots"))),
                         new ListItem(new Link(getVulnerabilityUrl(), new Image("Vulnerability", getVulnerabilityImageUrl())),
                                 new Text(" "),
-                                new Text(pluralOf(getVulnerabilityCount() + getSecurityHotspotCount(), "Vulnerability", "Vulnerabilities"))),
+                                new Text(pluralOf(getVulnerabilityCount(), "Vulnerability", "Vulnerabilities"))),
                         new ListItem(new Link(getCodeSmellUrl(), new Image("Code Smell", getCodeSmellImageUrl())),
                                 new Text(" "),
                                 new Text(pluralOf(getCodeSmellCount(), "Code Smell", "Code Smells"))),
@@ -273,13 +282,14 @@ public final class AnalysisSummary {
         private String duplicationsUrl;
         private String duplicationsImageUrl;
 
-        private long totalIssueCount;
-
         private long bugCount;
         private String bugUrl;
         private String bugImageUrl;
 
         private long securityHotspotCount;
+        private String securityHotspotUrl;
+        private String securityHotspotImageUrl;
+
         private long vulnerabilityCount;
         private String vulnerabilityUrl;
         private String vulnerabilityImageUrl;
@@ -362,11 +372,6 @@ public final class AnalysisSummary {
             return this;
         }
 
-        public Builder withTotalIssueCount(long totalIssueCount) {
-            this.totalIssueCount = totalIssueCount;
-            return this;
-        }
-
         public Builder withBugCount(long bugCount) {
             this.bugCount = bugCount;
             return this;
@@ -384,6 +389,16 @@ public final class AnalysisSummary {
 
         public Builder withSecurityHotspotCount(long securityHotspotCount) {
             this.securityHotspotCount = securityHotspotCount;
+            return this;
+        }
+
+        public Builder withSecurityHotspotUrl(String securityHotspotUrl) {
+            this.securityHotspotUrl = securityHotspotUrl;
+            return this;
+        }
+
+        public Builder withSecurityHotspotImageUrl(String securityHotspotImageUrl) {
+            this.securityHotspotImageUrl = securityHotspotImageUrl;
             return this;
         }
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
@@ -206,6 +206,7 @@ public final class AnalysisSummary {
         Document document = new Document(
                 new Paragraph(
                     new Image(getStatusDescription(), getStatusImageUrl()),
+                    new Text(" "),
                     new Text(String.format("**Project ID:** %s", getProjectKey()))),
                 failedConditions.isEmpty() ? new Text("") :
                         new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
@@ -215,7 +216,7 @@ public final class AnalysisSummary {
                                         .map(ListItem::new)
                                         .toArray(ListItem[]::new)),
                 new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
-                        com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,
+                        com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.NONE,
                         new ListItem(new Link(getBugUrl(), new Image("Bug", getBugImageUrl())),
                                 new Text(" "),
                                 new Text(pluralOf(getBugCount(), "Bug", "Bugs"))),
@@ -224,22 +225,20 @@ public final class AnalysisSummary {
                                 new Text(pluralOf(getVulnerabilityCount() + getSecurityHotspotCount(), "Vulnerability", "Vulnerabilities"))),
                         new ListItem(new Link(getCodeSmellUrl(), new Image("Code Smell", getCodeSmellImageUrl())),
                                 new Text(" "),
-                                new Text(pluralOf(getCodeSmellCount(), "Code Smell", "Code Smells")))),
-                new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
-                        com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,
+                                new Text(pluralOf(getCodeSmellCount(), "Code Smell", "Code Smells"))),
                         new ListItem(new Link(getCoverageUrl(), new Image("Coverage", getCoverageImageUrl())),
                                 new Text(" "), new Text(
                                 Optional.ofNullable(getNewCoverage())
                                         .map(decimalFormat::format)
                                         .map(i -> i + "% Coverage")
-                                        .orElse("No coverage information") + " (" +
+                                        .orElse("No coverage info") + " (" +
                                         decimalFormat.format(Optional.ofNullable(getCoverage()).orElse(BigDecimal.valueOf(0))) + "% Estimated after merge)")),
                         new ListItem(new Link(getDuplicationsUrl(), new Image("Duplications", getDuplicationsImageUrl())),
                                 new Text(" "),
                                 new Text(Optional.ofNullable(getNewDuplications())
                                         .map(decimalFormat::format)
                                         .map(i -> i + "% Duplicated Code")
-                                        .orElse("No duplication information") + " (" + decimalFormat.format(getDuplications()) + "% Estimated after merge)"))),
+                                        .orElse("No duplication info") + " (" + decimalFormat.format(getDuplications()) + "% Estimated after merge)"))),
                 new Paragraph(new Link(getDashboardUrl(), new Text("View in SonarQube"))));
 
         return formatterFactory.documentFormatter().format(document);

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummary.java
@@ -208,8 +208,7 @@ public final class AnalysisSummary {
                     3, 
                     new Text("Quality Gate"), 
                     new Text(" "), 
-                    new Image(getStatusDescription(), getStatusImageUrl())),
-                new Paragraph(new Text(String.format("**Project ID:** %s", getProjectKey()))),
+                    new Link(getDashboardUrl(), new Image(getStatusDescription(), getStatusImageUrl()))),
                 failedConditions.isEmpty() ? new Text("") :
                         new com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List(
                                 com.github.mc1arke.sonarqube.plugin.ce.pullrequest.markup.List.Style.BULLET,
@@ -241,7 +240,7 @@ public final class AnalysisSummary {
                                         .map(decimalFormat::format)
                                         .map(i -> i + "% Duplicated Code")
                                         .orElse("No duplication info") + " (" + decimalFormat.format(getDuplications()) + "% Estimated after merge)"))),
-                new Paragraph(new Link(getDashboardUrl(), new Text("View in SonarQube"))));
+                new Paragraph(new Text(String.format("**Project ID:** %s", getProjectKey()))));
 
         return formatterFactory.documentFormatter().format(document);
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/ReportGenerator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/ReportGenerator.java
@@ -120,7 +120,6 @@ public class ReportGenerator {
                 .orElse(null);
 
         Map<RuleType, Long> issueCounts = countRuleByType(analysisDetails.getIssues());
-        long issueTotal = issueCounts.values().stream().mapToLong(l -> l).sum();
 
         List<QualityGate.Condition> failedConditions = analysisDetails.findFailedQualityGateConditions();
 
@@ -151,8 +150,9 @@ public class ReportGenerator {
                 .withStatusImageUrl(QualityGate.Status.OK == analysisDetails.getQualityGateStatus()
                         ? baseImageUrl + "/checks/QualityGateBadge/passed.png"
                         : baseImageUrl + "/checks/QualityGateBadge/failed.png")
-                .withTotalIssueCount(issueTotal)
                 .withSecurityHotspotCount(issueCounts.get(RuleType.SECURITY_HOTSPOT))
+                .withSecurityHotspotUrl(getIssuesUrlForRuleType(analysisDetails, RuleType.SECURITY_HOTSPOT))
+                .withSecurityHotspotImageUrl(baseImageUrl + "/common/security_hotspot.png")
                 .withVulnerabilityCount(issueCounts.get(RuleType.VULNERABILITY))
                 .withVulnerabilityUrl(getIssuesUrlForRuleType(analysisDetails, RuleType.VULNERABILITY))
                 .withVulnerabilityImageUrl(baseImageUrl + "/common/vulnerability.png")

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
@@ -63,9 +63,10 @@ class AnalysisSummaryTest {
                 .withFailedQualityGateConditions(java.util.List.of("issuea", "issueb", "issuec"))
                 .withNewCoverage(BigDecimal.valueOf(99))
                 .withSecurityHotspotCount(69)
+                .withSecurityHotspotUrl("securityHotspotUrl")
+                .withSecurityHotspotImageUrl("securityHotspotImageUrl")
                 .withStatusDescription("status description")
                 .withStatusImageUrl("statusImageUrl")
-                .withTotalIssueCount(666)
                 .withVulnerabilityCount(96)
                 .withVulnerabilityUrl("vulnerabilityUrl")
                 .withVulnerabilityImageUrl("vulnerabilityImageUrl")
@@ -97,13 +98,17 @@ class AnalysisSummaryTest {
                         new Text(" "),
                         new Text("911 Bugs")),
 					new ListItem(
+						new Link("securityHotspotUrl", new Image("Security Hotspot","securityHotspotImageUrl")),
+						new Text(" "),
+						new Text("69 Security Hotspots")),
+					new ListItem(
 						new Link("vulnerabilityUrl", new Image("Vulnerability","vulnerabilityImageUrl")),
 						new Text(" "),
-						new Text("165 Vulnerabilities")),
+						new Text("96 Vulnerabilities")),
 					new ListItem(
-                        new Link("codeSmellUrl", new Image("Code Smell", "codeSmellImageUrl")),
-                        new Text(" "),
-                        new Text("1 Code Smell")),
+						new Link("codeSmellUrl", new Image("Code Smell", "codeSmellImageUrl")),
+						new Text(" "),
+						new Text("1 Code Smell")),
 					new ListItem(
 						new Link("codeCoverageUrl", new Image("Coverage", "codeCoverageImageUrl")),
 						new Text(" "),

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
@@ -86,8 +86,7 @@ class AnalysisSummaryTest {
                         3, 
                         new Text("Quality Gate"),
                         new Text(" "),
-                        new Image("status description", "statusImageUrl")),
-                new Paragraph(new Text("**Project ID:** projectKey")),
+                        new Link("dashboardUrl", new Image("status description", "statusImageUrl"))),
                 new List(List.Style.BULLET,
                         new ListItem(new Text("issuea")),
                         new ListItem(new Text("issueb")),
@@ -113,7 +112,7 @@ class AnalysisSummaryTest {
 						new Link("duplicationsUrl", new Image("Duplications", "duplicationsImageUrl")),
 						new Text(" "),
 						new Text("199.00% Duplicated Code (66.00% Estimated after merge)"))),
-                new Paragraph(new Link("dashboardUrl", new Text("View in SonarQube"))));
+                new Paragraph(new Text("**Project ID:** projectKey")));
 
         assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
@@ -82,33 +82,35 @@ class AnalysisSummaryTest {
         verify(formatter).format(documentArgumentCaptor.capture());
 
         Document expectedDocument = new Document(
-                new Paragraph(new Image("status description", "statusImageUrl"), new Text("**Project ID:** projectKey")),
+                new Paragraph(
+                        new Image("status description", "statusImageUrl"),
+                        new Text(" "),
+                        new Text("**Project ID:** projectKey")),
                 new List(List.Style.BULLET,
                         new ListItem(new Text("issuea")),
                         new ListItem(new Text("issueb")),
                         new ListItem(new Text("issuec"))),
-                new List(List.Style.BULLET,
+                new List(List.Style.NONE,
                     new ListItem(
                         new Link("bugUrl", new Image("Bug","bugImageUrl")),
                         new Text(" "),
                         new Text("911 Bugs")),
-                new ListItem(
-                        new Link("vulnerabilityUrl", new Image("Vulnerability","vulnerabilityImageUrl")),
-                        new Text(" "),
-                        new Text("165 Vulnerabilities")),
-                new ListItem(
+					new ListItem(
+						new Link("vulnerabilityUrl", new Image("Vulnerability","vulnerabilityImageUrl")),
+						new Text(" "),
+						new Text("165 Vulnerabilities")),
+					new ListItem(
                         new Link("codeSmellUrl", new Image("Code Smell", "codeSmellImageUrl")),
                         new Text(" "),
-                        new Text("1 Code Smell"))),
-                new List(List.Style.BULLET,
-                        new ListItem(
-                            new Link("codeCoverageUrl", new Image("Coverage", "codeCoverageImageUrl")),
-                            new Text(" "),
-                            new Text("99.00% Coverage (303.00% Estimated after merge)")),
-                        new ListItem(
-                                new Link("duplicationsUrl", new Image("Duplications", "duplicationsImageUrl")),
-                                new Text(" "),
-                                new Text("199.00% Duplicated Code (66.00% Estimated after merge)"))),
+                        new Text("1 Code Smell")),
+					new ListItem(
+						new Link("codeCoverageUrl", new Image("Coverage", "codeCoverageImageUrl")),
+						new Text(" "),
+						new Text("99.00% Coverage (303.00% Estimated after merge)")),
+					new ListItem(
+						new Link("duplicationsUrl", new Image("Duplications", "duplicationsImageUrl")),
+						new Text(" "),
+						new Text("199.00% Duplicated Code (66.00% Estimated after merge)"))),
                 new Paragraph(new Link("dashboardUrl", new Text("View in SonarQube"))));
 
         assertThat(documentArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDocument);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/AnalysisSummaryTest.java
@@ -82,10 +82,12 @@ class AnalysisSummaryTest {
         verify(formatter).format(documentArgumentCaptor.capture());
 
         Document expectedDocument = new Document(
-                new Paragraph(
-                        new Image("status description", "statusImageUrl"),
+                new Heading(
+                        3, 
+                        new Text("Quality Gate"),
                         new Text(" "),
-                        new Text("**Project ID:** projectKey")),
+                        new Image("status description", "statusImageUrl")),
+                new Paragraph(new Text("**Project ID:** projectKey")),
                 new List(List.Style.BULLET,
                         new ListItem(new Text("issuea")),
                         new ListItem(new Text("issueb")),

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/ReportGeneratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/report/ReportGeneratorTest.java
@@ -198,12 +198,13 @@ class ReportGeneratorTest {
                         .withProjectKey("projectKey")
                         .withSummaryImageUrl("http://localhost:9000/static/communityBranchPlugin/common/icon.png")
                         .withSecurityHotspotCount(1)
+						.withSecurityHotspotUrl("http://localhost:9000/project/issues?pullRequest=5&resolved=false&types=SECURITY_HOTSPOT&inNewCodePeriod=true&id=projectKey")
+						.withSecurityHotspotImageUrl("http://localhost:9000/static/communityBranchPlugin/common/security_hotspot.png")
                         .withVulnerabilityCount(1)
                         .withVulnerabilityUrl("http://localhost:9000/project/issues?pullRequest=5&resolved=false&types=VULNERABILITY&inNewCodePeriod=true&id=projectKey")
                         .withVulnerabilityImageUrl("http://localhost:9000/static/communityBranchPlugin/common/vulnerability.png")
                         .withStatusDescription("Failed")
                         .withStatusImageUrl("http://localhost:9000/static/communityBranchPlugin/checks/QualityGateBadge/failed.png")
-                        .withTotalIssueCount(5)
                         .withFailedQualityGateConditions(List.of("19 Lines to Cover (is less than 20)",
                                 "2 Code Smells (is greater than 0)",
                                 "68.00% Line Coverage (is less than 80.00%)",


### PR DESCRIPTION
Make compact analysis summary layout (useful for monorepos) + add Security Hotspot. Addresses [enhancement issue](https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/868)

<img width="789" alt="image" src="https://github.com/mc1arke/sonarqube-community-branch-plugin/assets/5638030/27765a2c-87f1-4c53-8404-e5826a97cb16">


