### PR TITLE
[bugfix-1005] Fix first analysis on non main branch fails

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegate.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/CommunityBranchLoaderDelegate.java
@@ -102,7 +102,12 @@ public class CommunityBranchLoaderDelegate implements BranchLoaderDelegate {
     private static Branch createBranch(DbClient dbClient, String branchName, String projectUuid, String targetBranch) {
         String targetUuid;
         if (null == targetBranch) {
-            targetUuid = projectUuid;
+            Optional<BranchDto> branchDto = findBranchByUuid(projectUuid, dbClient);
+            if (branchDto.isPresent()) {
+                targetUuid = branchDto.get().getUuid();
+            } else {
+                throw new IllegalStateException(String.format("There is no main branch for project '%s'", projectUuid));
+            }
         } else {
             Optional<BranchDto> branchDto = findBranchByKey(projectUuid, targetBranch, dbClient);
             if (branchDto.isPresent()) {


### PR DESCRIPTION
See [1005](https://github.com/mc1arke/sonarqube-community-branch-plugin/issues/1005)

In the first analysis of a non-existent branch we receive a null target branch an we are using as target branch uuid the project uuid. When sonar tries to link our new branch to this uuid fails as this branch uuid don't exist.

We have to recover the main branch of the project and assign the UUID of the branch as the target branch.

![image](https://github.com/user-attachments/assets/06d6fb10-efc9-4e6e-89fe-735d12e360a9)

![image](https://github.com/user-attachments/assets/02cea78e-81dc-4818-a086-21c69f3b1fa9)

![image](https://github.com/user-attachments/assets/f4571069-79ff-4435-a7e6-2476f1012a4f)

![image](https://github.com/user-attachments/assets/de0d27fd-2fd0-45b1-99f7-9607102cfa97)

