### PR TITLE
style: adjust MenuItem margin to separate main branch badge and quality gate status

### DIFF
--- a/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItem.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItem.tsx
@@ -50,7 +50,7 @@ export function MenuItem(props: Readonly<MenuItemProps>) {
       }}
     >
       <div className="sw-flex sw-items-center sw-justify-between sw-truncate sw-flex-1">
-        <div className="sw-flex sw-items-center">
+        <div className="sw-flex sw-items-center sw-mr-2">
           <BranchLikeIcon branchLike={branchLike} />
 
           {isMainBranch(branchLike) && (
@@ -60,7 +60,7 @@ export function MenuItem(props: Readonly<MenuItemProps>) {
             </>
           )}
           {!isMainBranch(branchLike) && (
-            <Text className="sw-ml-3 sw-mr-2" isSubtle>{displayName}</Text>
+            <Text className="sw-ml-3" isSubtle>{displayName}</Text>
           )}
         </div>
         <QualityGateStatus


### PR DESCRIPTION
This pull request makes a small UI adjustment to the `MenuItem` component in the branches section. The change tweaks the spacing between elements to ensure a more consistent and visually appealing layout.

- UI spacing adjustments:
  * Added a right margin (`sw-mr-2`) to the container holding the branch icon and display name for better separation from the quality gate status.
  * Removed an extra right margin (`sw-mr-2`) from the `Text` component displaying the branch name when it is not the main branch, preventing excessive spacing.


#### Images (Before/After)
<img width="291" height="195" alt="Bildschirmfoto 2026-02-26 um 01 00 53" src="https://github.com/user-attachments/assets/e31a3a21-7c37-4ed4-aaa7-b2108fc47297" />
<img width="299" height="195" alt="Bildschirmfoto 2026-02-26 um 01 00 39" src="https://github.com/user-attachments/assets/ec176309-dce1-42c1-9075-32a9d32a5171" />
