### PR TITLE
#1078: Ensure we're building the customised webapp

### DIFF
--- a/.env
+++ b/.env
@@ -5,4 +5,4 @@ SONARQUBE_VERSION=25.4.0.105899-community
 DOCKERFILE=Dockerfile
 
 # The version of the plugin to include in the image
-PLUGIN_VERSION=1.25.0-SNAPSHOT
+PLUGIN_VERSION=25.4.0-SNAPSHOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM node:22.16-alpine AS webapp-builder
 ARG WORKDIR
 
 COPY ./sonarqube-webapp ${WORKDIR}
-COPY ./sonarqube-webapp-addons ${WORKDIR}/libs/sq-server-addons
+COPY ./sonarqube-webapp-addons ${WORKDIR}/libs/addons
 
 WORKDIR ${WORKDIR}
 RUN yarn install

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.25.0-SNAPSHOT
+version=25.4.0-SNAPSHOT

--- a/sonarqube-webapp-addons/setup.sh
+++ b/sonarqube-webapp-addons/setup.sh
@@ -21,9 +21,9 @@ EOF
 
 function main() {
     cd ./sonarqube-webapp
-    echo "Creating symlink for sonarqube-webapp/libs/sq-server-addons"
-    rm -rf ./libs/sq-server-addons
-    ln -s "${CURRENT_DIR}/sonarqube-webapp-addons" ./libs/sq-server-addons
+    echo "Creating symlink for sonarqube-webapp/libs/addons"
+    rm -rf ./libs/addons
+    ln -s "${CURRENT_DIR}/sonarqube-webapp-addons" ./libs/addons
     override_vite_config
 }
 

--- a/sonarqube-webapp-addons/src/branches/app/ProjectBranchesApp.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/ProjectBranchesApp.tsx
@@ -21,10 +21,10 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { LargeCenteredLayout, PageContentFontWrapper, Title } from '~design-system';
-import withComponentContext from '~sq-server-commons/context/componentContext/withComponentContext';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import { withBranchLikes } from '~sq-server-commons/queries/branch';
-import { Component } from '~sq-server-commons/types/types';
+import withComponentContext from '~sq-server-shared/context/componentContext/withComponentContext';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import { withBranchLikes } from '~sq-server-shared/queries/branch';
+import { Component } from '~sq-server-shared/types/types';
 import BranchLikeTabs from './components/BranchLikeTabs';
 import LifetimeInformation from './components/LifetimeInformation';
 

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchLikeRow.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchLikeRow.tsx
@@ -26,18 +26,18 @@ import {
 } from '@sonarsource/echoes-react';
 import * as React from 'react';
 import { ActionCell, Badge, ContentCell, TableRowInteractive } from '~design-system';
