### PR TITLE
#940: Use correct component IDs when extracting analysis date

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListAction.java
@@ -95,7 +95,7 @@ public class ListAction extends ProjectWsAction {
             .selectByComponentUuidsAndMetricKeys(dbSession, pullRequestUuids, List.of(CoreMetrics.ALERT_STATUS_KEY)).stream()
             .collect(Collectors.toMap(LiveMeasureDto::getComponentUuid, Function.identity()));
         Map<String, String> analysisDateByBranchUuid = getDbClient().snapshotDao().selectLastAnalysesByRootComponentUuids(dbSession, pullRequestUuids).stream()
-            .collect(Collectors.toMap(SnapshotDto::getUuid, s -> DateUtils.formatDateTime(s.getCreatedAt())));
+            .collect(Collectors.toMap(SnapshotDto::getRootComponentUuid, s -> DateUtils.formatDateTime(s.getCreatedAt())));
 
         ProjectPullRequests.ListWsResponse.Builder protobufResponse = ProjectPullRequests.ListWsResponse.newBuilder();
         pullRequests

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
@@ -137,7 +137,7 @@ class ListActionTest {
 
         SnapshotDao snapshotDao = mock(SnapshotDao.class);
         when(dbClient.snapshotDao()).thenReturn(snapshotDao);
-        when(snapshotDao.selectLastAnalysesByRootComponentUuids(any(), any())).thenReturn(List.of(new SnapshotDto().setUuid("componentUuid").setCreatedAt(1234L)));
+        when(snapshotDao.selectLastAnalysesByRootComponentUuids(any(), any())).thenReturn(List.of(new SnapshotDto().setRootComponentUuid("uuid3").setCreatedAt(1234567891234L)));
 
         Response response = mock(Response.class);
 
@@ -157,6 +157,7 @@ class ListActionTest {
                 .setKey("prKey2")
                 .setTitle("title2")
                 .setBranch("prBranch2")
+                .setAnalysisDate("2009-02-13T23:31:31+0000")
                 .setStatus(ProjectPullRequests.Status.newBuilder()
                     .build())
                 .setIsOrphan(true)


### PR DESCRIPTION
The component ID was being used to create a map of analysis dates to items, but the Pull Request's component ID did not map into this item, so the Pull Request web service was always returning the analysis date as empty. The service has been altered to use the root component ID as was used in the search to ensure the IDs align.