### PR TITLE
fix(pr-overview): restore grid layout lost in plugin webapp buil

### DIFF
--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestOverview.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestOverview.tsx
@@ -32,6 +32,7 @@ import IgnoredConditionWarning from '~sq-server-commons/components/overview/Igno
 import LastAnalysisLabel from '~sq-server-commons/components/overview/LastAnalysisLabel';
 import QGStatus from '~sq-server-commons/components/overview/QualityGateStatus';
 import '~sq-server-commons/components/overview/styles.css';
+import './pr-overview-fix.css';
 import { useAvailableFeatures } from '~sq-server-commons/context/available-features/withAvailableFeatures';
 import {
   enhanceConditionWithMeasure,

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/pr-overview-fix.css
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/pr-overview-fix.css
@@ -1,0 +1,97 @@
+/*
+ * SonarQube Community Branch Plugin
+ * PR Overview Layout Fix
+ *
+ * Restores layout styles that are lost during the plugin webapp build.
+ *
+ * Background:
+ *   MeasuresCardPanel uses Emotion styled components (GridContainer,
+ *   StyleMeasuresCard, StyleMeasuresCardRightBorder, StyledConditionsCard)
+ *   defined in sonarqube-webapp/libs/shared/src/components/overview/
+ *   BranchSummaryStyles.tsx. These declare `display:grid`, column templates,
+ *   and `:before` / `:after` separator borders.
+ *
+ *   In the vanilla SonarQube build, Emotion's Babel plugin emits full CSS
+ *   rules for these styled components. In the plugin's re-packaged webapp
+ *   build (which overlays sonarqube-webapp-addons as a symlink under
+ *   sonarqube-webapp/libs/sq-server-addons with preserveSymlinks:true),
+ *   the emitted CSS for these classes contains only `overflow:hidden` and
+ *   `position:relative` - the grid declarations, row/column gaps, and
+ *   border pseudo-elements are dropped.
+ *
+ *   The observed DOM has the expected Tailwind classes
+ *   (js-summary sw-grid-cols-3) plus the empty Emotion classes
+ *   (css-1abqi5m eyk7lnq3, css-11hhga6 eyk7lnq2, etc.), but the computed
+ *   `display` is neither grid nor flex and the cards collapse into a
+ *   stacked single column with overlapping text.
+ *
+ * Fix:
+ *   Apply the missing layout rules via a static CSS file that is imported
+ *   from PullRequestOverview.tsx. Targets only the PR overview container
+ *   (.it__pr-overview + .js-summary) so main branch Overview is untouched.
+ */
+
+/* Outer 12-column grid - restore from GridContainer base rules */
+.it__pr-overview.sw-grid.sw-grid-cols-12 {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  column-gap: 1.5rem;
+  row-gap: 2rem;
+}
+
+/* The .js-summary inner container - restore grid layout and enable
+ * Tailwind sw-grid-cols-3 / sw-grid-cols-4 to work by ensuring the
+ * parent is display:grid */
+.js-summary {
+  display: grid;
+  column-gap: 1.5rem;
+  row-gap: 2rem;
+}
+
+.js-summary.sw-grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.js-summary.sw-grid-cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+/* Each direct child of .js-summary is a StyleMeasuresCard /
+ * StyleMeasuresCardRightBorder / StyledConditionsCard wrapper.
+ * Ensure min-width:0 so grid cells do not overflow. */
+.js-summary > div {
+  min-width: 0;
+  box-sizing: border-box;
+  position: relative;
+}
+
+/* Restore the right separator border that Emotion :before pseudo-element
+ * would normally render (StyleMeasuresCard, StyleMeasuresCardRightBorder,
+ * StyledConditionsCard all have the same :before rule). */
+.js-summary > div:not(:last-child)::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: -0.75rem; /* column-gap / -2 */
+  height: 100%;
+  width: 1px;
+  background: var(--echoes-color-border-weak, rgba(0, 0, 0, 0.08));
+}
+
+/* Ignore the :after bottom-border rule - it used `width: 100vw` which was
+ * buggy anyway (it overflows the container on narrow viewports). The grid
+ * row-gap already provides visual separation between rows. */
+
+/* Hide any <rect> with negative dimensions, which otherwise produces
+ * "A negative value is not valid" console errors during initial layout
+ * measurement of rating donut SVGs inside the PR overview. */
+.it__pr-overview svg rect[width^="-"],
+.it__pr-overview svg rect[height^="-"] {
+  display: none;
+}
+
+/* Standard flexbox min-width:0 hardening - ensure nested sw-flex children
+ * inside the PR overview never overflow their grid cells. */
+.it__pr-overview [class*="sw-flex"] > * {
+  min-width: 0;
+}