-import BranchLikeIcon from '~sq-server-commons/components/icon-mappers/BranchLikeIcon';
-import DateFromNow from '~sq-server-commons/components/intl/DateFromNow';
-import QualityGateStatus from '~sq-server-commons/components/nav/QualityGateStatus';
-import { getBranchLikeDisplayName } from '~sq-server-commons/helpers/branch-like';
-import { translate, translateWithParameters } from '~sq-server-commons/helpers/l10n';
+import BranchLikeIcon from '~sq-server-shared/components/icon-mappers/BranchLikeIcon';
+import DateFromNow from '~sq-server-shared/components/intl/DateFromNow';
+import QualityGateStatus from '~sq-server-shared/components/nav/QualityGateStatus';
+import { getBranchLikeDisplayName } from '~sq-server-shared/helpers/branch-like';
+import { translate, translateWithParameters } from '~sq-server-shared/helpers/l10n';
 import {
   isBranch,
   isMainBranch,
   isPullRequest,
-} from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { BranchLike } from '~sq-server-commons/types/branch-like';
-import { Component } from '~sq-server-commons/types/types';
+} from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { BranchLike } from '~sq-server-shared/types/branch-like';
+import { Component } from '~sq-server-shared/types/types';
 import BranchPurgeSetting from './BranchPurgeSetting';
 
 export interface BranchLikeRowProps {

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchLikeTable.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchLikeTable.tsx
@@ -20,11 +20,11 @@
 
 import * as React from 'react';
 import { ActionCell, ContentCell, HelperHintIcon, Table, TableRow } from '~design-system';
-import { getBranchLikeKey } from '~sq-server-commons/helpers/branch-like';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import HelpTooltip from '~sq-server-commons/sonar-aligned/components/controls/HelpTooltip';
-import { BranchLike } from '~sq-server-commons/types/branch-like';
-import { Component } from '~sq-server-commons/types/types';
+import { getBranchLikeKey } from '~sq-server-shared/helpers/branch-like';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import HelpTooltip from '~sq-server-shared/sonar-aligned/components/controls/HelpTooltip';
+import { BranchLike } from '~sq-server-shared/types/branch-like';
+import { Component } from '~sq-server-shared/types/types';
 import BranchLikeRow from './BranchLikeRow';
 
 const COLUMN_WIDTHS_WITH_PURGE_SETTING = ['auto', '10%', '15%', '15%', '5%'];

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchLikeTabs.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchLikeTabs.tsx
@@ -22,16 +22,16 @@ import { IconGitBranch, IconPullrequest } from '@sonarsource/echoes-react';
 import { useState } from 'react';
 import { ToggleButton, getTabId, getTabPanelId } from '~design-system';
 import { PullRequest } from '~shared/types/branch-like';
-import { sortBranches, sortPullRequests } from '~sq-server-commons/helpers/branch-like';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import { useBranchesQuery } from '~sq-server-commons/queries/branch';
+import { sortBranches, sortPullRequests } from '~sq-server-shared/helpers/branch-like';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import { useBranchesQuery } from '~sq-server-shared/queries/branch';
 import {
   isBranch,
   isMainBranch,
   isPullRequest,
-} from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { Branch, BranchLike } from '~sq-server-commons/types/branch-like';
-import { Component } from '~sq-server-commons/types/types';
+} from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { Branch, BranchLike } from '~sq-server-shared/types/branch-like';
+import { Component } from '~sq-server-shared/types/types';
 import BranchLikeTable from './BranchLikeTable';
 import DeleteBranchModal from './DeleteBranchModal';
 import RenameBranchModal from './RenameBranchModal';

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
@@ -19,12 +19,12 @@
  */
 
 import { HelperHintIcon, Spinner, Switch } from '~design-system';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import { useExcludeFromPurgeMutation } from '~sq-server-commons/queries/branch';
