### PR TITLE
Add support for Sonarqube 26.7

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=26.5.0.122743-community
+SONARQUBE_VERSION=26.7.0.124771-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile
 
 # The version of the plugin to include in the image
-PLUGIN_VERSION=26.6.0-SNAPSHOT
+PLUGIN_VERSION=26.7.0-SNAPSHOT

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '26.5.0.122743'
+def sonarqubeVersion = '26.7.0.124771'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=26.6.0-SNAPSHOT
+version=26.7.0-SNAPSHOT

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
@@ -18,7 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { HelperHintIcon, Spinner } from '~design-system';
+import { Spinner } from '@sonarsource/echoes-react';
+import { HelperHintIcon } from '~design-system';
 import { Switch } from '~adapters/components/common/Switch';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { useExcludeFromPurgeMutation } from '~sq-server-commons/queries/branch';
@@ -51,7 +52,7 @@ export default function BranchPurgeSetting(props: Props) {
         onChange={handleOnChange}
         value={branch.excludedFromPurge}
       />
-      <Spinner loading={isPending} className="sw-ml-1" />
+      <Spinner isLoading={isPending} className="sw-ml-1" />
       {isTheMainBranch && (
         <HelpTooltip
           className="sw-ml-1"

--- a/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformationRenderer.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformationRenderer.tsx
@@ -18,9 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Spinner } from '@sonarsource/echoes-react';
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Link, Spinner } from '~design-system';
+import { Link } from '~design-system';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
 
@@ -34,7 +35,7 @@ function LifetimeInformationRenderer(props: LifetimeInformationRendererProps) {
   const { branchAndPullRequestLifeTimeInDays, canAdmin, loading } = props;
 
   return (
-    <Spinner loading={loading}>
+    <Spinner isLoading={loading}>
       {branchAndPullRequestLifeTimeInDays && (
         <p>
           <FormattedMessage

--- a/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
@@ -18,8 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Spinner } from '@sonarsource/echoes-react';
 import * as React from 'react';
-import { ActionCell, ContentCell, Spinner, Table, TableRow } from '~design-system';
+import { ActionCell, ContentCell, Table, TableRow } from '~design-system';
 import {
   listBranchesNewCodeDefinition,
   resetNewCodeDefinition,
@@ -163,7 +164,7 @@ export default class BranchList extends React.PureComponent<Props, State> {
     }
 
     if (loading) {
-      return <Spinner />;
+      return <Spinner isLoading />;
     }
 
     const header = (

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensorTest.java
@@ -18,65 +18,48 @@
  */
 package com.github.mc1arke.sonarqube.plugin.scanner;
 
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabMergeRequestDecorator;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.System2;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ScannerPullRequestPropertySensorTest {
 
     private final System2 system2 = mock();
+    private final SensorContext context = mock();
     private final ScannerPullRequestPropertySensor sensor = new ScannerPullRequestPropertySensor(system2);
 
     @Test
-    void testPropertySensorWithGitlabCIEnvValues() throws IOException {
-        
-        Path temp = Files.createTempDirectory("sensor");
-
-        DefaultInputFile inputFile = new TestInputFileBuilder("foo", "src/Foo.xoo").initMetadata("a\nb\nc\nd\ne\nf\ng\nh\ni\n").build();
-        SensorContextTester context = SensorContextTester.create(temp);
-        context.fileSystem().add(inputFile);        
-
+    void testPropertySensorWithGitlabCIEnvValues() {
         when(system2.envVariable("GITLAB_CI")).thenReturn("true");
         when(system2.envVariable("CI_API_V4_URL")).thenReturn("value");
         when(system2.envVariable("CI_PROJECT_PATH")).thenReturn("value");
         when(system2.envVariable("CI_MERGE_REQUEST_PROJECT_URL")).thenReturn("value");
-        when(system2.envVariable("CI_PIPELINE_ID")).thenReturn("value");        
+        when(system2.envVariable("CI_PIPELINE_ID")).thenReturn("value");
 
         sensor.execute(context);
 
-        Map<String, String> properties = context.getContextProperties();
-
-        assertThat(properties).hasSize(2);
-    }    
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, "value");
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, "value");
+        verify(context, times(2)).addContextProperty(anyString(), anyString());
+    }
 
     @Test
-    void testPropertySensorWithGitlabEnvValues() throws IOException {
-        
-        Path temp = Files.createTempDirectory("sensor");
-
-        DefaultInputFile inputFile = new TestInputFileBuilder("foo", "src/Foo.xoo").initMetadata("a\nb\nc\nd\ne\nf\ng\nh\ni\n").build();
-        SensorContextTester context = SensorContextTester.create(temp);
-        context.fileSystem().add(inputFile);        
-
+    void testPropertySensorWithGitlabEnvValues() {
         when(system2.envVariable("GITLAB_CI")).thenReturn("true");
         when(system2.envVariable("CI_MERGE_REQUEST_PROJECT_URL")).thenReturn("value");
         when(system2.envVariable("CI_PIPELINE_ID")).thenReturn("value");
 
         sensor.execute(context);
 
-        Map<String, String> properties = context.getContextProperties();
-
-        assertThat(properties).hasSize(2);
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, "value");
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, "value");
+        verify(context, times(2)).addContextProperty(anyString(), anyString());
     }
 }


### PR DESCRIPTION
Closes #1277

Adds support for SonarQube Community Build 26.7 (26.7.0.124771).

Bumped the `sonarqubeVersion` in build.gradle, the .env defaults, and gradle.properties dev version. Skipped 26.6 entirely since no plugin release ever went out for it, so this jumps straight from 26.5.1 to 26.7.

One thing worth flagging for review: SonarSource hasn't tagged a 26.7 webapp snapshot yet (no `sqcb-26.7.0`), and 26.7's release notes are backend-only anyway, so I pinned the `sonarqube-webapp` submodule to `sqcb-26.6.0` instead of leaving it stale or pointing at `master` (which is tracking their internal 2026.x versioning and isn't compatible here).

Also had to fix `ScannerPullRequestPropertySensorTest`, it wouldn't compile anymore. `SensorContextTester` and `TestInputFileBuilder` got removed from the server distribution somewhere between 26.5 and 26.7. Rewrote it against a mocked `SensorContext` instead, same assertions, no changes needed on the production side.

Tested locally end to end: `./gradlew clean build` and the full test suite pass, and I ran it against a live 26.7 instance via docker-compose, plugin loads clean on both web and CE, and branch/PR analysis worked in my testing.

Happy to re-point the webapp submodule once SonarSource ships a 26.7 tag, if that's preferred over merging with the 26.6 one.
