### PR TITLE
Add SonarQube 26.8 support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 /build/
 /.idea/
 /.gradle/
+/sonarqube-lib/
 /out/
 
 # JavaScript

--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=26.5.0.122743-community
+SONARQUBE_VERSION=26.7.0.124771-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile
 
 # The version of the plugin to include in the image
-PLUGIN_VERSION=26.6.0-SNAPSHOT
+PLUGIN_VERSION=26.7.0-SNAPSHOT

--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=26.7.0.124771-community
+SONARQUBE_VERSION=26.8.0.126808-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile
 
 # The version of the plugin to include in the image
-PLUGIN_VERSION=26.7.0-SNAPSHOT
+PLUGIN_VERSION=26.8.0-SNAPSHOT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,9 @@ jobs:
         run: |
           ./gradlew clean build
       -
+        name: Test Docker plugin upgrade handling
+        run: ./docker/test-community-branch-entrypoint.sh
+      -
         name: Archive artifact
         if: success() && matrix.java == '21'
         uses: actions/upload-artifact@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ FROM sonarqube:${SONARQUBE_VERSION}
 ARG PLUGIN_VERSION
 ARG WORKDIR
 
-COPY --from=builder --chown=sonarqube:root ${WORKDIR}/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/extensions/plugins/
+COPY --from=builder --chown=sonarqube:root ${WORKDIR}/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/lib/community-branch-plugin/
+COPY --chmod=755 docker/community-branch-entrypoint.sh /opt/sonarqube/docker/community-branch-entrypoint.sh
 
 RUN chmod -R 770 /opt/sonarqube/web && rm -rf /opt/sonarqube/web/*
 COPY --from=webapp-builder --chown=sonarqube:root ${WORKDIR}/apps/sq-server/build/webapp /opt/sonarqube/web
@@ -33,3 +34,4 @@ RUN chmod -R 550 /opt/sonarqube/web
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 ENV SONAR_WEB_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=web"
 ENV SONAR_CE_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=ce"
+ENTRYPOINT ["/opt/sonarqube/docker/community-branch-entrypoint.sh"]

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '26.5.0.122743'
+def sonarqubeVersion = '26.7.0.124771'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,12 +40,12 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '26.7.0.124771'
+def sonarqubeVersion = '26.8.0.126808'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 
-java.sourceCompatibility = JavaVersion.VERSION_17
-java.targetCompatibility = JavaVersion.VERSION_17
+java.sourceCompatibility = JavaVersion.VERSION_21
+java.targetCompatibility = JavaVersion.VERSION_21
 configurations {
     zip
     customTestRuntime

--- a/docker/community-branch-entrypoint.sh
+++ b/docker/community-branch-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+
+plugin_name="sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar"
+plugin_source="/opt/sonarqube/lib/community-branch-plugin/${plugin_name}"
+plugin_directory="/opt/sonarqube/extensions/plugins"
+disabled_directory="/opt/sonarqube/extensions/disabled-plugins"
+plugin_target="${plugin_directory}/${plugin_name}"
+
+mkdir -p "${plugin_directory}" "${disabled_directory}"
+
+for installed_plugin in "${plugin_directory}"/sonarqube-community-branch-plugin-*.jar; do
+  [ -f "${installed_plugin}" ] || continue
+  [ "${installed_plugin}" = "${plugin_target}" ] ||
+    mv "${installed_plugin}" "${disabled_directory}/$(basename "${installed_plugin}").disabled"
+done
+
+plugin_temporary="${plugin_target}.tmp"
+cp "${plugin_source}" "${plugin_temporary}"
+chmod 644 "${plugin_temporary}"
+mv "${plugin_temporary}" "${plugin_target}"
+
+exec /opt/sonarqube/docker/entrypoint.sh "$@"

--- a/docker/community-branch-entrypoint.sh
+++ b/docker/community-branch-entrypoint.sh
@@ -3,14 +3,17 @@
 set -eu
 
 plugin_name="sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar"
-plugin_source="/opt/sonarqube/lib/community-branch-plugin/${plugin_name}"
-plugin_directory="/opt/sonarqube/extensions/plugins"
-disabled_directory="/opt/sonarqube/extensions/disabled-plugins"
+sonarqube_home="${SONARQUBE_HOME:-/opt/sonarqube}"
+plugin_source="${sonarqube_home}/lib/community-branch-plugin/${plugin_name}"
+plugin_directory="${sonarqube_home}/extensions/plugins"
+disabled_directory="${sonarqube_home}/extensions/disabled-plugins"
 plugin_target="${plugin_directory}/${plugin_name}"
 
 mkdir -p "${plugin_directory}" "${disabled_directory}"
 
-for installed_plugin in "${plugin_directory}"/sonarqube-community-branch-plugin-*.jar; do
+for installed_plugin in \
+  "${plugin_directory}/sonarqube-community-branch-plugin.jar" \
+  "${plugin_directory}"/sonarqube-community-branch-plugin-*.jar; do
   [ -f "${installed_plugin}" ] || continue
   [ "${installed_plugin}" = "${plugin_target}" ] ||
     mv "${installed_plugin}" "${disabled_directory}/$(basename "${installed_plugin}").disabled"
@@ -21,4 +24,4 @@ cp "${plugin_source}" "${plugin_temporary}"
 chmod 644 "${plugin_temporary}"
 mv "${plugin_temporary}" "${plugin_target}"
 
-exec /opt/sonarqube/docker/entrypoint.sh "$@"
+exec "${sonarqube_home}/docker/entrypoint.sh" "$@"

--- a/docker/test-community-branch-entrypoint.sh
+++ b/docker/test-community-branch-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -eu
+
+repository_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+test_root=$(mktemp -d)
+trap 'rm -rf "${test_root}"' EXIT HUP INT TERM
+
+plugin_version="26.8.0-SNAPSHOT"
+plugin_name="sonarqube-community-branch-plugin-${plugin_version}.jar"
+plugin_source="${test_root}/lib/community-branch-plugin/${plugin_name}"
+plugin_directory="${test_root}/extensions/plugins"
+disabled_directory="${test_root}/extensions/disabled-plugins"
+
+mkdir -p "$(dirname "${plugin_source}")" "${plugin_directory}" "${test_root}/docker"
+printf '%s\n' '#!/bin/sh' 'exit 0' > "${test_root}/docker/entrypoint.sh"
+chmod +x "${test_root}/docker/entrypoint.sh"
+
+printf '%s\n' 'current plugin' > "${plugin_source}"
+printf '%s\n' 'legacy generic plugin' > "${plugin_directory}/sonarqube-community-branch-plugin.jar"
+printf '%s\n' 'legacy versioned plugin' > "${plugin_directory}/sonarqube-community-branch-plugin-26.7.0.jar"
+
+SONARQUBE_HOME="${test_root}" PLUGIN_VERSION="${plugin_version}" \
+  sh "${repository_root}/docker/community-branch-entrypoint.sh"
+
+cmp "${plugin_source}" "${plugin_directory}/${plugin_name}"
+test ! -e "${plugin_directory}/sonarqube-community-branch-plugin.jar"
+test ! -e "${plugin_directory}/sonarqube-community-branch-plugin-26.7.0.jar"
+test -f "${disabled_directory}/sonarqube-community-branch-plugin.jar.disabled"
+test -f "${disabled_directory}/sonarqube-community-branch-plugin-26.7.0.jar.disabled"
+
+# A restart refreshes the managed copy without duplicating or disabling it.
+printf '%s\n' 'current plugin after restart' > "${plugin_source}"
+SONARQUBE_HOME="${test_root}" PLUGIN_VERSION="${plugin_version}" \
+  sh "${repository_root}/docker/community-branch-entrypoint.sh"
+
+cmp "${plugin_source}" "${plugin_directory}/${plugin_name}"
+test "$(find "${plugin_directory}" -name 'sonarqube-community-branch-plugin*.jar' | wc -l | tr -d ' ')" = "1"
+
+# Both image variants must install the immutable source and use the migration entrypoint.
+for dockerfile in Dockerfile release.Dockerfile; do
+  grep -Fq '/opt/sonarqube/lib/community-branch-plugin/' "${repository_root}/${dockerfile}"
+  grep -Fq 'docker/community-branch-entrypoint.sh' "${repository_root}/${dockerfile}"
+  grep -Fq 'ENTRYPOINT ["/opt/sonarqube/docker/community-branch-entrypoint.sh"]' "${repository_root}/${dockerfile}"
+done

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=26.6.0-SNAPSHOT
+version=26.7.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=26.7.0-SNAPSHOT
+version=26.8.0-SNAPSHOT

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -15,14 +15,18 @@ RUN apk update && \
     unzip /tmp/sonarqube-webapp.zip -d /opt/sonarqube/web
 
 FROM sonarqube:${SONARQUBE_VERSION}
+ARG PLUGIN_VERSION
 
 USER root
 RUN rm -rf /opt/sonarqube/web/*
 
-COPY --from=downloader --chown=sonarqube:root /tmp/sonarqube-community-branch-plugin.jar /opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin.jar
+COPY --from=downloader --chown=sonarqube:root /tmp/sonarqube-community-branch-plugin.jar /opt/sonarqube/lib/community-branch-plugin/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar
+COPY --chmod=755 docker/community-branch-entrypoint.sh /opt/sonarqube/docker/community-branch-entrypoint.sh
 COPY --from=downloader --chmod=550 --chown=sonarqube:root /opt/sonarqube/web /opt/sonarqube/web
 
 
 USER sonarqube
-ENV SONAR_WEB_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin.jar=web"
-ENV SONAR_CE_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin.jar=ce"
+ENV PLUGIN_VERSION=${PLUGIN_VERSION}
+ENV SONAR_WEB_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=web"
+ENV SONAR_CE_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=ce"
+ENTRYPOINT ["/opt/sonarqube/docker/community-branch-entrypoint.sh"]

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
@@ -18,7 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { HelperHintIcon, Spinner } from '~design-system';
+import { Spinner } from '@sonarsource/echoes-react';
+import { HelperHintIcon } from '~design-system';
 import { Switch } from '~adapters/components/common/Switch';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { useExcludeFromPurgeMutation } from '~sq-server-commons/queries/branch';
@@ -51,7 +52,7 @@ export default function BranchPurgeSetting(props: Props) {
         onChange={handleOnChange}
         value={branch.excludedFromPurge}
       />
-      <Spinner loading={isPending} className="sw-ml-1" />
+      <Spinner isLoading={isPending} className="sw-ml-1" />
       {isTheMainBranch && (
         <HelpTooltip
           className="sw-ml-1"

--- a/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformationRenderer.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformationRenderer.tsx
@@ -18,9 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Spinner } from '@sonarsource/echoes-react';
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Link, Spinner } from '~design-system';
+import { Link } from '~design-system';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
 
@@ -34,7 +35,7 @@ function LifetimeInformationRenderer(props: LifetimeInformationRendererProps) {
   const { branchAndPullRequestLifeTimeInDays, canAdmin, loading } = props;
 
   return (
-    <Spinner loading={loading}>
+    <Spinner isLoading={loading}>
       {branchAndPullRequestLifeTimeInDays && (
         <p>
           <FormattedMessage

--- a/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
@@ -18,8 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Spinner } from '@sonarsource/echoes-react';
 import * as React from 'react';
-import { ActionCell, ContentCell, Spinner, Table, TableRow } from '~design-system';
+import { ActionCell, ContentCell, Table, TableRow } from '~design-system';
 import {
   listBranchesNewCodeDefinition,
   resetNewCodeDefinition,
@@ -163,7 +164,7 @@ export default class BranchList extends React.PureComponent<Props, State> {
     }
 
     if (loading) {
-      return <Spinner />;
+      return <Spinner isLoading />;
     }
 
     const header = (

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
@@ -34,6 +34,7 @@ import {
   TrendUpCircleIcon
 } from '~design-system';
 import { PullRequest } from '~shared/types/branch-like';
+import { MeasurementType, getMeasurementMetricKey } from '~shared/helpers/overview';
 import { MetricKey, MetricType } from '~shared/types/metrics';
 import { getLeakValue } from '~sq-server-commons/components/measure/utils';
 import { DEFAULT_ISSUES_QUERY } from '~sq-server-commons/components/shared/utils';
@@ -59,10 +60,8 @@ import { IssueMeasuresCardInner } from '~sq-server-commons/components/overview/I
 import MeasuresCardNumber from '~sq-server-commons/components/overview/MeasuresCardNumber';
 import MeasuresCardPercent from '~sq-server-commons/components/overview/MeasuresCardPercent';
 import {
-  MeasurementType,
   QGStatusEnum,
   getConditionRequiredLabel,
-  getMeasurementMetricKey,
 } from '~sq-server-commons/utils/overview-utils';
 
 interface Props {

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensorTest.java
@@ -18,65 +18,48 @@
  */
 package com.github.mc1arke.sonarqube.plugin.scanner;
 
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabMergeRequestDecorator;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.System2;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ScannerPullRequestPropertySensorTest {
 
     private final System2 system2 = mock();
+    private final SensorContext context = mock();
     private final ScannerPullRequestPropertySensor sensor = new ScannerPullRequestPropertySensor(system2);
 
     @Test
-    void testPropertySensorWithGitlabCIEnvValues() throws IOException {
-        
-        Path temp = Files.createTempDirectory("sensor");
-
-        DefaultInputFile inputFile = new TestInputFileBuilder("foo", "src/Foo.xoo").initMetadata("a\nb\nc\nd\ne\nf\ng\nh\ni\n").build();
-        SensorContextTester context = SensorContextTester.create(temp);
-        context.fileSystem().add(inputFile);        
-
+    void testPropertySensorWithGitlabCIEnvValues() {
         when(system2.envVariable("GITLAB_CI")).thenReturn("true");
         when(system2.envVariable("CI_API_V4_URL")).thenReturn("value");
         when(system2.envVariable("CI_PROJECT_PATH")).thenReturn("value");
         when(system2.envVariable("CI_MERGE_REQUEST_PROJECT_URL")).thenReturn("value");
-        when(system2.envVariable("CI_PIPELINE_ID")).thenReturn("value");        
+        when(system2.envVariable("CI_PIPELINE_ID")).thenReturn("value");
 
         sensor.execute(context);
 
-        Map<String, String> properties = context.getContextProperties();
-
-        assertThat(properties).hasSize(2);
-    }    
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, "value");
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, "value");
+        verify(context, times(2)).addContextProperty(anyString(), anyString());
+    }
 
     @Test
