### PR TITLE
#1065: Send HTTP verbs in uppercase

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClient.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -132,7 +133,7 @@ public class AzureDevopsRestClient implements AzureDevopsClient {
 
 
     private <T> T execute(String url, String method, String content, Class<T> type) throws IOException {
-        RequestBuilder requestBuilder = RequestBuilder.create(method)
+        RequestBuilder requestBuilder = RequestBuilder.create(method.toUpperCase(Locale.ENGLISH))
                 .setUri(url)
                 .addHeader("Authorization", "Basic " + authToken)
                 .addHeader("Content-type", ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8).toString());

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/azuredevops/AzureDevopsRestClientTest.java
@@ -72,7 +72,7 @@ class AzureDevopsRestClientTest {
 
         RequestBuilder request = RequestBuilder.copy(requestArgumentCaptor.getValue());
 
-        assertThat(request.getMethod()).isEqualTo("post");
+        assertThat(request.getMethod()).isEqualTo("POST");
         assertThat(request.getUri()).isEqualTo(URI.create("http://url.test/api/project/_apis/git/repositories/repo/pullRequests/101/statuses?api-version=4.1-preview"));
         assertThat(request.getEntity().getContent()).hasContent("json");
     }
@@ -95,7 +95,7 @@ class AzureDevopsRestClientTest {
 
         RequestBuilder request = RequestBuilder.copy(requestArgumentCaptor.getValue());
 
-        assertThat(request.getMethod()).isEqualTo("post");
+        assertThat(request.getMethod()).isEqualTo("POST");
         assertThat(request.getUri()).isEqualTo(URI.create("http://url.test/api/project%20Id%20With%20Spaces/_apis/git/repositories/repository%20Name%20With%20Spaces/pullRequests/123/statuses?api-version=4.1-preview"));
         assertThat(request.getEntity().getContent()).hasContent("json");
     }
@@ -118,7 +118,7 @@ class AzureDevopsRestClientTest {
 
         RequestBuilder request = RequestBuilder.copy(requestArgumentCaptor.getValue());
 
-        assertThat(request.getMethod()).isEqualTo("post");
+        assertThat(request.getMethod()).isEqualTo("POST");
         assertThat(request.getUri()).isEqualTo(URI.create("http://test.url/projectId/_apis/git/repositories/repository%20Name/pullRequests/123/threads/321/comments?api-version=4.1"));
         assertThat(request.getEntity().getContent()).hasContent("json");
     }
@@ -143,7 +143,7 @@ class AzureDevopsRestClientTest {
 
         RequestBuilder request = RequestBuilder.copy(requestArgumentCaptor.getValue());
 
-        assertThat(request.getMethod()).isEqualTo("get");
+        assertThat(request.getMethod()).isEqualTo("GET");
         assertThat(request.getUri()).isEqualTo(URI.create("http://test.url/projectId/_apis/git/repositories/repository%20Name/pullRequests/123?api-version=4.1"));
         assertThat(request.getEntity()).isNull();
         assertThat(result).isSameAs(pullRequest);


### PR DESCRIPTION
Microsoft IIS isn't handling requests from the plugin during Azure Devops decoration as expected, seemingly due to the HTTP verbs being sent in lower case. To match the HTTP request spec the verbs are being transformed to uppercase before sending.