### PR TITLE
Add SonarQube 26.9 support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,7 @@
 
 # JavaScript
 node_modules/
+**/node_modules/
+**/.yarn/cache/
+sonarqube-webapp/apps/sq-server/build/
 /sonarqube-webapp/libs/sq-server-addons

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 /build/
 /.idea/
 /.gradle/
+/sonarqube-lib/
 /out/
 
 # JavaScript

--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=26.5.0.122743-community
+SONARQUBE_VERSION=26.7.0.124771-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile
 
 # The version of the plugin to include in the image
-PLUGIN_VERSION=26.6.0-SNAPSHOT
+PLUGIN_VERSION=26.7.0-SNAPSHOT

--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=26.7.0.124771-community
+SONARQUBE_VERSION=26.8.0.126808-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile
 
 # The version of the plugin to include in the image
-PLUGIN_VERSION=26.7.0-SNAPSHOT
+PLUGIN_VERSION=26.8.0-SNAPSHOT

--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # The Sonarqube base image. 'latest' if building locally, '8.5-community' if targeting a specific version
-SONARQUBE_VERSION=26.8.0.126808-community
+SONARQUBE_VERSION=26.9.0.129388-community
 
 # The name of the Dockerfile to run. 'Dockerfile' is building locally, 'release.Dockerfile' if building the release image
 DOCKERFILE=Dockerfile
 
 # The version of the plugin to include in the image
-PLUGIN_VERSION=26.8.0-SNAPSHOT
+PLUGIN_VERSION=26.9.0-SNAPSHOT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,9 @@ jobs:
         run: |
           ./gradlew clean build
       -
+        name: Test Docker plugin upgrade handling
+        run: ./docker/test-community-branch-entrypoint.sh
+      -
         name: Archive artifact
         if: success() && matrix.java == '21'
         uses: actions/upload-artifact@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,15 @@ RUN gradle build -x test
 
 
 FROM node:22.16-alpine AS webapp-builder
-ARG WORKDIR
 
-COPY ./sonarqube-webapp ${WORKDIR}
-COPY ./sonarqube-webapp-addons ${WORKDIR}/libs/sq-server-addons
+COPY ./sonarqube-webapp /home/build/sonarqube-webapp
+COPY ./sonarqube-webapp-addons /home/build/sonarqube-webapp-addons
 
-WORKDIR ${WORKDIR}
+WORKDIR /home/build
+RUN apk add --no-cache bash
+RUN ./sonarqube-webapp-addons/setup.sh
+
+WORKDIR /home/build/sonarqube-webapp
 RUN yarn install
 RUN yarn nx run sq-server:build
 
@@ -25,10 +28,11 @@ ARG PLUGIN_VERSION
 ARG WORKDIR
 
 COPY --from=builder --chown=sonarqube:root ${WORKDIR}/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/lib/community-branch-plugin/