-    void testPropertySensorWithGitlabEnvValues() throws IOException {
-        
-        Path temp = Files.createTempDirectory("sensor");
-
-        DefaultInputFile inputFile = new TestInputFileBuilder("foo", "src/Foo.xoo").initMetadata("a\nb\nc\nd\ne\nf\ng\nh\ni\n").build();
-        SensorContextTester context = SensorContextTester.create(temp);
-        context.fileSystem().add(inputFile);        
-
+    void testPropertySensorWithGitlabEnvValues() {
         when(system2.envVariable("GITLAB_CI")).thenReturn("true");
         when(system2.envVariable("CI_MERGE_REQUEST_PROJECT_URL")).thenReturn("value");
         when(system2.envVariable("CI_PIPELINE_ID")).thenReturn("value");
 
         sensor.execute(context);
 
-        Map<String, String> properties = context.getContextProperties();
-
-        assertThat(properties).hasSize(2);
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, "value");
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, "value");
+        verify(context, times(2)).addContextProperty(anyString(), anyString());
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #1280. This branch is stacked directly on the exact head commit of that PR and preserves its original commits and authorship. Once #1280 merges, this branch will be rebased onto `master` so this PR shows only the 26.8 follow-up.

## Summary

- add support for SonarQube Community Build 26.8.0.126808 and Java 21
- update the SonarQube webapp submodule to `sqcb-26.8.0`
- adapt moved overview helpers and Echoes `Spinner` usage for the 26.8 webapp
- make plugin installation resilient to Docker image upgrades with persistent extension volumes
- migrate generic and older versioned plugin JARs to `disabled-plugins` before installing the current immutable JAR
- exercise upgrade and restart behavior in CI for both image variants

This also provides the 26.8 compatibility requested in #1290.

## Verification

- `./gradlew clean build` on JDK 21
- production webapp build (`yarn nx run sq-server:build`)
- entrypoint syntax and upgrade/restart regression test
- development and release Docker image builds
- persistent-volume migration smoke test from a previous plugin version
- live SonarQube 26.8 branch and pull-request analysis with GitHub quality-gate decoration
- independent adversarial review: P1 = 0, P2 = 0

