### PR TITLE
docs: Update helm chart value examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ jvmCeOpts: "-javaagent:/opt/sonarqube/lib/common/sonarqube-community-branch-plug
 plugins:
   install:
     - https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/${version}/sonarqube-community-branch-plugin-${version}.jar
-jvmOpts: "-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${version}.jar=web"
-jvmCeOpts: "-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${version}.jar=ce"
+sonarProperties:
+  sonar.web.javaAdditionalOpts: "-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${version}.jar=web"
+  sonar.ce.javaAdditionalOpts: "-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${version}.jar=ce"
 ```
 
 ### Issues with file path with persistency


### PR DESCRIPTION
Helm chart values `jvmOpts` and `jvmCeOpts` were deprecated in [v8.3.1](https://github.com/SonarSource/helm-chart-sonarqube/releases/tag/sonarqube-10.0.0-sonarqube-dce-10.0.0). See https://github.com/SonarSource/helm-chart-sonarqube/commit/d42cc00b879705972e75a059bb80c0fc602fb62b