### PR TITLE
Upgrade to Sonarqube 25.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '25.4.0.105899'
+def sonarqubeVersion = '25.5.0.107428'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/PRLink.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/PRLink.tsx
@@ -19,7 +19,7 @@
  */
 
 import { LinkStandalone } from '@sonarsource/echoes-react';
-import { Image } from '~sq-server-shared/sonar-aligned/components/common/Image';
+import { Image } from '~adapters/components/common/Image';
 import { isDefined } from '~sq-server-shared/helpers/types';
 import { translate, translateWithParameters } from '~sq-server-shared/helpers/l10n';
 import { isPullRequest } from '~sq-server-shared/sonar-aligned/helpers/branch-like';

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
@@ -32,7 +32,7 @@ import {
   TrendUpCircleIcon,
 } from '~design-system';
 import { PullRequest } from '~sq-server-shared/types/branch-like';
-import { MetricKey, MetricType } from '~sq-server-shared/sonar-aligned/types/metrics';
+import { MetricKey, MetricType } from '~shared/types/metrics';
 import { getLeakValue } from '~sq-server-shared/components/measure/utils';
 import { DEFAULT_ISSUES_QUERY } from '~sq-server-shared/components/shared/utils';
 import { findMeasure } from '~sq-server-shared/helpers/measures';
@@ -58,7 +58,7 @@ import MeasuresCardNumber from '~sq-server-shared/components/overview/MeasuresCa
 import MeasuresCardPercent from '~sq-server-shared/components/overview/MeasuresCardPercent';
 import {
   MeasurementType,
-  Status,
+  QGStatusEnum as Status,
   getConditionRequiredLabel,
   getMeasurementMetricKey,
 } from '~sq-server-shared/utils/overview-utils';

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestMetaTopBar.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestMetaTopBar.tsx
@@ -20,7 +20,7 @@
 
 import { useIntl } from 'react-intl';
 import { PullRequest } from '~sq-server-shared/types/branch-like';
-import { MetricKey, MetricType } from '~sq-server-shared/sonar-aligned/types/metrics';
+import { MetricKey, MetricType } from '~shared/types/metrics';
 import { getLeakValue } from '~sq-server-shared/components/measure/utils';
 import { findMeasure } from '~sq-server-shared/helpers/measures';
 import { formatMeasure } from '~sq-server-shared/sonar-aligned/helpers/measures';

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/SonarLintAd.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/SonarLintAd.tsx
@@ -32,11 +32,11 @@ import {
   SubTitle,
   SubnavigationFlowSeparator,
 } from '~design-system';
-import { Status } from '~shared/types/common';
+import { QGSStatus as Status } from '~shared/types/common';
 import { useCurrentUser } from '~sq-server-shared/context/current-user/CurrentUserContext';
 import useLocalStorage from '~sq-server-shared/hooks/useLocalStorage';
 import { isLoggedIn } from '~sq-server-shared/types/users';
-import { Status as QGStatus } from '~sq-server-shared/utils/overview-utils';
+import { QGStatusEnum as QGStatus } from '~sq-server-shared/utils/overview-utils';
 
 interface Props {
   status?: Status;


### PR DESCRIPTION
Upgrades to Sonarqube 25.5 for both front-end and back-end, with the required front-end changes to be compatible with upstream modifications.