### PR TITLE
#958: Set plugin group ID to root in container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /home/build/project
 RUN gradle build -x test
 
 FROM sonarqube:${SONARQUBE_VERSION}
-COPY --from=builder --chown=sonarqube /home/build/project/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/extensions/plugins/
+COPY --from=builder --chown=sonarqube:0 /home/build/project/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/extensions/plugins/
 
 ARG PLUGIN_VERSION
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -5,7 +5,7 @@ FROM sonarqube:${SONARQUBE_VERSION}
 ARG PLUGIN_VERSION
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 
-ADD --chown=sonarqube https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/${PLUGIN_VERSION}/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar /opt/sonarqube/extensions/plugins/
+ADD --chown=sonarqube:0 https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/${PLUGIN_VERSION}/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar /opt/sonarqube/extensions/plugins/
 
 ENV SONAR_WEB_JAVAADDITIONALOPTS="-javaagent:./extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=web"
 ENV SONAR_CE_JAVAADDITIONALOPTS="-javaagent:./extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=ce"


### PR DESCRIPTION
Not all the Sonarqube image variants contain a group named sonarqube, so the `chown` command fails as it's unable to find the target group. To overcome this the group is being set to `0` which should always exist as the root user's group.