### PR TITLE
Prevent Bitbucket Cloud OAuth credentials from being written to debug logs

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/bitbucket/DefaultBitbucketClientFactory.java
@@ -70,7 +70,7 @@ public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
                     .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "Client ID must be set in configuration"));
             String clientSecret = Optional.ofNullable(StringUtils.trimToNull(almSettingDto.getDecryptedClientSecret(settings.getEncryption())))
                     .orElseThrow(() -> new InvalidConfigurationException(InvalidConfigurationException.Scope.GLOBAL, "Client Secret must be set in configuration"));
-            String bearerToken = BitbucketCloudClient.negotiateBearerToken(clientId, clientSecret, objectMapper, clientBuilder.build());
+            String bearerToken = BitbucketCloudClient.negotiateBearerToken(clientId, clientSecret, objectMapper, httpClientBuilderFactory.createClientBuilder().build());
             return new BitbucketCloudClient(objectMapper, createAuthorisingClient(clientBuilder, bearerToken), new BitbucketConfiguration(appId, almRepo));
         } else {
             String almSlug = Optional.ofNullable(StringUtils.trimToNull(projectAlmSettingDto.getAlmSlug()))
@@ -93,6 +93,7 @@ public class DefaultBitbucketClientFactory implements BitbucketClientFactory {
     private static OkHttpClient.Builder createBaseClientBuilder(HttpClientBuilderFactory httpClientBuilderFactory) {
         HttpLoggingInterceptor httpLoggingInterceptor = new HttpLoggingInterceptor(LOGGER::debug);
         httpLoggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+        httpLoggingInterceptor.redactHeader("Authorization");
         return httpClientBuilderFactory.createClientBuilder().addInterceptor(httpLoggingInterceptor);
     }
 


### PR DESCRIPTION
## Summary
- `DefaultBitbucketClientFactory` attaches an `HttpLoggingInterceptor` at `Level.BODY` to the Bitbucket client, logged via `LOGGER::debug`.
- The Bitbucket Cloud OAuth client-credentials request (`BitbucketCloudClient.negotiateBearerToken`) sets its `Authorization: Basic base64(clientId:clientSecret)` header directly on the request, and reused the same logging-enabled client to execute it. The token-exchange response body also contains the resulting bearer token in plain text.
- Net effect: with DEBUG logging enabled on the `ce` process (a routine troubleshooting step), the Bitbucket Cloud OAuth client secret and the negotiated bearer access token were written to the Compute Engine logs in clear/trivially-reversible form.
- This PR uses a plain, non-logging `OkHttpClient` for the token-negotiation call only, and adds `redactHeader("Authorization")` to the shared logging interceptor as defense-in-depth so the Bitbucket Server PAT (or any future auth header) can't leak through DEBUG logs either.

## Test plan
- [x] Manually traced `DefaultBitbucketClientFactoryUnitTest#testCreateClientIsCloudIfCloudConfig` against the change — the mocked `HttpClientBuilderFactory#createClientBuilder()` returns the same builder for every call and the test still asserts `addInterceptor` is invoked exactly twice, so behaviour is unchanged from the test's perspective.
- [ ] Please run the full `./gradlew test` suite in CI — I was unable to run it locally in this environment (missing access to the internal SonarQube artifact repository needed to resolve `DbClient`/`ComponentFinder`/etc., which fails identically on unmodified `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)