### PR DESCRIPTION
## Problem

On the Pull Request Overview page in the plugin-repacked webapp, the six measure cards (New issues, Accepted, Fixed, Coverage, Duplications, Security Hotspots) collapse into a single stacked column instead of forming a grid. The main branch Overview of the same project renders correctly.

## Root cause

`MeasuresCardPanel` uses Emotion styled components defined in `sonarqube-webapp/libs/shared/src/components/overview/BranchSummaryStyles.tsx`:

- `GridContainer` — declares `display: grid` and `grid-template-columns: repeat(12, minmax(0, 1fr))`
- `StyleMeasuresCard`, `StyleMeasuresCardRightBorder`, `StyledConditionsCard` — declare `:before` / `:after` separator borders

In the vanilla SonarQube build these are emitted correctly. In this plugin's addon-merge build (`sonarqube-webapp-addons` symlinked under `sonarqube-webapp/libs/sq-server-addons` with `preserveSymlinks: true` via `sonarqube-webapp-addons/setup.sh`), the resulting CSS for these Emotion classes contains only `overflow:hidden` and `position:relative`. The grid declarations, row/column gaps and `:before` pseudo-elements are dropped.

DOM observed after an analysis of a PR (SonarQube 26.3.0.120487 Community Build + plugin 26.3.0):

```html
<div class="it__pr-overview sw-mt-12 sw-mb-8 sw-grid sw-grid-cols-12 ... css-iazbj4 e9als040" data-component="pull-request-overview">
  ...
  <div class="sw-relative sw-overflow-hidden js-summary sw-grid-cols-3 css-1abqi5m eyk7lnq3">
    <div class="css-11hhga6 eyk7lnq2">...</div>
    <div class="css-11hhga6 eyk7lnq2">...</div>
    <div class="css-11hhga6 eyk7lnq2">...</div>
    <div class="css-wvouw8 eyk7lnq1">...</div>
    <div class="css-wvouw8 eyk7lnq1">...</div>
    <div>...</div>
  </div>
```

The computed `display` on `.js-summary` is neither `grid` nor `flex`, so all six children stack vertically and overlap.

The underlying cause appears to be that when an Emotion `styled.div` base definition lives in the submoduled `sonarqube-webapp` and the styled component is consumed from a `sonarqube-webapp-addons` file, the template-literal base rules are not preserved through the build — only the class name is.

## Fix

Add a small static CSS file scoped to `.it__pr-overview` / `.js-summary` that restores the missing layout rules:

- `display: grid` on `.it__pr-overview.sw-grid.sw-grid-cols-12` with 12-col template and gaps
- `display: grid` on `.js-summary` with 3- / 4-col templates (matching the Tailwind classes the component already sets)
- `min-width: 0` on `.js-summary > div` so grid cells do not overflow
- `:before` separator borders on non-last children (restores `StyleMeasuresCard:before` behavior)
- Hides SVG `<rect>` elements with negative width/height (a minor symptom — rating donuts briefly measure with `width="-60"` / `height="-76"` before re-layout, producing console errors)
- `min-width: 0` on `sw-flex` children within `.it__pr-overview` (flexbox hardening)

The CSS file is imported from `PullRequestOverview.tsx` so it only loads on the PR overview page and does not affect the main branch Overview.

## Testing

Tested against SonarQube 26.3.0.120487 Community Build with plugin 26.3.0 running in Kubernetes. Before the fix all PR overview cards collapsed into a vertical stack with overlapping labels. After the fix the cards render in the expected grid layout with separator borders, matching the main branch Overview.

## Files changed

- `sonarqube-webapp-addons/src/branches/components/pull-requests/pr-overview-fix.css` (new)
- `sonarqube-webapp-addons/src/branches/components/pull-requests/PullRequestOverview.tsx` (add import)