-COPY --chmod=755 docker/community-branch-entrypoint.sh /opt/sonarqube/docker/community-branch-entrypoint.sh
+COPY --chown=sonarqube:root docker/community-branch-entrypoint.sh /opt/sonarqube/docker/community-branch-entrypoint.sh
+RUN chmod 755 /opt/sonarqube/docker/community-branch-entrypoint.sh
 
 RUN chmod -R 770 /opt/sonarqube/web && rm -rf /opt/sonarqube/web/*
-COPY --from=webapp-builder --chown=sonarqube:root ${WORKDIR}/apps/sq-server/build/webapp /opt/sonarqube/web
+COPY --from=webapp-builder --chown=sonarqube:root /home/build/sonarqube-webapp/apps/sq-server/build/webapp /opt/sonarqube/web
 RUN chmod -R 550 /opt/sonarqube/web
 
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ FROM sonarqube:${SONARQUBE_VERSION}
 ARG PLUGIN_VERSION
 ARG WORKDIR
 
-COPY --from=builder --chown=sonarqube:root ${WORKDIR}/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/extensions/plugins/
+COPY --from=builder --chown=sonarqube:root ${WORKDIR}/build/libs/sonarqube-community-branch-plugin-*.jar /opt/sonarqube/lib/community-branch-plugin/
+COPY --chmod=755 docker/community-branch-entrypoint.sh /opt/sonarqube/docker/community-branch-entrypoint.sh
 
 RUN chmod -R 770 /opt/sonarqube/web && rm -rf /opt/sonarqube/web/*
 COPY --from=webapp-builder --chown=sonarqube:root ${WORKDIR}/apps/sq-server/build/webapp /opt/sonarqube/web
@@ -33,3 +34,4 @@ RUN chmod -R 550 /opt/sonarqube/web
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 ENV SONAR_WEB_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=web"
 ENV SONAR_CE_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=ce"
+ENTRYPOINT ["/opt/sonarqube/docker/community-branch-entrypoint.sh"]

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '26.5.0.122743'
+def sonarqubeVersion = '26.7.0.124771'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '26.8.0.126808'
+def sonarqubeVersion = '26.9.0.129388'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,12 +40,12 @@ repositories {
     }
 }
 
-def sonarqubeVersion = '26.7.0.124771'
+def sonarqubeVersion = '26.8.0.126808'
 def sonarqubeLibDir = "${projectDir}/sonarqube-lib"
 def sonarLibraries = "${sonarqubeLibDir}/sonarqube-${sonarqubeVersion}/lib"
 
-java.sourceCompatibility = JavaVersion.VERSION_17
-java.targetCompatibility = JavaVersion.VERSION_17
+java.sourceCompatibility = JavaVersion.VERSION_21
+java.targetCompatibility = JavaVersion.VERSION_21
 configurations {
     zip
     customTestRuntime

--- a/docker/community-branch-entrypoint.sh
+++ b/docker/community-branch-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+
+plugin_name="sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar"
+plugin_source="/opt/sonarqube/lib/community-branch-plugin/${plugin_name}"
+plugin_directory="/opt/sonarqube/extensions/plugins"
+disabled_directory="/opt/sonarqube/extensions/disabled-plugins"
+plugin_target="${plugin_directory}/${plugin_name}"
+
+mkdir -p "${plugin_directory}" "${disabled_directory}"
+
+for installed_plugin in "${plugin_directory}"/sonarqube-community-branch-plugin-*.jar; do
+  [ -f "${installed_plugin}" ] || continue
+  [ "${installed_plugin}" = "${plugin_target}" ] ||
+    mv "${installed_plugin}" "${disabled_directory}/$(basename "${installed_plugin}").disabled"
+done
+
+plugin_temporary="${plugin_target}.tmp"
+cp "${plugin_source}" "${plugin_temporary}"
+chmod 644 "${plugin_temporary}"
+mv "${plugin_temporary}" "${plugin_target}"
+
+exec /opt/sonarqube/docker/entrypoint.sh "$@"

--- a/docker/community-branch-entrypoint.sh
+++ b/docker/community-branch-entrypoint.sh
@@ -3,14 +3,17 @@
 set -eu
 
 plugin_name="sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar"
-plugin_source="/opt/sonarqube/lib/community-branch-plugin/${plugin_name}"
-plugin_directory="/opt/sonarqube/extensions/plugins"
-disabled_directory="/opt/sonarqube/extensions/disabled-plugins"
+sonarqube_home="${SONARQUBE_HOME:-/opt/sonarqube}"
+plugin_source="${sonarqube_home}/lib/community-branch-plugin/${plugin_name}"
+plugin_directory="${sonarqube_home}/extensions/plugins"
+disabled_directory="${sonarqube_home}/extensions/disabled-plugins"
 plugin_target="${plugin_directory}/${plugin_name}"
 
 mkdir -p "${plugin_directory}" "${disabled_directory}"
 
-for installed_plugin in "${plugin_directory}"/sonarqube-community-branch-plugin-*.jar; do
+for installed_plugin in \
+  "${plugin_directory}/sonarqube-community-branch-plugin.jar" \
+  "${plugin_directory}"/sonarqube-community-branch-plugin-*.jar; do
   [ -f "${installed_plugin}" ] || continue
   [ "${installed_plugin}" = "${plugin_target}" ] ||
     mv "${installed_plugin}" "${disabled_directory}/$(basename "${installed_plugin}").disabled"
@@ -21,4 +24,4 @@ cp "${plugin_source}" "${plugin_temporary}"
 chmod 644 "${plugin_temporary}"
 mv "${plugin_temporary}" "${plugin_target}"
 
-exec /opt/sonarqube/docker/entrypoint.sh "$@"
+exec "${sonarqube_home}/docker/entrypoint.sh" "$@"

--- a/docker/test-community-branch-entrypoint.sh
+++ b/docker/test-community-branch-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -eu
+
+repository_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+test_root=$(mktemp -d)
+trap 'rm -rf "${test_root}"' EXIT HUP INT TERM
+
+plugin_version="26.8.0-SNAPSHOT"
+plugin_name="sonarqube-community-branch-plugin-${plugin_version}.jar"
+plugin_source="${test_root}/lib/community-branch-plugin/${plugin_name}"
+plugin_directory="${test_root}/extensions/plugins"
+disabled_directory="${test_root}/extensions/disabled-plugins"
+
+mkdir -p "$(dirname "${plugin_source}")" "${plugin_directory}" "${test_root}/docker"
+printf '%s\n' '#!/bin/sh' 'exit 0' > "${test_root}/docker/entrypoint.sh"
+chmod +x "${test_root}/docker/entrypoint.sh"
+
+printf '%s\n' 'current plugin' > "${plugin_source}"
+printf '%s\n' 'legacy generic plugin' > "${plugin_directory}/sonarqube-community-branch-plugin.jar"
+printf '%s\n' 'legacy versioned plugin' > "${plugin_directory}/sonarqube-community-branch-plugin-26.7.0.jar"
+
+SONARQUBE_HOME="${test_root}" PLUGIN_VERSION="${plugin_version}" \
+  sh "${repository_root}/docker/community-branch-entrypoint.sh"
+
+cmp "${plugin_source}" "${plugin_directory}/${plugin_name}"
+test ! -e "${plugin_directory}/sonarqube-community-branch-plugin.jar"
+test ! -e "${plugin_directory}/sonarqube-community-branch-plugin-26.7.0.jar"
+test -f "${disabled_directory}/sonarqube-community-branch-plugin.jar.disabled"
+test -f "${disabled_directory}/sonarqube-community-branch-plugin-26.7.0.jar.disabled"
+
+# A restart refreshes the managed copy without duplicating or disabling it.
+printf '%s\n' 'current plugin after restart' > "${plugin_source}"
+SONARQUBE_HOME="${test_root}" PLUGIN_VERSION="${plugin_version}" \
+  sh "${repository_root}/docker/community-branch-entrypoint.sh"
+
+cmp "${plugin_source}" "${plugin_directory}/${plugin_name}"
+test "$(find "${plugin_directory}" -name 'sonarqube-community-branch-plugin*.jar' | wc -l | tr -d ' ')" = "1"
+
+# Both image variants must install the immutable source and use the migration entrypoint.
+for dockerfile in Dockerfile release.Dockerfile; do
+  grep -Fq '/opt/sonarqube/lib/community-branch-plugin/' "${repository_root}/${dockerfile}"
+  grep -Fq 'docker/community-branch-entrypoint.sh' "${repository_root}/${dockerfile}"
+  grep -Fq 'ENTRYPOINT ["/opt/sonarqube/docker/community-branch-entrypoint.sh"]' "${repository_root}/${dockerfile}"
+done

--- a/docker/test-community-branch-entrypoint.sh
+++ b/docker/test-community-branch-entrypoint.sh
@@ -6,7 +6,7 @@ repository_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 test_root=$(mktemp -d)
 trap 'rm -rf "${test_root}"' EXIT HUP INT TERM
 
-plugin_version="26.8.0-SNAPSHOT"
+plugin_version="26.9.0-SNAPSHOT"
 plugin_name="sonarqube-community-branch-plugin-${plugin_version}.jar"
 plugin_source="${test_root}/lib/community-branch-plugin/${plugin_name}"
 plugin_directory="${test_root}/extensions/plugins"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=26.8.0-SNAPSHOT
+version=26.9.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=26.6.0-SNAPSHOT
+version=26.7.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=26.7.0-SNAPSHOT
+version=26.8.0-SNAPSHOT

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -15,14 +15,18 @@ RUN apk update && \
     unzip /tmp/sonarqube-webapp.zip -d /opt/sonarqube/web
 
 FROM sonarqube:${SONARQUBE_VERSION}
+ARG PLUGIN_VERSION
 
 USER root
 RUN rm -rf /opt/sonarqube/web/*
 
-COPY --from=downloader --chown=sonarqube:root /tmp/sonarqube-community-branch-plugin.jar /opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin.jar
+COPY --from=downloader --chown=sonarqube:root /tmp/sonarqube-community-branch-plugin.jar /opt/sonarqube/lib/community-branch-plugin/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar
+COPY --chmod=755 docker/community-branch-entrypoint.sh /opt/sonarqube/docker/community-branch-entrypoint.sh
 COPY --from=downloader --chmod=550 --chown=sonarqube:root /opt/sonarqube/web /opt/sonarqube/web
 
 
 USER sonarqube
-ENV SONAR_WEB_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin.jar=web"
-ENV SONAR_CE_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin.jar=ce"
+ENV PLUGIN_VERSION=${PLUGIN_VERSION}
+ENV SONAR_WEB_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=web"
+ENV SONAR_CE_JAVAADDITIONALOPTS="-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-${PLUGIN_VERSION}.jar=ce"
+ENTRYPOINT ["/opt/sonarqube/docker/community-branch-entrypoint.sh"]

--- a/sonarqube-webapp-addons/setup.sh
+++ b/sonarqube-webapp-addons/setup.sh
@@ -3,6 +3,8 @@
 set -Eeuo pipefail
 
 CURRENT_DIR=$(pwd)
+WEBAPP_DIR=${1:-"${CURRENT_DIR}/sonarqube-webapp"}
+ADDONS_DIR=${2:-"${CURRENT_DIR}/sonarqube-webapp-addons"}
 
 function override_vite_config() {
     if [[ -f ./vite.config.src.ts ]]; then
@@ -12,18 +14,29 @@ function override_vite_config() {
     echo "Overriding config vite.config.base.ts"
     mv ./vite.config.base.ts ./vite.config.src.ts
     cat <<EOF >vite.config.base.ts
+import { resolve } from 'node:path';
 import { baseViteConfig as config } from './vite.config.src';
 
 export * from './vite.config.src';
-export const baseViteConfig = { ...config, resolve: { preserveSymlinks: true } };
+export const baseViteConfig = {
+  ...config,
+  resolve: {
+    ...config.resolve,
+    preserveSymlinks: true,
+    alias: {
+      ...config.resolve?.alias,
+      '~sq-server-commons': resolve(__dirname, 'libs/sq-server-commons/src'),
+    },
+  },
+};
 EOF
 }
 
 function main() {
-    cd ./sonarqube-webapp
+    cd "${WEBAPP_DIR}"
     echo "Creating symlink for sonarqube-webapp/libs/sq-server-addons"
     rm -rf ./libs/sq-server-addons
-    ln -s "${CURRENT_DIR}/sonarqube-webapp-addons" ./libs/sq-server-addons
+    ln -s "${ADDONS_DIR}" ./libs/sq-server-addons
     override_vite_config
 }
 

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchLikeTable.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchLikeTable.tsx
@@ -20,9 +20,9 @@
 
 import * as React from 'react';
 import { ActionCell, ContentCell, HelperHintIcon, Table, TableRow } from '~design-system';
+import Tooltip from '~sq-server-commons/components/controls/Tooltip';
 import { getBranchLikeKey } from '~sq-server-commons/helpers/branch-like';
 import { translate } from '~sq-server-commons/helpers/l10n';
-import HelpTooltip from '~sq-server-commons/sonar-aligned/components/controls/HelpTooltip';
 import { BranchLike } from '~sq-server-commons/types/branch-like';
 import { Component } from '~sq-server-commons/types/types';
 import BranchLikeRow from './BranchLikeRow';
@@ -54,14 +54,15 @@ function BranchLikeTable(props: BranchLikeTableProps) {
             <span>
               {translate('project_branch_pull_request.branch.auto_deletion.keep_when_inactive')}
             </span>
-            <HelpTooltip
-              className="sw-ml-1"
-              overlay={translate(
-                'project_branch_pull_request.branch.auto_deletion.keep_when_inactive.tooltip',
-              )}
-            >
-              <HelperHintIcon />
-            </HelpTooltip>
+            <span className="sw-ml-1">
+              <Tooltip
+                content={translate(
+                  'project_branch_pull_request.branch.auto_deletion.keep_when_inactive.tooltip',
+                )}
+              >
+                <HelperHintIcon />
+              </Tooltip>
+            </span>
           </div>
         </ContentCell>
       )}

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
@@ -18,7 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { HelperHintIcon, Spinner } from '~design-system';
+import { Spinner } from '@sonarsource/echoes-react';
+import { HelperHintIcon } from '~design-system';
 import { Switch } from '~adapters/components/common/Switch';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { useExcludeFromPurgeMutation } from '~sq-server-commons/queries/branch';
@@ -51,7 +52,7 @@ export default function BranchPurgeSetting(props: Props) {
         onChange={handleOnChange}
         value={branch.excludedFromPurge}
       />
-      <Spinner loading={isPending} className="sw-ml-1" />
+      <Spinner isLoading={isPending} className="sw-ml-1" />
       {isTheMainBranch && (
         <HelpTooltip
           className="sw-ml-1"

--- a/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/BranchPurgeSetting.tsx
@@ -21,9 +21,9 @@
 import { Spinner } from '@sonarsource/echoes-react';
 import { HelperHintIcon } from '~design-system';
 import { Switch } from '~adapters/components/common/Switch';
+import Tooltip from '~sq-server-commons/components/controls/Tooltip';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { useExcludeFromPurgeMutation } from '~sq-server-commons/queries/branch';
-import HelpTooltip from '~sq-server-commons/sonar-aligned/components/controls/HelpTooltip';
 import { isMainBranch } from '~shared/helpers/branch-like';
 import { Branch } from '~sq-server-commons/types/branch-like';
 import { Component } from '~sq-server-commons/types/types';
@@ -54,14 +54,15 @@ export default function BranchPurgeSetting(props: Props) {
       />
       <Spinner isLoading={isPending} className="sw-ml-1" />
       {isTheMainBranch && (
-        <HelpTooltip
-          className="sw-ml-1"
-          overlay={translate(
-            'project_branch_pull_request.branch.auto_deletion.main_branch_tooltip',
-          )}
-        >
-          <HelperHintIcon aria-label={translate('help')} />
-        </HelpTooltip>
+        <span className="sw-ml-1">
+          <Tooltip
+            content={translate(
+              'project_branch_pull_request.branch.auto_deletion.main_branch_tooltip',
+            )}
+          >
+            <HelperHintIcon aria-label={translate('help')} />
+          </Tooltip>
+        </span>
       )}
     </>
   );

--- a/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformationRenderer.tsx
+++ b/sonarqube-webapp-addons/src/branches/app/components/LifetimeInformationRenderer.tsx
@@ -18,9 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Spinner } from '@sonarsource/echoes-react';
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Link, Spinner } from '~design-system';
+import { Link } from '~design-system';
 import { translate } from '~sq-server-commons/helpers/l10n';
 import { formatMeasure } from '~sq-server-commons/sonar-aligned/helpers/measures';
 
@@ -34,7 +35,7 @@ function LifetimeInformationRenderer(props: LifetimeInformationRendererProps) {
   const { branchAndPullRequestLifeTimeInDays, canAdmin, loading } = props;
 
   return (
-    <Spinner loading={loading}>
+    <Spinner isLoading={loading}>
       {branchAndPullRequestLifeTimeInDays && (
         <p>
           <FormattedMessage

--- a/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItemList.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-like/MenuItemList.tsx
@@ -24,7 +24,7 @@ import { HelperHintIcon, ItemDivider, ItemHeader } from '~design-system';
 import { isDefined } from '~shared/helpers/types';
 import { getBranchLikeKey, isSameBranchLike } from '~sq-server-commons/helpers/branch-like';
 import { translate } from '~sq-server-commons/helpers/l10n';
-import HelpTooltip from '~sq-server-commons/sonar-aligned/components/controls/HelpTooltip';
+import Tooltip from '~sq-server-commons/components/controls/Tooltip';
 import { BranchLike, BranchLikeTree } from '~sq-server-commons/types/branch-like';
 import MenuItem from './MenuItem';
 
@@ -121,12 +121,11 @@ export function MenuItemList(props: MenuItemListProps) {
           <ItemDivider aria-hidden />
           <ItemHeader>
             {translate('branch_like_navigation.orphan_pull_requests')}
-            <HelpTooltip
-              className="sw-ml-1"
-              overlay={translate('branch_like_navigation.orphan_pull_requests.tooltip')}
-            >
-              <HelperHintIcon />
-            </HelpTooltip>
+            <span className="sw-ml-1">
+              <Tooltip content={translate('branch_like_navigation.orphan_pull_requests.tooltip')}>
+                <HelperHintIcon />
+              </Tooltip>
+            </span>
           </ItemHeader>
           <ItemDivider aria-hidden />
           {branchLikeTree.orphanPullRequests.map((pr) => renderItem(pr))}

--- a/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/branch-list/BranchList.tsx
@@ -18,8 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Spinner } from '@sonarsource/echoes-react';
 import * as React from 'react';
-import { ActionCell, ContentCell, Spinner, Table, TableRow } from '~design-system';
+import { ActionCell, ContentCell, Table, TableRow } from '~design-system';
 import {
   listBranchesNewCodeDefinition,
   resetNewCodeDefinition,
@@ -163,7 +164,7 @@ export default class BranchList extends React.PureComponent<Props, State> {
     }
 
     if (loading) {
-      return <Spinner />;
+      return <Spinner isLoading />;
     }
 
     const header = (

--- a/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
+++ b/sonarqube-webapp-addons/src/branches/components/pull-requests/MeasuresCardPanel.tsx
@@ -34,6 +34,7 @@ import {
   TrendUpCircleIcon
 } from '~design-system';
 import { PullRequest } from '~shared/types/branch-like';
+import { MeasurementType, getMeasurementMetricKey } from '~shared/helpers/overview';
 import { MetricKey, MetricType } from '~shared/types/metrics';
 import { getLeakValue } from '~sq-server-commons/components/measure/utils';
 import { DEFAULT_ISSUES_QUERY } from '~sq-server-commons/components/shared/utils';
@@ -59,10 +60,8 @@ import { IssueMeasuresCardInner } from '~sq-server-commons/components/overview/I
 import MeasuresCardNumber from '~sq-server-commons/components/overview/MeasuresCardNumber';
 import MeasuresCardPercent from '~sq-server-commons/components/overview/MeasuresCardPercent';
 import {
-  MeasurementType,
   QGStatusEnum,
   getConditionRequiredLabel,
-  getMeasurementMetricKey,
 } from '~sq-server-commons/utils/overview-utils';
 
 interface Props {

--- a/sonarqube-webapp-addons/src/feature-license/entitlements.ts
+++ b/sonarqube-webapp-addons/src/feature-license/entitlements.ts
@@ -1,0 +1,58 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ */
+
+import { queryOptions, useQueries } from '@tanstack/react-query';
+import { createQueryHook, StaleTime } from '~shared/queries/common';
+import {
+  combineEntitlementChecks,
+  EntitlementCheckParams,
+  notEntitled,
+} from '~shared/queries/entitlement-checks';
+import { EntitlementCheckFeatureKey } from '~shared/types/billing';
+import { PurchaseableFeature } from '~sq-server-commons/types/editions';
+
+export const useEntitlementCheckQuery = createQueryHook((params: EntitlementCheckParams) =>
+  queryOptions({
+    queryKey: ['entitlement-check', params.featureKey, params.resourceType, params.resourceId],
+    queryFn: () => Promise.resolve(notEntitled(params.featureKey)),
+    staleTime: StaleTime.LIVE,
+  }),
+);
+
+export function useEntitlementChecksQuery(featureKeys: readonly EntitlementCheckFeatureKey[]) {
+  const usableKeys = featureKeys.filter((key) => key.length > 0);
+
+  return useQueries({
+    queries: usableKeys.map((featureKey) =>
+      queryOptions({
+        queryKey: ['entitlement-check', featureKey],
+        queryFn: () => Promise.resolve(notEntitled(featureKey)),
+        staleTime: StaleTime.LIVE,
+      }),
+    ),
+    combine: combineEntitlementChecks,
+  });
+}
+
+export const usePurchasableFeature = createQueryHook((featureKey: string) =>
+  queryOptions({
+    queryKey: ['purchasable-feature', featureKey],
+    queryFn: (): Promise<PurchaseableFeature[]> => Promise.resolve([]),
+    select: (features): PurchaseableFeature | undefined =>
+      features.find((feature) => feature.featureKey === featureKey),
+    staleTime: StaleTime.NEVER,
+  }),
+);

