### PR TITLE
Fix authorization bypass in ProjectWsAction and DeleteAction

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/ProjectWsAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/ProjectWsAction.java
@@ -69,7 +69,7 @@ public abstract class ProjectWsAction implements AlmSettingsWsAction {
 
         try (DbSession dbSession = dbClient.openSession(false)) {
             ProjectDto project = componentFinder.getProjectByKey(dbSession, projectKey);
-            userSession.hasEntityPermission(permission, project);
+            userSession.checkEntityPermission(permission, project);
             handleProjectRequest(project, request, response, dbSession);
         }
     }

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/DeleteAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/DeleteAction.java
@@ -53,7 +53,7 @@ public class DeleteAction extends ProjectWsAction {
 
     @Override
     public void handleProjectRequest(ProjectDto project, Request request, Response response, DbSession dbSession) {
-        userSession.checkLoggedIn().hasEntityPermission(ProjectPermission.ADMIN, project);
+        userSession.checkLoggedIn().checkEntityPermission(ProjectPermission.ADMIN, project);
 
         String pullRequestId = request.mandatoryParam(PULL_REQUEST_PARAMETER);
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/DeleteBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/DeleteBindingActionTest.java
@@ -90,7 +90,7 @@ class DeleteBindingActionTest {
         verify(dbSession).commit();
         verify(projectAlmSettingDao).deleteByProject(dbSession, componentDto);
         verify(response).noContent();
-        verify(userSession).hasEntityPermission(ProjectPermission.ADMIN, componentDto);
+        verify(userSession).checkEntityPermission(ProjectPermission.ADMIN, componentDto);
 
     }
 

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/ValidateBindingActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/ValidateBindingActionTest.java
@@ -203,6 +203,6 @@ class ValidateBindingActionTest {
         underTest.handle(request, response);
 
         verify(validator).validate(projectAlmSettingDto, almSettingDto);
-        verify(userSession).hasEntityPermission(ProjectPermission.USER, projectDto);
+        verify(userSession).checkEntityPermission(ProjectPermission.USER, projectDto);
     }
 }

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/DeleteActionTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/pullrequest/action/DeleteActionTest.java
@@ -130,7 +130,7 @@ class DeleteActionTest {
         when(componentFinder.getProjectByKey(any(), any())).thenReturn(new ProjectDto().setKey("projectKey").setUuid("uuid0"));
 
         when(userSession.checkLoggedIn()).thenReturn(userSession);
-        when(userSession.hasEntityPermission(any(), any(EntityDto.class))).thenThrow(new UnauthorizedException("Dummy"));
+        when(userSession.checkEntityPermission(any(), any(EntityDto.class))).thenThrow(new UnauthorizedException("Dummy"));
 
         Response response = mock();
 


### PR DESCRIPTION
👋🏻 Hello! I was just about to add this awesome looking project to my SonarQube Community install (thanks for your work!) and noticed a couple of issues on the security scan. Please let me know if I've missed a contributor step or, of course, if it's totally wrong and I should just close this and we can all forget I was ever here.

Issue: `hasEntityPermission()` returns a boolean that was silently discarded, meaning permission checks were never enforced. Replaced here with `checkEntityPermission()` which throws on failure.