### PR TITLE
#897: Truncate report keys when sending to Bitbucket server

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Marvin Wichmann, Michael Clarke
+ * Copyright (C) 2020-2025 Marvin Wichmann, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -116,4 +116,11 @@ public interface BitbucketClient {
      * @throws IOException on any issue submitting the build status
      */
     void submitBuildStatus(String commitSha, BuildStatus buildStatus) throws IOException;
+
+    /**
+     * Perform any clean-up of the report key to make it valid for the Bitbucket API.
+     * @param reportKey the key for the current report
+     * @return the key modified to make it the right length or remove invalid characters
+     */
+    String normaliseReportKey(String reportKey);
 }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Marvin Wichmann, Michael Clarke
+ * Copyright (C) 2020-2025 Marvin Wichmann, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -211,6 +211,11 @@ class BitbucketCloudClient implements BitbucketClient {
         try (Response response = okHttpClient.newCall(req).execute()) {
             validate(response);
         }
+    }
+
+    @Override
+    public String normaliseReportKey(String reportKey) {
+        return reportKey;
     }
 
     void deleteExistingReport(String commit, String reportKey) throws IOException {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Mathias Åhsberg, Michael Clarke
+ * Copyright (C) 2020-2025 Mathias Åhsberg, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -190,6 +190,14 @@ class BitbucketServerClient implements BitbucketClient {
         try (Response response = okHttpClient.newCall(req).execute()) {
             validate(response);
         }
+    }
+
+    @Override
+    public String normaliseReportKey(String reportKey) {
+        if (reportKey.length() <= 50) {
+            return reportKey;
+        }
+        return "t-" + reportKey.substring(reportKey.length() - 48);
     }
 
     public ServerProperties getServerProperties() throws IOException {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Mathias Åhsberg, Michael Clarke
+ * Copyright (C) 2020-2025 Mathias Åhsberg, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -94,7 +94,7 @@ public class BitbucketPullRequestDecorator implements PullRequestBuildStatusDeco
                     analysisDetails.getQualityGateStatus() == QualityGate.Status.OK ? ReportStatus.PASSED : ReportStatus.FAILED
             );
 
-            String reportKey = Boolean.TRUE.equals(projectAlmSettingDto.getMonorepo()) ? analysisDetails.getAnalysisProjectKey() : REPORT_KEY;
+            String reportKey = client.normaliseReportKey(Boolean.TRUE.equals(projectAlmSettingDto.getMonorepo()) ? analysisDetails.getAnalysisProjectKey() : REPORT_KEY);
 
             client.uploadReport(analysisDetails.getCommitSha(), codeInsightsReport, reportKey);
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketCloudClientUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Michael Clarke
+ * Copyright (C) 2021-2025 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -267,5 +267,11 @@ class BitbucketCloudClientUnitTest {
         assertThat(request.url()).hasToString("https://api.bitbucket.org/2.0/repositories/project/repository/commit/commit/statuses/build");
 
         verify(mapper).writeValueAsString(buildStatus);
+    }
+
+    @Test
+    void shouldReturnOriginalKeyFromNormalisation() {
+        assertThat(underTest.normaliseReportKey("MyVeryLongReportKeyThatWon'tBeModifiedByTheNormalisation"))
+                .isEqualTo("MyVeryLongReportKeyThatWon'tBeModifiedByTheNormalisation");
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/BitbucketServerClientUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Michael Clarke
+ * Copyright (C) 2021-2025 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -40,6 +40,8 @@ import okhttp3.ResponseBody;
 import okio.Buffer;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -437,5 +439,15 @@ class BitbucketServerClientUnitTest {
         assertThat(request.url()).hasToString("https://my-server.org/rest/api/1.0/projects/project/repos/repository/commits/commit/builds");
 
         verify(mapper).writeValueAsString(buildStatus);
+    }
+
+    @CsvSource({"shortReportKey, shortReportKey", "fiftyCharactersLongReportKey123456789012, fiftyCharactersLongReportKey123456789012",
+            "moreThanFiftyCharactersLongReportKey12345678901234567890, t-FiftyCharactersLongReportKey12345678901234567890"})
+    @ParameterizedTest
+   void shouldNormaliseReportKeyToFiftyCharacters(String input, String expected) {
+        String result = underTest.normaliseReportKey(input);
+
+        assertThat(result).hasSizeLessThanOrEqualTo(50)
+                .isEqualTo(expected);
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/bitbucket/BitbucketPullRequestDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Mathias Åhsberg, Michael Clarke
+ * Copyright (C) 2020-2025 Mathias Åhsberg, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -105,8 +105,10 @@ class BitbucketPullRequestDecoratorTest {
         when(analysisSummary.getSummaryImageUrl()).thenReturn(IMAGE_URL);
         when(analysisSummary.getDashboardUrl()).thenReturn(DASHBOARD_URL);
         when(reportGenerator.createAnalysisSummary(any())).thenReturn(analysisSummary);
+        when(client.normaliseReportKey(any())).thenReturn("reportKey");
         underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
 
+        verify(client).normaliseReportKey(REPORT_KEY);
         ArgumentCaptor<List<ReportData>> reportDataArgumentCaptor = ArgumentCaptor.captor();
         verify(client).createCodeInsightsAnnotation(ISSUE_KEY, ISSUE_LINE, ISSUE_LINK, ISSUE_MESSAGE, ISSUE_PATH, "HIGH", "BUG");
         verify(client).createLinkDataValue(DASHBOARD_URL);
@@ -115,7 +117,7 @@ class BitbucketPullRequestDecoratorTest {
         when(analysisSummary.getFixedIssues()).thenReturn(new AnalysisSummary.UrlIconMetric<>("fixedIssuesUrl", "fixedIssuesImageUrl", 12));
         when(analysisSummary.getNewIssues()).thenReturn(new AnalysisSummary.UrlIconMetric<>("newIssuesUrl", "newIssuesImageUrl", 666L));
         when(analysisSummary.getSecurityHotspots()).thenReturn(new AnalysisSummary.UrlIconMetric<>("securityHotspotsUrl", "securityHotspotsImageUrl", 69));
-        verify(client).deleteAnnotations(COMMIT, REPORT_KEY);
+        verify(client).deleteAnnotations(COMMIT, "reportKey");
 
         assertThat(reportDataArgumentCaptor.getValue())
                 .usingRecursiveComparison()
@@ -140,17 +142,19 @@ class BitbucketPullRequestDecoratorTest {
         when(analysisSummary.getFixedIssues()).thenReturn(new AnalysisSummary.UrlIconMetric<>("fixedIssuesUrl", "fixedIssuesImageUrl", 1));
         when(analysisSummary.getNewIssues()).thenReturn(new AnalysisSummary.UrlIconMetric<>("newIssuesUrl", "newIssuesImageUrl", 666L));
         when(analysisSummary.getSecurityHotspots()).thenReturn(new AnalysisSummary.UrlIconMetric<>("securityHotspotsUrl", "securityHotspotsImageUrl", 69));
+        when(client.normaliseReportKey(REPORT_KEY)).thenReturn("reportKey");
         underTest.decorateQualityGateStatus(analysisDetails, almSettingDto, projectAlmSettingDto);
 
+        verify(client).normaliseReportKey(REPORT_KEY);
         ArgumentCaptor<List<ReportData>> reportDataArgumentCaptor = ArgumentCaptor.captor();
         verify(client).createCodeInsightsAnnotation(ISSUE_KEY, ISSUE_LINE, ISSUE_LINK, ISSUE_MESSAGE, ISSUE_PATH, "HIGH", "BUG");
         verify(client).createLinkDataValue(DASHBOARD_URL);
         verify(client).createCodeInsightsReport(reportDataArgumentCaptor.capture(), eq("Quality Gate passed" + System.lineSeparator()), any(), eq(DASHBOARD_URL), eq(String.format("%s/common/icon.png", IMAGE_URL)), eq(ReportStatus.PASSED));
-        verify(client).deleteAnnotations(COMMIT, REPORT_KEY);
+        verify(client).deleteAnnotations(COMMIT, "reportKey");
 
         ArgumentCaptor<BuildStatus> buildStatusArgumentCaptor = ArgumentCaptor.captor();
         verify(client).submitBuildStatus(eq(COMMIT), buildStatusArgumentCaptor.capture());
-        assertThat(buildStatusArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(new BuildStatus(BuildStatus.State.SUCCESSFUL, REPORT_KEY, "SonarQube", DASHBOARD_URL));
+        assertThat(buildStatusArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(new BuildStatus(BuildStatus.State.SUCCESSFUL, "reportKey", "SonarQube", DASHBOARD_URL));
 
         assertThat(reportDataArgumentCaptor.getValue())
                 .usingRecursiveComparison()


### PR DESCRIPTION
When using a monorepo with a long project key, Bitbucket server reports an error for the report key being too long during decoration. As the report key is based on the project key which is typically derived from a project's group ID and artefact ID, this may end up being a long value with limited control over setting its length. To overcome this, when sending a report to Bitbucket server, the project key will be truncated where it's more than 50 characters, and prepended with `t-` to make it clear the value was truncated and try and prevent conflicts with any other projects.