--- a/sonarqube-webapp-addons/src/index.ts
+++ b/sonarqube-webapp-addons/src/index.ts
@@ -1,3 +1,4 @@
 import branches from './branches';
+import * as entitlements from './feature-license/entitlements';
 
-export const addons = { branches };
+export const addons = { branches, entitlements };

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensorTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/scanner/ScannerPullRequestPropertySensorTest.java
@@ -18,65 +18,48 @@
  */
 package com.github.mc1arke.sonarqube.plugin.scanner;
 
+import com.github.mc1arke.sonarqube.plugin.ce.pullrequest.gitlab.GitlabMergeRequestDecorator;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.System2;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ScannerPullRequestPropertySensorTest {
 
     private final System2 system2 = mock();
+    private final SensorContext context = mock();
     private final ScannerPullRequestPropertySensor sensor = new ScannerPullRequestPropertySensor(system2);
 
     @Test
-    void testPropertySensorWithGitlabCIEnvValues() throws IOException {
-        
-        Path temp = Files.createTempDirectory("sensor");
-
-        DefaultInputFile inputFile = new TestInputFileBuilder("foo", "src/Foo.xoo").initMetadata("a\nb\nc\nd\ne\nf\ng\nh\ni\n").build();
-        SensorContextTester context = SensorContextTester.create(temp);
-        context.fileSystem().add(inputFile);        
-
+    void testPropertySensorWithGitlabCIEnvValues() {
         when(system2.envVariable("GITLAB_CI")).thenReturn("true");
         when(system2.envVariable("CI_API_V4_URL")).thenReturn("value");
         when(system2.envVariable("CI_PROJECT_PATH")).thenReturn("value");
         when(system2.envVariable("CI_MERGE_REQUEST_PROJECT_URL")).thenReturn("value");
-        when(system2.envVariable("CI_PIPELINE_ID")).thenReturn("value");        
+        when(system2.envVariable("CI_PIPELINE_ID")).thenReturn("value");
 
         sensor.execute(context);
 
-        Map<String, String> properties = context.getContextProperties();
-
-        assertThat(properties).hasSize(2);
-    }    
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, "value");
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, "value");
+        verify(context, times(2)).addContextProperty(anyString(), anyString());
+    }
 
     @Test
