### PR TITLE
#958: Remove group assignment during container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG SONARQUBE_VERSION
 
-FROM gradle:8.9-jdk17-jammy as builder
+FROM gradle:8.9-jdk17-jammy AS builder
 
 COPY . /home/build/project
 WORKDIR /home/build/project
 RUN gradle build -x test
 
 FROM sonarqube:${SONARQUBE_VERSION}
-COPY --from=builder --chown=sonarqube:sonarqube /home/build/project/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/extensions/plugins/
+COPY --from=builder --chown=sonarqube /home/build/project/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/extensions/plugins/
 
 ARG PLUGIN_VERSION
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -5,7 +5,7 @@ FROM sonarqube:${SONARQUBE_VERSION}
 ARG PLUGIN_VERSION
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 
-ADD --chown=sonarqube:sonarqube https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/${PLUGIN_VERSION}/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar /opt/sonarqube/extensions/plugins/
+ADD --chown=sonarqube https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/${PLUGIN_VERSION}/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar /opt/sonarqube/extensions/plugins/
 
 ENV SONAR_WEB_JAVAADDITIONALOPTS="-javaagent:./extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=web"
 ENV SONAR_CE_JAVAADDITIONALOPTS="-javaagent:./extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=ce"


### PR DESCRIPTION
The sonarqube images no longer create a sonarqube group for the sonarqube user to be placed into, instead they put the sonarqube user in the root group. To prevent the plugin builds failing when attempting to set the plugin ownership to a group that doesn't exist, the `chown` command is being altered to only set the user ownership, not the associated group.