-import HelpTooltip from '~sq-server-commons/sonar-aligned/components/controls/HelpTooltip';
-import { isMainBranch } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { Branch } from '~sq-server-commons/types/branch-like';
-import { Component } from '~sq-server-commons/types/types';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import { useExcludeFromPurgeMutation } from '~sq-server-shared/queries/branch';
+import HelpTooltip from '~sq-server-shared/sonar-aligned/components/controls/HelpTooltip';
+import { isMainBranch } from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { Branch } from '~sq-server-shared/types/branch-like';
+import { Component } from '~sq-server-shared/types/types';
 
 interface Props {
   branch: Branch;

--- a/sonarqube-webapp-addons/src/branches/app/components/DeleteBranchModal.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/DeleteBranchModal.tsx
@@ -22,11 +22,11 @@ import { Button, ButtonVariety } from '@sonarsource/echoes-react';
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Modal } from '~design-system';
-import { getBranchLikeDisplayName } from '~sq-server-commons/helpers/branch-like';
-import { useDeletBranchMutation } from '~sq-server-commons/queries/branch';
-import { isPullRequest } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { BranchLike } from '~sq-server-commons/types/branch-like';
-import { Component } from '~sq-server-commons/types/types';
+import { getBranchLikeDisplayName } from '~sq-server-shared/helpers/branch-like';
+import { useDeletBranchMutation } from '~sq-server-shared/queries/branch';
+import { isPullRequest } from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { BranchLike } from '~sq-server-shared/types/branch-like';
+import { Component } from '~sq-server-shared/types/types';
 
 interface Props {
   branchLike: BranchLike;

--- a/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformation.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformation.tsx
@@ -19,10 +19,10 @@
  */
 
 import * as React from 'react';
-import { getValue } from '~sq-server-commons/api/settings';
-import withAppStateContext from '~sq-server-commons/context/app-state/withAppStateContext';
-import { AppState } from '~sq-server-commons/types/appstate';
-import { SettingsKey } from '~sq-server-commons/types/settings';
+import { getValue } from '~sq-server-shared/api/settings';
+import withAppStateContext from '~sq-server-shared/context/app-state/withAppStateContext';
+import { AppState } from '~sq-server-shared/types/appstate';
+import { SettingsKey } from '~sq-server-shared/types/settings';
 import LifetimeInformationRenderer from './LifetimeInformationRenderer';
 
 interface Props {

--- a/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformationRenderer.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformationRenderer.tsx
@@ -21,8 +21,8 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Link, Spinner } from '~design-system';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import { formatMeasure } from '~sq-server-shared/sonar-aligned/helpers/measures';
 
 export interface LifetimeInformationRendererProps {
   branchAndPullRequestLifeTimeInDays?: string;

--- a/sonarqube-webapp-addons/src/branches/app/components/RenameBranchModal.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/RenameBranchModal.tsx
@@ -23,10 +23,10 @@ import * as React from 'react';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { FormField, InputField, Modal } from '~design-system';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import { useRenameMainBranchMutation } from '~sq-server-commons/queries/branch';
-import { MainBranch } from '~sq-server-commons/types/branch-like';
-import { Component } from '~sq-server-commons/types/types';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import { useRenameMainBranchMutation } from '~sq-server-shared/queries/branch';
+import { MainBranch } from '~sq-server-shared/types/branch-like';
+import { Component } from '~sq-server-shared/types/types';
 
 interface Props {
   branch: MainBranch;

--- a/sonarqube-webapp-addons/src/branches/app/components/SetAsMainBranchModal.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/SetAsMainBranchModal.tsx
@@ -22,12 +22,12 @@ import { Button, ButtonVariety } from '@sonarsource/echoes-react';
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { FlagMessage, Modal } from '~design-system';
-import DocumentationLink from '~sq-server-commons/components/common/DocumentationLink';
-import { DocLink } from '~sq-server-commons/helpers/doc-links';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import { useSetMainBranchMutation } from '~sq-server-commons/queries/branch';
-import { Branch } from '~sq-server-commons/types/branch-like';
-import { Component } from '~sq-server-commons/types/types';
+import DocumentationLink from '~sq-server-shared/components/common/DocumentationLink';
+import { DocLink } from '~sq-server-shared/helpers/doc-links';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import { useSetMainBranchMutation } from '~sq-server-shared/queries/branch';
+import { Branch } from '~sq-server-shared/types/branch-like';
+import { Component } from '~sq-server-shared/types/types';
 
 interface SetAsMainBranchModalProps {
   branch: Branch;

--- a/sonarqube-webapp-addons/src/branches/app/routes.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/routes.tsx
@@ -19,7 +19,7 @@
  */
 
 import { Route } from 'react-router-dom';
-import { lazyLoadComponent } from '~shared/helpers/lazyLoadComponent';
+import { lazyLoadComponent } from '~sq-server-shared/sonar-aligned/helpers/lazyLoadComponent';
 
 const ProjectBranchesApp = lazyLoadComponent(() => import('./ProjectBranchesApp'));
 

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/CurrentBranchLikeMergeInformation.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/CurrentBranchLikeMergeInformation.tsx
@@ -20,8 +20,8 @@
 
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { PullRequest } from '~shared/types/branch-like';
-import { translate, translateWithParameters } from '~sq-server-commons/helpers/l10n';
+import { PullRequest } from '~sq-server-shared/types/branch-like';
+import { translate, translateWithParameters } from '~sq-server-shared/helpers/l10n';
 
 export interface CurrentBranchLikeMergeInformationProps {
   pullRequest: PullRequest;

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/Menu.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/Menu.tsx
@@ -21,16 +21,16 @@
 import * as React from 'react';
 import { DropdownMenu, InputSearch, ItemDivider, Link } from '~design-system';
 import { ComponentQualifier } from '~shared/types/component';
-import { Router } from '~shared/types/router';
-import { getBrancheLikesAsTree, isSameBranchLike } from '~sq-server-commons/helpers/branch-like';
-import { KeyboardKeys } from '~sq-server-commons/helpers/keycodes';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import { getBranchLikeUrl } from '~sq-server-commons/helpers/urls';
-import { withRouter } from '~sq-server-commons/sonar-aligned/components/hoc/withRouter';
-import { isBranch, isPullRequest } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { queryToSearchString } from '~sq-server-commons/sonar-aligned/helpers/urls';
-import { BranchLike, BranchLikeTree } from '~sq-server-commons/types/branch-like';
-import { Component } from '~sq-server-commons/types/types';
+import { Router } from '~sq-server-shared/sonar-aligned/types/router';
+import { getBrancheLikesAsTree, isSameBranchLike } from '~sq-server-shared/helpers/branch-like';
+import { KeyboardKeys } from '~sq-server-shared/helpers/keycodes';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import { getBranchLikeUrl } from '~sq-server-shared/helpers/urls';
+import { withRouter } from '~sq-server-shared/sonar-aligned/components/hoc/withRouter';
+import { isBranch, isPullRequest } from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { queryToSearchString } from '~sq-server-shared/sonar-aligned/helpers/urls';
+import { BranchLike, BranchLikeTree } from '~sq-server-shared/types/branch-like';
+import { Component } from '~sq-server-shared/types/types';
 import MenuItemList from './MenuItemList';
 
 interface Props {

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItem.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItem.tsx
@@ -21,12 +21,12 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import { Badge, ItemButton, TextBold, TextMuted } from '~design-system';
-import BranchLikeIcon from '~sq-server-commons/components/icon-mappers/BranchLikeIcon';
-import QualityGateStatus from '~sq-server-commons/components/nav/QualityGateStatus';
-import { getBranchLikeDisplayName } from '~sq-server-commons/helpers/branch-like';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import { isMainBranch } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { BranchLike } from '~sq-server-commons/types/branch-like';
+import BranchLikeIcon from '~sq-server-shared/components/icon-mappers/BranchLikeIcon';
+import QualityGateStatus from '~sq-server-shared/components/nav/QualityGateStatus';
+import { getBranchLikeDisplayName } from '~sq-server-shared/helpers/branch-like';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import { isMainBranch } from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { BranchLike } from '~sq-server-shared/types/branch-like';
 
 export interface MenuItemProps {
   branchLike: BranchLike;

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItemList.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItemList.tsx
@@ -21,11 +21,11 @@
 import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { HelperHintIcon, ItemDivider, ItemHeader } from '~design-system';
-import { isDefined } from '~shared/helpers/types';
-import { getBranchLikeKey, isSameBranchLike } from '~sq-server-commons/helpers/branch-like';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import HelpTooltip from '~sq-server-commons/sonar-aligned/components/controls/HelpTooltip';
-import { BranchLike, BranchLikeTree } from '~sq-server-commons/types/branch-like';
+import { isDefined } from '~sq-server-shared/helpers/types';
+import { getBranchLikeKey, isSameBranchLike } from '~sq-server-shared/helpers/branch-like';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import HelpTooltip from '~sq-server-shared/sonar-aligned/components/controls/HelpTooltip';
+import { BranchLike, BranchLikeTree } from '~sq-server-shared/types/branch-like';
 import MenuItem from './MenuItem';
 
 export interface MenuItemListProps {

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/PRLink.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/PRLink.tsx
@@ -19,13 +19,13 @@
  */
 
 import { LinkStandalone } from '@sonarsource/echoes-react';
-import { Image } from '~adapters/components/common/Image';
-import { isDefined } from '~shared/helpers/types';
-import { translate, translateWithParameters } from '~sq-server-commons/helpers/l10n';
-import { isPullRequest } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { AlmKeys } from '~sq-server-commons/types/alm-settings';
-import { BranchLike } from '~sq-server-commons/types/branch-like';
-import { Component } from '~sq-server-commons/types/types';
+import { Image } from '~sq-server-shared/sonar-aligned/components/common/Image';
+import { isDefined } from '~sq-server-shared/helpers/types';
+import { translate, translateWithParameters } from '~sq-server-shared/helpers/l10n';
+import { isPullRequest } from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { AlmKeys } from '~sq-server-shared/types/alm-settings';
+import { BranchLike } from '~sq-server-shared/types/branch-like';
+import { Component } from '~sq-server-shared/types/types';
 
 function getPRUrlAlmKey(url = '') {
   const lowerCaseUrl = url.toLowerCase();

--- a/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
@@ -23,19 +23,19 @@ import { ActionCell, ContentCell, Spinner, Table, TableRow } from '~design-syste
 import {
   listBranchesNewCodeDefinition,
   resetNewCodeDefinition,
-} from '~sq-server-commons/api/newCodeDefinition';
-import BranchNCDAutoUpdateMessage from '~sq-server-commons/components/new-code-definition/BranchNCDAutoUpdateMessage';
+} from '~sq-server-shared/api/newCodeDefinition';
+import BranchNCDAutoUpdateMessage from '~sq-server-shared/components/new-code-definition/BranchNCDAutoUpdateMessage';
 import {
   PreviouslyNonCompliantBranchNCD,
   isPreviouslyNonCompliantDaysNCD,
-} from '~sq-server-commons/components/new-code-definition/utils';
-import { sortBranches } from '~sq-server-commons/helpers/branch-like';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import { DEFAULT_NEW_CODE_DEFINITION_TYPE } from '~sq-server-commons/helpers/new-code-definition';
-import { isBranch } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { Branch, BranchLike, BranchWithNewCodePeriod } from '~sq-server-commons/types/branch-like';
-import { NewCodeDefinition } from '~sq-server-commons/types/new-code-definition';
-import { Component } from '~sq-server-commons/types/types';
+} from '~sq-server-shared/components/new-code-definition/utils';
+import { sortBranches } from '~sq-server-shared/helpers/branch-like';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import { DEFAULT_NEW_CODE_DEFINITION_TYPE } from '~sq-server-shared/helpers/new-code-definition';
+import { isBranch } from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { Branch, BranchLike, BranchWithNewCodePeriod } from '~sq-server-shared/types/branch-like';
+import { NewCodeDefinition } from '~sq-server-shared/types/new-code-definition';
+import { Component } from '~sq-server-shared/types/types';
 import BranchListRow from './BranchListRow';
 import BranchNewCodeDefinitionSettingModal from './BranchNewCodeDefinitionSettingModal';
 

--- a/sonarqube-webapp-addons/src/branches/components/branch-list/BranchListRow.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-list/BranchListRow.tsx
@@ -34,15 +34,15 @@ import {
   FlagWarningIcon,
   TableRowInteractive,
 } from '~design-system';
-import BranchLikeIcon from '~sq-server-commons/components/icon-mappers/BranchLikeIcon';
-import DateTimeFormatter from '~sq-server-commons/components/intl/DateTimeFormatter';
-import { translate, translateWithParameters } from '~sq-server-commons/helpers/l10n';
-import { isNewCodeDefinitionCompliant } from '~sq-server-commons/helpers/new-code-definition';
-import { BranchWithNewCodePeriod } from '~sq-server-commons/types/branch-like';
+import BranchLikeIcon from '~sq-server-shared/components/icon-mappers/BranchLikeIcon';
+import DateTimeFormatter from '~sq-server-shared/components/intl/DateTimeFormatter';
+import { translate, translateWithParameters } from '~sq-server-shared/helpers/l10n';
+import { isNewCodeDefinitionCompliant } from '~sq-server-shared/helpers/new-code-definition';
+import { BranchWithNewCodePeriod } from '~sq-server-shared/types/branch-like';
 import {
   NewCodeDefinition,
   NewCodeDefinitionType,
-} from '~sq-server-commons/types/new-code-definition';
+} from '~sq-server-shared/types/new-code-definition';
 
 export interface BranchListRowProps {
   branch: BranchWithNewCodePeriod;

--- a/sonarqube-webapp-addons/src/branches/components/branch-list/BranchListSection.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-list/BranchListSection.tsx
@@ -19,10 +19,10 @@
  */
 
 import { Heading } from '@sonarsource/echoes-react';
-import { translate } from '~sq-server-commons/helpers/l10n';
-import type { Branch } from '~sq-server-commons/types/branch-like';
-import type { NewCodeDefinition } from '~sq-server-commons/types/new-code-definition';
-import type { Component } from '~sq-server-commons/types/types';
+import { translate } from '~sq-server-shared/helpers/l10n';
+import type { Branch } from '~sq-server-shared/types/branch-like';
+import type { NewCodeDefinition } from '~sq-server-shared/types/new-code-definition';
+import type { Component } from '~sq-server-shared/types/types';
 import BranchList from './BranchList';
 
 interface Props {

--- a/sonarqube-webapp-addons/src/branches/components/branch-list/BranchNewCodeDefinitionSettingModal.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-list/BranchNewCodeDefinitionSettingModal.tsx
@@ -22,24 +22,24 @@ import { Button, ButtonVariety, Label } from '@sonarsource/echoes-react';
 import { noop } from 'lodash';
 import * as React from 'react';
 import { Modal, Spinner } from '~design-system';
-import { setNewCodeDefinition } from '~sq-server-commons/api/newCodeDefinition';
-import NewCodeDefinitionDaysOption from '~sq-server-commons/components/new-code-definition/NewCodeDefinitionDaysOption';
-import NewCodeDefinitionPreviousVersionOption from '~sq-server-commons/components/new-code-definition/NewCodeDefinitionPreviousVersionOption';
-import NewCodeDefinitionSettingAnalysis from '~sq-server-commons/components/new-code-definition/NewCodeDefinitionSettingAnalysis';
-import NewCodeDefinitionSettingReferenceBranch from '~sq-server-commons/components/new-code-definition/NewCodeDefinitionSettingReferenceBranch';
+import { setNewCodeDefinition } from '~sq-server-shared/api/newCodeDefinition';
+import NewCodeDefinitionDaysOption from '~sq-server-shared/components/new-code-definition/NewCodeDefinitionDaysOption';
+import NewCodeDefinitionPreviousVersionOption from '~sq-server-shared/components/new-code-definition/NewCodeDefinitionPreviousVersionOption';
+import NewCodeDefinitionSettingAnalysis from '~sq-server-shared/components/new-code-definition/NewCodeDefinitionSettingAnalysis';
+import NewCodeDefinitionSettingReferenceBranch from '~sq-server-shared/components/new-code-definition/NewCodeDefinitionSettingReferenceBranch';
 import {
   getSettingValue,
   NewCodeDefinitionLevels,
   validateSetting,
-} from '~sq-server-commons/components/new-code-definition/utils';
-import { toISO8601WithOffsetString } from '~sq-server-commons/helpers/dates';
-import { translate, translateWithParameters } from '~sq-server-commons/helpers/l10n';
-import { getNumberOfDaysDefaultValue } from '~sq-server-commons/helpers/new-code-definition';
-import { Branch, BranchWithNewCodePeriod } from '~sq-server-commons/types/branch-like';
+} from '~sq-server-shared/components/new-code-definition/utils';
+import { toISO8601WithOffsetString } from '~sq-server-shared/helpers/dates';
+import { translate, translateWithParameters } from '~sq-server-shared/helpers/l10n';
+import { getNumberOfDaysDefaultValue } from '~sq-server-shared/helpers/new-code-definition';
+import { Branch, BranchWithNewCodePeriod } from '~sq-server-shared/types/branch-like';
 import {
   NewCodeDefinition,
   NewCodeDefinitionType,
-} from '~sq-server-commons/types/new-code-definition';
+} from '~sq-server-shared/types/new-code-definition';
 
 interface Props {
   branch: BranchWithNewCodePeriod;

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/BranchQualityGateConditions.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/BranchQualityGateConditions.tsx
@@ -26,25 +26,25 @@ import {
   DEFAULT_ISSUES_QUERY,
   isIssueMeasure,
   propsToIssueParams,
-} from '~sq-server-commons/components/shared/utils';
-import { getLocalizedMetricName, translate } from '~sq-server-commons/helpers/l10n';
-import { getShortType, isDiffMetric } from '~sq-server-commons/helpers/measures';
-import { getComponentDrilldownUrl } from '~sq-server-commons/helpers/urls';
-import { getBranchLikeQuery } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
+} from '~sq-server-shared/components/shared/utils';
+import { getLocalizedMetricName, translate } from '~sq-server-shared/helpers/l10n';
+import { getShortType, isDiffMetric } from '~sq-server-shared/helpers/measures';
+import { getComponentDrilldownUrl } from '~sq-server-shared/helpers/urls';
+import { getBranchLikeQuery } from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { formatMeasure } from '~sq-server-shared/sonar-aligned/helpers/measures';
 import {
   getComponentIssuesUrl,
   getComponentSecurityHotspotsUrl,
-} from '~sq-server-commons/sonar-aligned/helpers/urls';
-import { BranchLike } from '~sq-server-commons/types/branch-like';
-import { IssueType } from '~sq-server-commons/types/issues';
-import { QualityGateStatusConditionEnhanced } from '~sq-server-commons/types/quality-gates';
-import { Component } from '~sq-server-commons/types/types';
+} from '~sq-server-shared/sonar-aligned/helpers/urls';
+import { BranchLike } from '~sq-server-shared/types/branch-like';
+import { IssueType } from '~sq-server-shared/types/issues';
+import { QualityGateStatusConditionEnhanced } from '~sq-server-shared/types/quality-gates';
+import { Component } from '~sq-server-shared/types/types';
 import {
   METRICS_REPORTED_IN_OVERVIEW_CARDS,
   RATING_METRICS_MAPPING,
   RATING_TO_SEVERITIES_MAPPING,
-} from '~sq-server-commons/utils/overview-utils';
+} from '~sq-server-shared/utils/overview-utils';
 
 interface Props {
   branchLike?: BranchLike;

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
@@ -31,37 +31,37 @@ import {
   TrendDownCircleIcon,
   TrendUpCircleIcon,
 } from '~design-system';
-import { PullRequest } from '~shared/types/branch-like';
-import { MetricKey, MetricType } from '~shared/types/metrics';
-import { getLeakValue } from '~sq-server-commons/components/measure/utils';
-import { DEFAULT_ISSUES_QUERY } from '~sq-server-commons/components/shared/utils';
-import { findMeasure } from '~sq-server-commons/helpers/measures';
-import { getComponentDrilldownUrl } from '~sq-server-commons/helpers/urls';
-import { getBranchLikeQuery } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
-import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
+import { PullRequest } from '~sq-server-shared/types/branch-like';
+import { MetricKey, MetricType } from '~sq-server-shared/sonar-aligned/types/metrics';
+import { getLeakValue } from '~sq-server-shared/components/measure/utils';
+import { DEFAULT_ISSUES_QUERY } from '~sq-server-shared/components/shared/utils';
+import { findMeasure } from '~sq-server-shared/helpers/measures';
+import { getComponentDrilldownUrl } from '~sq-server-shared/helpers/urls';
+import { getBranchLikeQuery } from '~sq-server-shared/sonar-aligned/helpers/branch-like';
+import { formatMeasure } from '~sq-server-shared/sonar-aligned/helpers/measures';
 import {
   getComponentIssuesUrl,
   getComponentSecurityHotspotsUrl,
-} from '~sq-server-commons/sonar-aligned/helpers/urls';
-import { QualityGateStatusConditionEnhanced } from '~sq-server-commons/types/quality-gates';
-import { Component, MeasureEnhanced, QualityGate } from '~sq-server-commons/types/types';
+} from '~sq-server-shared/sonar-aligned/helpers/urls';
+import { QualityGateStatusConditionEnhanced } from '~sq-server-shared/types/quality-gates';
+import { Component, MeasureEnhanced, QualityGate } from '~sq-server-shared/types/types';
 
 import {
   GridContainer,
   StyleMeasuresCard,
   StyleMeasuresCardRightBorder,
   StyledConditionsCard,
-} from '~sq-server-commons/components/overview/BranchSummaryStyles';
-import FailedConditions from '~sq-server-commons/components/overview/FailedConditions';
-import { IssueMeasuresCardInner } from '~sq-server-commons/components/overview/IssueMeasuresCardInner';
-import MeasuresCardNumber from '~sq-server-commons/components/overview/MeasuresCardNumber';
-import MeasuresCardPercent from '~sq-server-commons/components/overview/MeasuresCardPercent';
+} from '~sq-server-shared/components/overview/BranchSummaryStyles';
+import FailedConditions from '~sq-server-shared/components/overview/FailedConditions';
+import { IssueMeasuresCardInner } from '~sq-server-shared/components/overview/IssueMeasuresCardInner';
+import MeasuresCardNumber from '~sq-server-shared/components/overview/MeasuresCardNumber';
+import MeasuresCardPercent from '~sq-server-shared/components/overview/MeasuresCardPercent';
 import {
   MeasurementType,
-  QGStatusEnum as Status,
+  Status,
   getConditionRequiredLabel,
   getMeasurementMetricKey,
-} from '~sq-server-commons/utils/overview-utils';
+} from '~sq-server-shared/utils/overview-utils';
 
 interface Props {
   component: Component;

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestMetaTopBar.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestMetaTopBar.tsx
@@ -19,12 +19,12 @@
  */
 
 import { useIntl } from 'react-intl';
-import { PullRequest } from '~shared/types/branch-like';
-import { MetricKey, MetricType } from '~shared/types/metrics';
-import { getLeakValue } from '~sq-server-commons/components/measure/utils';
-import { findMeasure } from '~sq-server-commons/helpers/measures';
-import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
-import { MeasureEnhanced } from '~sq-server-commons/types/types';
+import { PullRequest } from '~sq-server-shared/types/branch-like';
+import { MetricKey, MetricType } from '~sq-server-shared/sonar-aligned/types/metrics';
+import { getLeakValue } from '~sq-server-shared/components/measure/utils';
+import { findMeasure } from '~sq-server-shared/helpers/measures';
+import { formatMeasure } from '~sq-server-shared/sonar-aligned/helpers/measures';
+import { MeasureEnhanced } from '~sq-server-shared/types/types';
 import CurrentBranchLikeMergeInformation from '../branch-like/CurrentBranchLikeMergeInformation';
 
 interface Props {

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestOverview.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestOverview.tsx
@@ -20,23 +20,23 @@
 
 import { uniq } from 'lodash';
 import { BasicSeparator, CenteredLayout, PageContentFontWrapper, Spinner } from '~design-system';
-import { isDefined } from '~shared/helpers/types';
-import { PullRequest } from '~shared/types/branch-like';
-import { AnalysisStatus } from '~sq-server-commons/components/overview/AnalysisStatus';
-import IgnoredConditionWarning from '~sq-server-commons/components/overview/IgnoredConditionWarning';
-import LastAnalysisLabel from '~sq-server-commons/components/overview/LastAnalysisLabel';
-import QGStatus from '~sq-server-commons/components/overview/QualityGateStatus';
+import { isDefined } from '~sq-server-shared/helpers/types';
+import { PullRequest } from '~sq-server-shared/types/branch-like';
+import { AnalysisStatus } from '~sq-server-shared/components/overview/AnalysisStatus';
+import IgnoredConditionWarning from '~sq-server-shared/components/overview/IgnoredConditionWarning';
+import LastAnalysisLabel from '~sq-server-shared/components/overview/LastAnalysisLabel';
+import QGStatus from '~sq-server-shared/components/overview/QualityGateStatus';
 import {
   enhanceConditionWithMeasure,
   enhanceMeasuresWithMetrics,
-} from '~sq-server-commons/helpers/measures';
-import { useBranchStatusQuery } from '~sq-server-commons/queries/branch';
-import { useMeasuresComponentQuery } from '~sq-server-commons/queries/measures';
-import { useComponentQualityGateQuery } from '~sq-server-commons/queries/quality-gates';
+} from '~sq-server-shared/helpers/measures';
+import { useBranchStatusQuery } from '~sq-server-shared/queries/branch';
+import { useMeasuresComponentQuery } from '~sq-server-shared/queries/measures';
+import { useComponentQualityGateQuery } from '~sq-server-shared/queries/quality-gates';
 
-import '~sq-server-commons/components/overview/styles.css';
-import { Component } from '~sq-server-commons/types/types';
-import { PR_METRICS } from '~sq-server-commons/utils/overview-utils';
+import '~sq-server-shared/components/overview/styles.css';
+import { Component } from '~sq-server-shared/types/types';
+import { PR_METRICS } from '~sq-server-shared/utils/overview-utils';
 import MeasuresCardPanel from './MeasuresCardPanel';
 import PullRequestMetaTopBar from './PullRequestMetaTopBar';
 import SonarLintAd from './SonarLintAd';

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/SonarLintAd.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/SonarLintAd.tsx
@@ -32,11 +32,11 @@ import {
   SubTitle,
   SubnavigationFlowSeparator,
 } from '~design-system';
-import { QGStatus as Status } from '~shared/types/common';
-import { useCurrentUser } from '~sq-server-commons/context/current-user/CurrentUserContext';
-import useLocalStorage from '~sq-server-commons/hooks/useLocalStorage';
-import { isLoggedIn } from '~sq-server-commons/types/users';
-import { QGStatusEnum as QGStatus } from '~sq-server-commons/utils/overview-utils';
+import { Status } from '~shared/types/common';
+import { useCurrentUser } from '~sq-server-shared/context/current-user/CurrentUserContext';
+import useLocalStorage from '~sq-server-shared/hooks/useLocalStorage';
+import { isLoggedIn } from '~sq-server-shared/types/users';
+import { Status as QGStatus } from '~sq-server-shared/utils/overview-utils';
 
 interface Props {
   status?: Status;


### PR DESCRIPTION
Older versions of sonarqube-webapp have the additional components in an `addons` rather than `sq-server-addons` directory, so the build customisation isn't creating a modified front-end. The project setup has therefore been updated to use the path the webapp expects, and the branch components altered to use the right imports for the target version of Sonarqube. To simplify the plugin versioning, the plugin version has been altered to match the major and minor version of the Sonarqube distribution it's aiming to support.