### PR TITLE
#934: Use static report key for non-monorepo Bitbucket decoration

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2020-2024 Mathias Åhsberg, Michael Clarke
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
 package com.github.mc1arke.sonarqube.plugin.ce.pullrequest.bitbucket;
 
 import com.github.mc1arke.sonarqube.plugin.almclient.bitbucket.BitbucketClient;
@@ -43,7 +61,7 @@ import static org.mockito.Mockito.when;
 class BitbucketPullRequestDecoratorTest {
 
     private static final String COMMIT = "commit";
-    private static final String REPORT_KEY = "report-key";
+    private static final String REPORT_KEY = "com.sonarsource.sonarqube";
 
     private static final String ISSUE_KEY = "issue-key";
     private static final int ISSUE_LINE = 1;


### PR DESCRIPTION
The Bitbucket decoration is currently using the project key to create the analysis report key, but the Sonarqube documentation states this should be a static value across all projects. To ensure that the Bitbucket `Required report` configuration can be created as per the guidance in Sonarqube documentation, the static key is being used where the repository has not been set as a monorepo.