### PR TITLE
Upgrade to Sonarqube 25.8

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=25.7.0.110598-community
+SONARQUBE_VERSION=25.8.0.112029-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
-DOCKERFILE=release.Dockerfile
+DOCKERFILE=Dockerfile
 
 # The version of the plugin to include in the image
-PLUGIN_VERSION=25.7.0
+PLUGIN_VERSION=25.8.0-SNAPSHOT

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '25.7.0.110598'
+def sonarqubeVersion = '25.8.0.112029'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=25.7.1
+version=25.8.0-SNAPSHOT


### PR DESCRIPTION
Updates to the 25.8 backend and front-end, with no additional changes required for plugin compatibility.