### PR TITLE
#909: Use default branch as Pull Request base when target does not exist

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchConfigurationFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchConfigurationFactory.java
@@ -41,7 +41,7 @@ public class BranchConfigurationFactory {
 
     public BranchConfiguration createPullRequestConfiguration(String pullRequestKey, String pullRequestBranch, String pullRequestBase, ProjectBranches branches) {
         String targetBranch = Optional.ofNullable(pullRequestBase).orElse(branches.defaultBranchName());
-        String referenceBranch = findReferenceBranch(targetBranch, branches);
+        String referenceBranch = findReferenceBranch(Optional.ofNullable(branches.get(targetBranch)).map(BranchInfo::name).orElse(branches.defaultBranchName()), branches);
         return new CommunityBranchConfiguration(pullRequestBranch, BranchType.PULL_REQUEST, referenceBranch, targetBranch, pullRequestKey);
     }
 
@@ -58,6 +58,7 @@ public class BranchConfigurationFactory {
             throw MessageException.of(String.format("The branch '%s' of type %s does not have a target", target.name(), target.type()));
         }
 
-        return findReferenceBranch(targetBranchTarget, branches);
+        return Optional.ofNullable(branches.get(targetBranchTarget)).map(BranchInfo::name)
+                .orElseThrow(() -> MessageException.of(String.format("The branch '%s' of type %s has a target '%s' which does not exist", target.name(), target.type(), targetBranchTarget)));
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchConfigurationFactoryTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/BranchConfigurationFactoryTest.java
@@ -119,6 +119,20 @@ class BranchConfigurationFactoryTest {
     }
 
     @Test
+    void shouldReturnPullRequestWithTargetOfDefaultBranchIfTargetDoesNotExistAndDefaultExists() {
+        ProjectBranches projectBranches = mock();
+        when(projectBranches.isEmpty()).thenReturn(false);
+        when(projectBranches.defaultBranchName()).thenReturn("defaultBranch");
+        BranchInfo branchInfo = new BranchInfo("defaultBranch", BranchType.BRANCH, true, null);
+        when(projectBranches.get("defaultBranch")).thenReturn(branchInfo);
+
+        BranchConfigurationFactory underTest = new BranchConfigurationFactory();
+        BranchConfiguration actual = underTest.createPullRequestConfiguration("key", "source", "missing", projectBranches);
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(new CommunityBranchConfiguration("source", BranchType.PULL_REQUEST, "defaultBranch", "missing", "key"));
+    }
+
+    @Test
     void shouldReturnPullRequestWithTargetOfTargetAsReferenceIfTargetBranchExists() {
         ProjectBranches projectBranches = mock(ProjectBranches.class);
         when(projectBranches.isEmpty()).thenReturn(false);


### PR DESCRIPTION
The resolution of Pull Request details currently uses the project default branch when a pull request is analysed without specifying a target branch. However, when a target branch is specified, the plugin expects that branch to exist and throws an exception if the target branch is not found. To overcome this, the target branch is being resolved to the default branch where no target branch is specified or the requested target branch does not exist. As the API used to gather branch information does not return PULL_REQUEST details, the result of this searching is that a pull request will either target a branch from the main branch, or target the main branch, there is no further nesting or pull requests and branches.