### PR TITLE
#1075: Switch classloader injection to reference a stable class

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/classloader/ProviderType.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/classloader/ProviderType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Michael Clarke
+ * Copyright (C) 2019-2025 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,7 +19,7 @@
 package com.github.mc1arke.sonarqube.plugin.classloader;
 
 import org.sonar.api.Plugin;
-import org.sonar.api.rules.ActiveRule;
+import org.sonar.api.rule.Severity;
 
 import java.util.Arrays;
 
@@ -29,7 +29,7 @@ import java.util.Arrays;
         ElevatedClassLoaderFactory createFactory(Plugin.Context context) {
             return new ClassReferenceElevatedClassLoaderFactory(context.getBootConfiguration()
                                                                         .get(ElevatedClassLoaderFactoryProvider.class
-                                                                                     .getName() + ".targetType").orElse(ActiveRule.class.getName()));
+                                                                                     .getName() + ".targetType").orElse(Severity.class.getName()));
         }
     },
 


### PR DESCRIPTION
The class reference class loader strategy currently loads a class from Sonarqube core that will be removed in future versions of Sonarqube since the Profile import and export features this class is part of have been deprecated. The reference is being replaced a non-deprecated class from the same API component.