### PR TITLE
Upgrade to Sonarqube 25.7

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=25.6.0.109173-community
+SONARQUBE_VERSION=25.7.0.110598-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
-DOCKERFILE=release.Dockerfile
+DOCKERFILE=Dockerfile
 
 # The version of the plugin to include in the image
-PLUGIN_VERSION=25.6.0
+PLUGIN_VERSION=25.7.0-SNAPSHOT

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '25.6.0.109173'
+def sonarqubeVersion = '25.7.0.110598'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=25.6.1
+version=25.7.0-SNAPSHOT

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchLikeRow.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchLikeRow.tsx
@@ -27,7 +27,7 @@ import {
 import * as React from 'react';
 import { ActionCell, Badge, ContentCell, TableRowInteractive } from '~design-system';
 import BranchLikeIcon from '~sq-server-commons/components/icon-mappers/BranchLikeIcon';
-import DateFromNow from '~sq-server-commons/components/intl/DateFromNow';
+import DateFromNow from '~shared/components/intl/DateFromNow';
 import QualityGateStatus from '~sq-server-commons/components/nav/QualityGateStatus';
 import { getBranchLikeDisplayName } from '~sq-server-commons/helpers/branch-like';
 import { translate, translateWithParameters } from '~sq-server-commons/helpers/l10n';
@@ -35,7 +35,7 @@ import {
   isBranch,
   isMainBranch,
   isPullRequest,
-} from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+} from '~shared/helpers/branch-like';
 import { BranchLike } from '~sq-server-commons/types/branch-like';
 import { Component } from '~sq-server-commons/types/types';
 import BranchPurgeSetting from './BranchPurgeSetting';

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchLikeTabs.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchLikeTabs.tsx
@@ -29,7 +29,7 @@ import {
   isBranch,
   isMainBranch,
   isPullRequest,
-} from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+} from '~shared/helpers/branch-like';
 import { Branch, BranchLike } from '~sq-server-commons/types/branch-like';
 import { Component } from '~sq-server-commons/types/types';
 import BranchLikeTable from './BranchLikeTable';

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
@@ -22,7 +22,7 @@ import { HelperHintIcon, Spinner, Switch } from '~design-system';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { useExcludeFromPurgeMutation } from '~sq-server-commons/queries/branch';
 import HelpTooltip from '~sq-server-commons/sonar-aligned/components/controls/HelpTooltip';
-import { isMainBranch } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+import { isMainBranch } from '~shared/helpers/branch-like';
 import { Branch } from '~sq-server-commons/types/branch-like';
 import { Component } from '~sq-server-commons/types/types';
 

--- a/sonarqube-webapp-addons/src/branches/app/components/DeleteBranchModal.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/DeleteBranchModal.tsx
@@ -24,7 +24,7 @@ import { FormattedMessage } from 'react-intl';
 import { Modal } from '~design-system';
 import { getBranchLikeDisplayName } from '~sq-server-commons/helpers/branch-like';
 import { useDeletBranchMutation } from '~sq-server-commons/queries/branch';
-import { isPullRequest } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+import { isPullRequest } from '~shared/helpers/branch-like';
 import { BranchLike } from '~sq-server-commons/types/branch-like';
 import { Component } from '~sq-server-commons/types/types';
 

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/Menu.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/Menu.tsx
@@ -26,8 +26,8 @@ import { getBrancheLikesAsTree, isSameBranchLike } from '~sq-server-commons/help
 import { KeyboardKeys } from '~sq-server-commons/helpers/keycodes';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { getBranchLikeUrl } from '~sq-server-commons/helpers/urls';
-import { withRouter } from '~sq-server-commons/sonar-aligned/components/hoc/withRouter';
-import { isBranch, isPullRequest } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+import { withRouter } from '~shared/components/hoc/withRouter';
+import { isBranch, isPullRequest } from '~shared/helpers/branch-like';
 import { queryToSearchString } from '~sq-server-commons/sonar-aligned/helpers/urls';
 import { BranchLike, BranchLikeTree } from '~sq-server-commons/types/branch-like';
 import { Component } from '~sq-server-commons/types/types';

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItem.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItem.tsx
@@ -25,7 +25,7 @@ import BranchLikeIcon from '~sq-server-commons/components/icon-mappers/BranchLik
 import QualityGateStatus from '~sq-server-commons/components/nav/QualityGateStatus';
 import { getBranchLikeDisplayName } from '~sq-server-commons/helpers/branch-like';
 import { translate } from '~sq-server-commons/helpers/l10n';
