### PR TITLE
Check agent is correctly installed during plugin startup

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgent.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/CommunityBranchAgent.java
@@ -51,9 +51,11 @@ public final class CommunityBranchAgent {
         Component component = Component.fromString(args).orElseThrow(() -> new IllegalArgumentException("Invalid/missing agent argument"));
 
         if (component == Component.CE) {
+            redefineEdition(instrumentation, "com.github.mc1arke.sonarqube.plugin.CommunityBranchPluginBootstrap", redefineIsAvailableFlag());
             redefineEdition(instrumentation, "org.sonar.core.platform.PlatformEditionProvider", redefineOptionalEditionGetMethod());
             redefineEdition(instrumentation, "org.sonar.server.almsettings.MultipleAlmFeature", redefineIsAvailableFlag());
         } else if (component == Component.WEB) {
+            redefineEdition(instrumentation, "com.github.mc1arke.sonarqube.plugin.CommunityBranchPluginBootstrap", redefineIsAvailableFlag());
             redefineEdition(instrumentation, "org.sonar.server.almsettings.MultipleAlmFeature", redefineIsAvailableFlag());
             redefineEdition(instrumentation, "org.sonar.server.newcodeperiod.ws.SetAction", redefineConstructorEditionProviderField(EditionProvider.Edition.DEVELOPER));
             redefineEdition(instrumentation, "org.sonar.server.newcodeperiod.ws.UnsetAction", redefineConstructorEditionProviderField(EditionProvider.Edition.DEVELOPER));


### PR DESCRIPTION
Users currently submit a number of reports for Sonarqube reporting that branch analysis is not available despite them having the plugin installed, which are typically triggered by the user not having set up the Java agent on one of the components correctly. This is compounded by the Sonarqube plugin screen showing the plugin as being installed in these scenarios even where the plugin's classes and configuration have not been fully loaded into Sonarqube. To overcome this, the plugin bootstrap class is now checking for the agent having made an alteration to one of the bootstrap methods as an indication that the agent has run successfully for both the Compute Engine and Web components, with the plugin failing to start if either component doesn't detect the agent modifications, and therefore preventing the Sonarqube server starting. Whilst this won't fully resolve the problem of users not installing the plugin properly, it prevents them believing the plugin is installed and then only finding out things aren't right at the point they try and submit an analysis with branch or pull request properties.