### PR TITLE
#972: Ensure a consistent timezone is used in comparisons

### DIFF
--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
@@ -33,6 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.sonar.api.server.ws.Request;
 import org.sonar.api.server.ws.Response;
 import org.sonar.api.server.ws.WebService;
+import org.sonar.api.utils.DateUtils;
 import org.sonar.db.DbClient;
 import org.sonar.db.component.BranchDao;
 import org.sonar.db.component.BranchDto;
@@ -157,7 +158,7 @@ class ListActionTest {
                 .setKey("prKey2")
                 .setTitle("title2")
                 .setBranch("prBranch2")
-                .setAnalysisDate("2009-02-13T23:31:31+0000")
+                .setAnalysisDate(DateUtils.formatDateTime(1234567891234L))
                 .setStatus(ProjectPullRequests.Status.newBuilder()
                     .build())
                 .setIsOrphan(true)


### PR DESCRIPTION
The service code uses DateUtils to convert a long into a String format, which DateUtils converting the long to an instant, then an OffsetDateTime before passing this through a formatter, using the local timezone during the OffsetDateTime conversion.
As the test was using a pre-created String based on the UTC timezone, the test does not correctly compare the values when being executed in a different timezone. To overcome this, the test has been altered to use the same DateUtils methods to convert from the long to a String, thereby ensuring the same timezone handling is using in both test and live code.