### PR TITLE
#1011: Add support for Sonarqube 24.12

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=10.6-community
+SONARQUBE_VERSION=24.12.0.100206-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '10.6.0.92116'
+def sonarqubeVersion = '24.12.0.100206'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
@@ -185,6 +185,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
     private static String toBitbucketSeverity(Severity severity) {
         switch (severity) {
             case HIGH:
+            case BLOCKER:
                 return "HIGH";
             case MEDIUM:
                 return "MEDIUM";

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecorator.java
@@ -145,10 +145,12 @@ public class GithubPullRequestDecorator implements PullRequestBuildStatusDecorat
         Severity maxSeverity = sonarqubeSeverity.stream().max(Severity::compareTo).orElseThrow();
         switch (maxSeverity) {
             case LOW:
+            case INFO:
                 return GHCheckRun.AnnotationLevel.NOTICE;
             case MEDIUM:
                 return GHCheckRun.AnnotationLevel.WARNING;
             case HIGH:
+            case BLOCKER:
                 return GHCheckRun.AnnotationLevel.FAILURE;
             default:
                 throw new IllegalArgumentException("Unknown severity value: " + sonarqubeSeverity);

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/GithubPullRequestDecoratorTest.java
@@ -174,7 +174,7 @@ class GithubPullRequestDecoratorTest {
             output.add(new GHCheckRunBuilder.Annotation(
                 "path" + i,
                 i,
-                GHCheckRun.AnnotationLevel.values()[i % GHCheckRun.AnnotationLevel.values().length],
+                GHCheckRun.AnnotationLevel.values()[i % Severity.values().length < 2 ? 0 : i % Severity.values().length > 2 ? 2 : 1],
                 "issue message " + i));
         }
 
@@ -235,7 +235,7 @@ class GithubPullRequestDecoratorTest {
             output.add(new GHCheckRunBuilder.Annotation(
                 "path" + i,
                 i,
-                GHCheckRun.AnnotationLevel.values()[i %  GHCheckRun.AnnotationLevel.values().length],
+                GHCheckRun.AnnotationLevel.values()[i % Severity.values().length < 2 ? 0 : i % Severity.values().length > 2 ? 2 : 1],
                 "issue message " + i));
         }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/ListActionTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.server.ws.Request;
 import org.sonar.api.server.ws.Response;
 import org.sonar.api.server.ws.WebService;
@@ -40,8 +41,8 @@ import org.sonar.db.component.BranchDto;
 import org.sonar.db.component.BranchType;
 import org.sonar.db.component.SnapshotDao;
 import org.sonar.db.component.SnapshotDto;
-import org.sonar.db.measure.LiveMeasureDao;
-import org.sonar.db.measure.LiveMeasureDto;
+import org.sonar.db.measure.MeasureDao;
+import org.sonar.db.measure.MeasureDto;
 import org.sonar.db.project.ProjectDto;
 import org.sonar.db.protobuf.DbProjectBranches;
 import org.sonar.server.component.ComponentFinder;
@@ -130,11 +131,11 @@ class ListActionTest {
             .setUuid("uuid2")
             .setKey("branch2Key")));
 
-        LiveMeasureDao liveMeasureDao = mock();
-        when(dbClient.liveMeasureDao()).thenReturn(liveMeasureDao);
-        when(liveMeasureDao.selectByComponentUuidsAndMetricKeys(any(), any(), any())).thenReturn(List.of(new LiveMeasureDto()
+        MeasureDao measureDao = mock();
+        when(dbClient.measureDao()).thenReturn(measureDao);
+        when(measureDao.selectByComponentUuidsAndMetricKeys(any(), any(), any())).thenReturn(List.of(new MeasureDto()
             .setComponentUuid("uuid1")
-            .setData("live measure")));
+            .addValue(CoreMetrics.ALERT_STATUS_KEY, "live measure")));
 
         SnapshotDao snapshotDao = mock();
         when(dbClient.snapshotDao()).thenReturn(snapshotDao);


### PR DESCRIPTION
The latest release for Sonarqube has removed the LiveMeasures concept, instead just using Measures, and has moved to a new versioning strategy for community edition. The plugin has therefore been update to the latest version number of Sonarqube and the appropriate DAO and DTO references updated.