-import { isMainBranch } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+import { isMainBranch } from '~shared/helpers/branch-like';
 import { BranchLike } from '~sq-server-commons/types/branch-like';
 
 export interface MenuItemProps {

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/PRLink.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/PRLink.tsx
@@ -22,7 +22,7 @@ import { LinkStandalone } from '@sonarsource/echoes-react';
 import { Image } from '~adapters/components/common/Image';
 import { isDefined } from '~shared/helpers/types';
 import { translate, translateWithParameters } from '~sq-server-commons/helpers/l10n';
-import { isPullRequest } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+import { isPullRequest } from '~shared/helpers/branch-like';
 import { AlmKeys } from '~sq-server-commons/types/alm-settings';
 import { BranchLike } from '~sq-server-commons/types/branch-like';
 import { Component } from '~sq-server-commons/types/types';

--- a/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
@@ -32,7 +32,7 @@ import {
 import { sortBranches } from '~sq-server-commons/helpers/branch-like';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { DEFAULT_NEW_CODE_DEFINITION_TYPE } from '~sq-server-commons/helpers/new-code-definition';
-import { isBranch } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+import { isBranch } from '~shared/helpers/branch-like';
 import { Branch, BranchLike, BranchWithNewCodePeriod } from '~sq-server-commons/types/branch-like';
 import { NewCodeDefinition } from '~sq-server-commons/types/new-code-definition';
 import { Component } from '~sq-server-commons/types/types';

--- a/sonarqube-webapp-addons/src/branches/components/branch-list/BranchListRow.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-list/BranchListRow.tsx
@@ -35,7 +35,7 @@ import {
   TableRowInteractive,
 } from '~design-system';
 import BranchLikeIcon from '~sq-server-commons/components/icon-mappers/BranchLikeIcon';
-import DateTimeFormatter from '~sq-server-commons/components/intl/DateTimeFormatter';
+import DateTimeFormatter from '~shared/components/intl/DateTimeFormatter';
 import { translate, translateWithParameters } from '~sq-server-commons/helpers/l10n';
 import { isNewCodeDefinitionCompliant } from '~sq-server-commons/helpers/new-code-definition';
 import { BranchWithNewCodePeriod } from '~sq-server-commons/types/branch-like';

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/BranchQualityGateConditions.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/BranchQualityGateConditions.tsx
@@ -30,7 +30,7 @@ import {
 import { getLocalizedMetricName, translate } from '~sq-server-commons/helpers/l10n';
 import { getShortType, isDiffMetric } from '~sq-server-commons/helpers/measures';
 import { getComponentDrilldownUrl } from '~sq-server-commons/helpers/urls';
-import { getBranchLikeQuery } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+import { getBranchLikeQuery } from '~shared/helpers/branch-like';
 import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
 import {
   getComponentIssuesUrl,

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
@@ -37,14 +37,15 @@ import { getLeakValue } from '~sq-server-commons/components/measure/utils';
 import { DEFAULT_ISSUES_QUERY } from '~sq-server-commons/components/shared/utils';
 import { findMeasure } from '~sq-server-commons/helpers/measures';
 import { getComponentDrilldownUrl } from '~sq-server-commons/helpers/urls';
-import { getBranchLikeQuery } from '~sq-server-commons/sonar-aligned/helpers/branch-like';
+import { getBranchLikeQuery } from '~shared/helpers/branch-like';
 import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
 import {
   getComponentIssuesUrl,
   getComponentSecurityHotspotsUrl,
 } from '~sq-server-commons/sonar-aligned/helpers/urls';
 import { QualityGateStatusConditionEnhanced } from '~sq-server-commons/types/quality-gates';
-import { Component, MeasureEnhanced, QualityGate } from '~sq-server-commons/types/types';
+import { Component, QualityGate } from '~sq-server-commons/types/types';
+import { MeasureEnhanced } from '~shared/types/measures';
 
 import {
   GridContainer,

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestMetaTopBar.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestMetaTopBar.tsx
@@ -24,7 +24,7 @@ import { MetricKey, MetricType } from '~shared/types/metrics';
 import { getLeakValue } from '~sq-server-commons/components/measure/utils';
 import { findMeasure } from '~sq-server-commons/helpers/measures';
 import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
-import { MeasureEnhanced } from '~sq-server-commons/types/types';
+import { MeasureEnhanced } from '~shared/types/measures';
 import CurrentBranchLikeMergeInformation from '../branch-like/CurrentBranchLikeMergeInformation';
 
 interface Props {

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestOverview.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestOverview.tsx
@@ -31,7 +31,7 @@ import {
   enhanceMeasuresWithMetrics,
 } from '~sq-server-commons/helpers/measures';
 import { useBranchStatusQuery } from '~sq-server-commons/queries/branch';
-import { useMeasuresComponentQuery } from '~sq-server-commons/queries/measures';
+import { useMeasuresComponentQuery } from '~adapters/queries/measures';
 import { useComponentQualityGateQuery } from '~sq-server-commons/queries/quality-gates';
 
 import '~sq-server-commons/components/overview/styles.css';


### PR DESCRIPTION
Upgrades to Sonarqube 25.7 for both front-end and back-end. As the front-end repository does not contain a tag aligned to the 25.7 release, the last commit from the day of the current front-end release has been used for the webapp submodule.