-    void testPropertySensorWithGitlabEnvValues() throws IOException {
-        
-        Path temp = Files.createTempDirectory("sensor");
-
-        DefaultInputFile inputFile = new TestInputFileBuilder("foo", "src/Foo.xoo").initMetadata("a\nb\nc\nd\ne\nf\ng\nh\ni\n").build();
-        SensorContextTester context = SensorContextTester.create(temp);
-        context.fileSystem().add(inputFile);        
-
+    void testPropertySensorWithGitlabEnvValues() {
         when(system2.envVariable("GITLAB_CI")).thenReturn("true");
         when(system2.envVariable("CI_MERGE_REQUEST_PROJECT_URL")).thenReturn("value");
         when(system2.envVariable("CI_PIPELINE_ID")).thenReturn("value");
 
         sensor.execute(context);
 
-        Map<String, String> properties = context.getContextProperties();
-
-        assertThat(properties).hasSize(2);
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PROJECT_URL, "value");
+        verify(context, times(1)).addContextProperty(GitlabMergeRequestDecorator.PULLREQUEST_GITLAB_PIPELINE_ID, "value");
+        verify(context, times(2)).addContextProperty(anyString(), anyString());
     }
 }


### PR DESCRIPTION
## Summary

- update the SonarQube server API and Docker base image to `26.9.0.129388`
- update the webapp submodule to the `sqcb-26.9.0` tag
- restore addon module resolution under the SonarQube 26.9 Vite configuration
- replace the removed `HelpTooltip` component with the supported legacy `Tooltip`
- keep Docker builds compatible with the legacy builder while retaining automatic plugin upgrades in persistent extension volumes

This is built on top of #1296 because SonarQube 26.9 requires the 26.7/26.8 compatibility changes and persistent-volume plugin upgrade handling introduced there. Please merge #1296 first; after that, this PR's 26.9-specific commit can be reviewed on its own.

## Verification

- `./gradlew clean test`
- `./docker/test-community-branch-entrypoint.sh`
- production webapp build with `yarn nx run sq-server:build`
- native amd64 Docker image build for `26.9.0.129388-community`
- GitHub Actions build: https://github.com/Adrian-Eckardt/sonarqube-community-branch-plugin/actions/runs/34200462051
- disposable SonarQube 26.9 + PostgreSQL runtime tests covering main, named branch, and pull-request scans
- pull-request APIs verified for branch metadata, new-code measures, issues, and quality-gate status
- negative quality-gate test verified that `sonar.qualitygate.wait=true` returns scanner exit code 3
- deployed to an existing SonarQube 26.9 instance and verified a real GitLab merge-request analysis against `main` without creating a separate SonarQube project
