### PR TITLE
Fix duplicated code snippet in Azure DevOps PR decoration

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/azuredevops/AzureDevOpsPullRequestDecorator.java
@@ -166,12 +166,12 @@ public class AzureDevOpsPullRequestDecorator extends DiscussionAwarePullRequestD
         try {
             CreateCommentRequest comment = new CreateCommentRequest(analysisIssueSummary.format(markdownFormatterFactory));
             CommentPosition fileStart = new CommentPosition(
-                    location.getTextRange().getEndLine(),
-                    location.getTextRange().getEndOffset() + 1
-            );
-            CommentPosition fileEnd = new CommentPosition(
                     location.getTextRange().getStartLine(),
                     location.getTextRange().getStartOffset() + 1
+            );
+            CommentPosition fileEnd = new CommentPosition(
+                    location.getTextRange().getEndLine(),
+                    location.getTextRange().getEndOffset() + 1
             );
             String file = filePath.startsWith("/") ? filePath : "/" + filePath;
             CommentThreadContext commentThreadContext = new CommentThreadContext(file, fileStart, fileEnd);


### PR DESCRIPTION
Swapped the start and end positions of the comment text range. In Azure DevOps, providing a range where the end comes before the start (or is identical in a way that confuses the UI) can cause the PR decoration to duplicate the code snippet in the comment.

Tested [here](https://dev.azure.com/casuffitsharp/TesteSQ/_git/TesteSQ/pullrequest/17)

Fixes #1213