### PR TITLE
Quick fix for scrolling inside the Branch & PR page

### DIFF
--- a/sonarqube-webapp-addons/src/branches/app/ProjectBranchesApp.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/ProjectBranchesApp.tsx
@@ -37,7 +37,7 @@ function ProjectBranchesApp(props: ProjectBranchesAppProps) {
   const { component, fetchComponent } = props;
 
   return (
-    <div id="project-branch-like" className="sw-mx-auto sw-max-w-[1680px]">
+    <div id="project-branch-like" className="sw-mx-auto sw-max-w-[1680px] sw-overflow-y-auto">
       <PageContentFontWrapper className="sw-my-8 sw-typo-default">
         <header className="sw-mb-5">
           <Helmet defer={false} title={translate('project_branch_pull_request.page')} />


### PR DESCRIPTION
Fixes #1245 

This isn't the best solution since this also adds a potential `overflow-y: auto` for the dropdown (if it would ever have a ton of items) since the component is being used for the dropdown and the page and it also doesn't look that good but it fixes the issue for users. 

<img width="2791" height="1327" alt="image" src="https://github.com/user-attachments/assets/1cf62b8f-1a98-416f-a9c5-bb45fb8b3d18" />

Best case scenario would be rebuilding the whole branches component and having a dedicated branch page. 