### PR TITLE
fix: Update GitHub PR check name

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
@@ -51,6 +51,7 @@ import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.report.ReportGenerator
 
 public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorator {
 
+    private static final String DEFAULT_CHECK_RUN_NAME = "SonarQube Code Analysis";
     private final GithubClientFactory githubClientFactory;
     private final ReportGenerator reportGenerator;
     private final MarkdownFormatterFactory markdownFormatterFactory;
@@ -71,7 +72,8 @@ public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorat
             GitHub github = githubClientFactory.createClient(almSettingDto, projectAlmSettingDto);
             GHRepository repository = github.getRepository(projectAlmSettingDto.getAlmRepo());
 
-            GHPullRequest pullRequest = createCheckRun(repository,  analysisDetails, Optional.ofNullable(projectAlmSettingDto.getSummaryCommentEnabled()).orElse(false));
+            GHPullRequest pullRequest = createCheckRun(repository, analysisDetails, projectAlmSettingDto.getMonorepo(),
+                    Optional.ofNullable(projectAlmSettingDto.getSummaryCommentEnabled()).orElse(false));
 
             return DecorationResult.builder()
                     .withPullRequestUrl(pullRequest.getHtmlUrl().toExternalForm())
@@ -88,7 +90,8 @@ public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorat
     }
 
 
-    private GHPullRequest createCheckRun(GHRepository repository, AnalysisDetails analysisDetails, boolean postSummaryComment) throws IOException {
+    private GHPullRequest createCheckRun(GHRepository repository, AnalysisDetails analysisDetails,
+            boolean isMonorepo, boolean postSummaryComment) throws IOException {
         AnalysisSummary analysisSummary = reportGenerator.createAnalysisSummary(analysisDetails);
         String summary = analysisSummary.format(markdownFormatterFactory);
 
@@ -102,7 +105,10 @@ public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorat
             );
         }
 
-        repository.createCheckRun("SonarQube Code Analysis", analysisDetails.getCommitSha())
+        String checkRunName = isMonorepo
+            ? String.format("[%s] %s", analysisDetails.getAnalysisProjectName(), DEFAULT_CHECK_RUN_NAME)
+            : DEFAULT_CHECK_RUN_NAME;
+        repository.createCheckRun(checkRunName, analysisDetails.getCommitSha())
             .withStartedAt(analysisDetails.getAnalysisDate())
             .withCompletedAt(Date.from(clock.instant()))
             .withStatus(GHCheckRun.Status.COMPLETED)

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
@@ -102,7 +102,7 @@ public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorat
             );
         }
 
-        repository.createCheckRun(String.format("%s Sonarqube Results", analysisDetails.getAnalysisProjectName()), analysisDetails.getCommitSha())
+        repository.createCheckRun("SonarQube Code Analysis", analysisDetails.getCommitSha())
             .withStartedAt(analysisDetails.getAnalysisDate())
             .withCompletedAt(Date.from(clock.instant()))
             .withStatus(GHCheckRun.Status.COMPLETED)

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
@@ -153,7 +153,7 @@ class GithubPullRequestDecoratorTest {
         DecorationResult decorationResult = testCase.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
 
         verify(gitHub).getRepository("alm-repo");
-        verify(repository).createCheckRun("Project Name Sonarqube Results", "commit-sha");
+        verify(repository).createCheckRun("SonarQube Code Analysis", "commit-sha");
 
         ArgumentCaptor<GHCheckRunBuilder.Output> outputCaptor = ArgumentCaptor.captor();
 
@@ -214,7 +214,7 @@ class GithubPullRequestDecoratorTest {
         DecorationResult decorationResult = testCase.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
 
         verify(gitHub).getRepository("alm-repo");
-        verify(repository).createCheckRun("Project Name Sonarqube Results", "commit-sha");
+        verify(repository).createCheckRun("SonarQube Code Analysis", "commit-sha");
 
         ArgumentCaptor<GHCheckRunBuilder.Output> outputCaptor = ArgumentCaptor.captor();
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
@@ -86,6 +86,7 @@ class GithubPullRequestDecoratorTest {
     @BeforeEach
     void setUp() throws IOException {
         when(projectAlmSettingDto.getAlmRepo()).thenReturn("alm-repo");
+        when(projectAlmSettingDto.getMonorepo()).thenReturn(false);
         when(analysisDetails.getPullRequestId()).thenReturn("123");
         when(analysisDetails.getAnalysisDate()).thenReturn(Date.from(clock.instant()));
         when(analysisDetails.getAnalysisId()).thenReturn("analysis-id");


### PR DESCRIPTION
Fixes #415

Use a static check name instead, which makes it easier to apply global rulesets to repositories.