### PR TITLE
#1133: Add support for disabling inline comments in Azure decoration

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Markus Heberling, Michael Clarke
+ * Copyright (C) 2020-2025 Markus Heberling, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -79,6 +80,11 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
     @Override
     public List<ALM> alm() {
         return Collections.singletonList(ALM.AZURE_DEVOPS);
+    }
+
+    @Override
+    protected boolean isInlineCommentsEnabled(ProjectAlmSettingDto projectAlmSettingDto) {
+        return Objects.requireNonNullElse(projectAlmSettingDto.getInlineAnnotationsEnabled(), true);
     }
 
     @Override

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Markus Heberling, Michael Clarke
+ * Copyright (C) 2020-2025 Markus Heberling, Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -65,6 +65,11 @@ public class GitlabMergeRequestDecorator extends DiscussionAwarePullRequestDecor
     @Override
     public List<ALM> alm() {
         return Collections.singletonList(ALM.GITLAB);
+    }
+
+    @Override
+    protected boolean isInlineCommentsEnabled(ProjectAlmSettingDto projectAlmSettingDto) {
+        return true;
     }
 
     @Override

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/SetAzureBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/SetAzureBindingAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2025 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,6 +18,8 @@
  */
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.binding.action;
 
+import java.util.Objects;
+
 import org.sonar.api.server.ws.Request;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
@@ -29,6 +31,7 @@ public class SetAzureBindingAction extends SetBindingAction {
 
     private static final String PROJECT_NAME_PARAMETER = "projectName";
     private static final String REPOSITORY_NAME_PARAMETER = "repositoryName";
+    private static final String INLINE_ANNOTATIONS_ENABLED_PARAMETER = "inlineAnnotationsEnabled";
 
     public SetAzureBindingAction(DbClient dbClient, ComponentFinder componentFinder, UserSession userSession) {
         super(dbClient, componentFinder, userSession, "set_azure_binding");
@@ -40,6 +43,7 @@ public class SetAzureBindingAction extends SetBindingAction {
         super.configureAction(action);
         action.createParam(REPOSITORY_NAME_PARAMETER).setRequired(true).setMaximumLength(256);
         action.createParam(PROJECT_NAME_PARAMETER).setRequired(true).setMaximumLength(256);
+        action.createParam(INLINE_ANNOTATIONS_ENABLED_PARAMETER).setBooleanPossibleValues().setDefaultValue(true);
     }
 
     @Override
@@ -50,7 +54,8 @@ public class SetAzureBindingAction extends SetBindingAction {
                 .setAlmSettingUuid(settingsUuid)
                 .setAlmRepo(request.mandatoryParam(REPOSITORY_NAME_PARAMETER))
                 .setAlmSlug(request.mandatoryParam(PROJECT_NAME_PARAMETER))
-                .setMonorepo(monoRepo);
+                .setMonorepo(monoRepo)
+                .setInlineAnnotationsEnabled(Objects.requireNonNullElse(request.paramAsBoolean(INLINE_ANNOTATIONS_ENABLED_PARAMETER), true));
     }
 
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/SetAzureBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/SetAzureBindingActionTest.java
@@ -63,6 +63,11 @@ class SetAzureBindingActionTest {
         when(monoRepoParameter.setRequired(anyBoolean())).thenReturn(monoRepoParameter);
         when(newAction.createParam("monorepo")).thenReturn(monoRepoParameter);
 
+        WebService.NewParam inlineAnnotationsParameter = mock();
+        when(inlineAnnotationsParameter.setBooleanPossibleValues()).thenReturn(inlineAnnotationsParameter);
+        when(inlineAnnotationsParameter.setDefaultValue(any())).thenReturn(inlineAnnotationsParameter);
+        when(newAction.createParam("inlineAnnotationsEnabled")).thenReturn(inlineAnnotationsParameter);
+
         SetAzureBindingAction testCase = new SetAzureBindingAction(dbClient, componentFinder, userSession);
         testCase.configureAction(newAction);
 
@@ -71,6 +76,7 @@ class SetAzureBindingActionTest {
         verify(projectNameParameter).setRequired(true);
         verify(almSettingParameter).setRequired(true);
         verify(monoRepoParameter).setRequired(true);
+        verify(inlineAnnotationsParameter).setBooleanPossibleValues();
         verify(monoRepoParameter).setBooleanPossibleValues();
     }
 
@@ -83,11 +89,12 @@ class SetAzureBindingActionTest {
         Request request = mock();
         when(request.mandatoryParam("repositoryName")).thenReturn("repository");
         when(request.mandatoryParam("projectName")).thenReturn("project");
+        when(request.paramAsBoolean("inlineAnnotationsEnabled")).thenReturn(true);
 
         SetAzureBindingAction testCase = new SetAzureBindingAction(dbClient, componentFinder, userSession);
         ProjectAlmSettingDto result = testCase.createProjectAlmSettingDto("projectUuid", "settingsUuid", true, request);
 
-        assertThat(result).usingRecursiveComparison().isEqualTo(new ProjectAlmSettingDto().setProjectUuid("projectUuid").setAlmSettingUuid("settingsUuid").setAlmRepo("repository").setAlmSlug("project").setMonorepo(true));
+        assertThat(result).usingRecursiveComparison().isEqualTo(new ProjectAlmSettingDto().setProjectUuid("projectUuid").setAlmSettingUuid("settingsUuid").setAlmRepo("repository").setAlmSlug("project").setMonorepo(true).setInlineAnnotationsEnabled(true));
 
     }
 }


### PR DESCRIPTION
Sonarqube provides a toggle in the front-end to disable inline comments on Azure DevOps repository decoration. This parameter was being ignored in the endpoint handling, and the decorator did not check for the value in the project settings, so the configured value was ignored and inline comments were treated as always being enabled. The Azure bindings endpoints has been altered to parse the `inlineAnnotationsEnabled` parameter and save it in the project settings, and the Azure decorator modified to check this parameter before performing any operations on inline comments in a Pull request.