### PR TITLE
Expose a parameter to allow configuring inline annotations for GitLab

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/gitlab/GitlabMergeRequestDecorator.java
@@ -44,6 +44,7 @@ import org.sonar.db.alm.setting.ProjectAlmSettingDto;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class GitlabMergeRequestDecorator extends DiscussionAwarePullRequestDecorator<GitlabClient, MergeRequest, User, Discussion, Note> {
@@ -68,7 +69,7 @@ public class GitlabMergeRequestDecorator extends DiscussionAwarePullRequestDecor
 
     @Override
     protected boolean isInlineCommentsEnabled(ProjectAlmSettingDto projectAlmSettingDto) {
-        return true;
+        return Objects.requireNonNullElse(projectAlmSettingDto.getInlineAnnotationsEnabled(), true);
     }
 
     @Override

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/SetGitlabBindingAction.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/server/pullrequest/ws/binding/action/SetGitlabBindingAction.java
@@ -18,6 +18,8 @@
  */
 package com.github.mc1arke.sonarqube.plugin.server.pullrequest.ws.binding.action;
 
+import java.util.Objects;
+
 import org.sonar.api.server.ws.Request;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
@@ -27,6 +29,7 @@ import org.sonar.server.user.UserSession;
 
 public class SetGitlabBindingAction extends SetBindingAction {
     private static final String REPOSITORY_PARAMETER = "repository";
+    private static final String INLINE_ANNOTATIONS_ENABLED_PARAMETER = "inlineAnnotationsEnabled";
 
     public SetGitlabBindingAction(DbClient dbClient, ComponentFinder componentFinder, UserSession userSession) {
         super(dbClient, componentFinder, userSession, "set_gitlab_binding");
@@ -36,6 +39,7 @@ public class SetGitlabBindingAction extends SetBindingAction {
     protected void configureAction(WebService.NewAction action) {
         super.configureAction(action);
         action.createParam(REPOSITORY_PARAMETER);
+        action.createParam(INLINE_ANNOTATIONS_ENABLED_PARAMETER).setBooleanPossibleValues().setDefaultValue(false);
     }
 
     @Override
@@ -45,7 +49,8 @@ public class SetGitlabBindingAction extends SetBindingAction {
                 .setProjectUuid(projectUuid)
                 .setAlmSettingUuid(settingsUuid)
                 .setAlmRepo(request.param(REPOSITORY_PARAMETER))
-                .setMonorepo(monoRepo);
+                .setMonorepo(monoRepo)
+                .setInlineAnnotationsEnabled(Objects.requireNonNullElse(request.paramAsBoolean(INLINE_ANNOTATIONS_ENABLED_PARAMETER), false));
     }
 
 }


### PR DESCRIPTION
After our GitLab server tried to send me about 400 e-mails for a single merge request, I wanted to be able to configure inline comments as it is possible for Azure.
The implementation should also be equivalent to the Azure one.

Unfortunately I have not found an easy way to expose this to UI. If there is one, I am happy to implement it!

It can be set via the API however, which I think is better than nothing.